### PR TITLE
Add congestion-aware routing

### DIFF
--- a/assets/demo/config.json
+++ b/assets/demo/config.json
@@ -21,9 +21,9 @@
     }
   },
   "routing": {
-    "w_smoke": 1.0,
-    "w_fed": 10.0,
-    "w_queue": 1.0,
+    "w_smoke": 0.0,
+    "w_fed": 0.0,
+    "w_queue": 0.0,
     "fed_rejection_threshold": 1.0,
     "visibility_extinction_threshold": 0.5,
     "sampling_step_m": 2.0,
@@ -154,12 +154,8 @@
       "journey_0": {
         "destinations": [
           {
-            "target": "exit_A_left",
-            "percentage": 50
-          },
-          {
             "target": "exit_B_right",
-            "percentage": 50
+            "percentage": 100
           }
         ]
       }

--- a/assets/demo/config.json
+++ b/assets/demo/config.json
@@ -21,9 +21,9 @@
     }
   },
   "routing": {
-    "w_smoke": 0.0,
-    "w_fed": 0.0,
-    "w_queue": 0.0,
+    "w_smoke": 1.0,
+    "w_fed": 10.0,
+    "w_queue": 1.0,
     "fed_rejection_threshold": 1.0,
     "visibility_extinction_threshold": 0.5,
     "sampling_step_m": 2.0,
@@ -154,8 +154,12 @@
       "journey_0": {
         "destinations": [
           {
+            "target": "exit_A_left",
+            "percentage": 1
+          },
+          {
             "target": "exit_B_right",
-            "percentage": 100
+            "percentage": 99
           }
         ]
       }

--- a/assets/demo/config.json
+++ b/assets/demo/config.json
@@ -20,6 +20,16 @@
       "useShortestPaths": false
     }
   },
+  "routing": {
+    "w_smoke": 1.0,
+    "w_fed": 10.0,
+    "w_queue": 1.0,
+    "fed_rejection_threshold": 1.0,
+    "visibility_extinction_threshold": 0.5,
+    "sampling_step_m": 2.0,
+    "base_speed_m_per_s": 1.3,
+    "default_exit_capacity": 1.3
+  },
   "exits": {
     "exit_A_left": {
       "type": "polygon",

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -9,10 +9,9 @@ Route costs are recomputed from current hazard fields at each
 reevaluation tick, so the chosen path adapts as conditions evolve.
 
 > **Note:** The cost model supports both smoke and FED (toxic gas)
-> terms, but the simulation loop currently passes
-> `fed_rate_sampler=None`, so only smoke influences route ranking at
-> runtime. FED-based cost can be activated by wiring a sampler into
-> the scenario loop.
+> terms. FED-based route cost is active when a `fed_model` is
+> provided to `run_scenario`; otherwise `fed_rate_sampler` is `None`
+> and only smoke influences route ranking.
 
 ## Stage graph
 
@@ -80,8 +79,8 @@ the following steps:
    speed.
 4. Optionally, estimate the FED growth along the segment from the
    FED rate at the polyline midpoint (by arc length) and the
-   estimated travel time. (Currently inactive — `fed_rate_sampler`
-   is `None` in the simulation loop.)
+   estimated travel time. (Active only when a `fed_model` is
+   provided; otherwise `fed_rate_sampler` is `None`.)
 
 ### Line-of-sight extinction
 
@@ -231,9 +230,9 @@ the interval.
 
 2. rank_routes(source, t, FED, K_field)
    ├─ evaluate all edges → dynamic costs from current smoke/FED
-   ├─ Dijkstra with dynamic weights → one shortest path per reachable exit
-   │   (only the geometrically shortest path to each exit is smoke-scored;
-   │    alternative paths to the same exit are not enumerated)
+   ├─ Dijkstra with dynamic weights → one minimum-cost path per reachable exit
+   │   (only the single lowest-cost path to each exit under these weights
+   │    is evaluated; alternative paths to the same exit are not enumerated)
    ├─ evaluate_route on each path (composite cost + rejection flags)
    ├─ visibility rejection pass
    │   └─ if ≥1 route has any visible segment:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -4,10 +4,15 @@
 
 The pyFDS-Evac routing system implements dynamic, smoke-aware path
 planning. Agents evaluate candidate routes based on smoke exposure
-and toxic gas dose, and periodically reroute to lower-cost paths as
-conditions change. Route costs are recomputed from current hazard
-fields at each reevaluation tick, so the chosen path adapts as
-conditions evolve.
+and periodically reroute to lower-cost paths as conditions change.
+Route costs are recomputed from current hazard fields at each
+reevaluation tick, so the chosen path adapts as conditions evolve.
+
+> **Note:** The cost model supports both smoke and FED (toxic gas)
+> terms, but the simulation loop currently passes
+> `fed_rate_sampler=None`, so only smoke influences route ranking at
+> runtime. FED-based cost can be activated by wiring a sampler into
+> the scenario loop.
 
 ## Stage graph
 
@@ -56,8 +61,9 @@ if result:
 ## Route cost evaluation
 
 Each candidate route is scored by evaluating its segments (edges)
-against current smoke and FED conditions. The cost model combines
-path length, smoke exposure, and toxic gas dose.
+against current smoke conditions. The cost model combines path
+length and smoke exposure (FED terms are supported but not currently
+active — see note above).
 
 ### Segment evaluation
 
@@ -72,9 +78,10 @@ the following steps:
    the [smoke-speed model](smoke-speed-model.md).
 3. Estimate the travel time from the segment length and reduced
    speed.
-4. Estimate the FED growth along the segment from the FED rate
-   at the polyline midpoint (by arc length) and the estimated
-   travel time.
+4. Optionally, estimate the FED growth along the segment from the
+   FED rate at the polyline midpoint (by arc length) and the
+   estimated travel time. (Currently inactive — `fed_rate_sampler`
+   is `None` in the simulation loop.)
 
 ### Line-of-sight extinction
 
@@ -174,7 +181,9 @@ the interval.
 
 2. rank_routes(source, t, FED, K_field)
    ├─ evaluate all edges → dynamic costs from current smoke/FED
-   ├─ Dijkstra with dynamic weights → one cheapest path per reachable exit
+   ├─ Dijkstra with dynamic weights → one shortest path per reachable exit
+   │   (only the geometrically shortest path to each exit is smoke-scored;
+   │    alternative paths to the same exit are not enumerated)
    ├─ evaluate_route on each path (composite cost + rejection flags)
    ├─ visibility rejection pass
    │   └─ if ≥1 route has any visible segment:

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -140,6 +140,7 @@ from pyfds_evac.core.route_graph import RouteCostConfig
 config = RouteCostConfig(
     w_smoke=1.0,                          # smoke cost weight
     w_fed=10.0,                           # FED cost weight
+    w_queue=1.0,                          # queueing cost weight (0 disables)
     fed_rejection_threshold=1.0,          # reject if FED_max exceeds
     visibility_extinction_threshold=0.5,  # K threshold for visibility
     sampling_step_m=2.0,                  # ray sample spacing
@@ -147,8 +148,57 @@ config = RouteCostConfig(
     alpha=0.706,                          # speed-law coefficient
     beta=-0.057,                          # speed-law coefficient
     min_speed_factor=0.1,                 # speed factor floor
+    default_exit_capacity=1.3,            # fallback capacity (agents/s)
 )
 ```
+
+### Congestion-aware routing
+
+When `w_queue > 0`, an exit-congestion term is added to the
+composite cost:
+
+```
+queue_distance = base_speed_m_per_s * N_exit / capacity
+composite = path_length * (1 + w_smoke * K_ave)
+          + w_fed * FED_max
+          + w_queue * queue_distance
+```
+
+where:
+
+- `N_exit` is the number of agents currently targeting that exit
+- `capacity` is the exit's `capacity_agents_per_s` (default 1.3)
+- `base_speed_m_per_s` converts queueing delay (seconds) into
+  distance-equivalent cost (metres) so all terms share the same
+  unit space
+
+The queue term is applied at route-level ranking (Phase 3) only,
+not in Dijkstra edge weights, because it is a per-exit constant
+that cannot change which path is selected to a given exit.
+
+Setting `w_queue = 0` disables congestion-aware routing entirely
+(backward compatible with existing behaviour).
+
+Exit capacity can be configured per exit in the scenario config:
+
+```json
+{
+  "exits": {
+    "exit_1": {
+      "capacity_agents_per_s": 2.5
+    }
+  }
+}
+```
+
+When not specified, the default from
+`RouteCostConfig.default_exit_capacity` (1.3 agents/s) is used.
+
+This approach is inspired by the game-theoretic exit selection
+model of Ehtamo et al. (2010), where each agent minimises
+estimated evacuation time (queueing + walking). The staggered
+reevaluation schedule provides natural convergence to Nash
+equilibrium without explicit iteration.
 
 ## Dynamic rerouting
 
@@ -277,6 +327,7 @@ Full cost evaluation for one candidate route:
 | `fed_max_route`    | `float`             | Projected cumulative FED          |
 | `composite_cost`   | `float`             | Final cost used for ranking       |
 | `segments`         | `list[SegmentCost]` | Per-segment breakdowns            |
+| `queue_time_s`     | `float`             | Estimated queueing time at exit   |
 | `rejected`         | `bool`              | Whether route was rejected        |
 | `rejection_reason` | `str \| None`       | Reason for rejection              |
 
@@ -292,3 +343,6 @@ Full cost evaluation for one candidate route:
   Waypoint-based visibility and evacuation modeling.
 - [Ronchi et al. (2013)](../materials/Ronchi2013.pdf) -- FDS+Evac
   evacuation model validation and verification.
+- Ehtamo, H., Heliövaara, S., Korhonen, T. & Hostikka, S. (2010).
+  Game theoretic best-response dynamics for evacuees' exit selection.
+  *Advances in Complex Systems*, 13(1), 113–134.

--- a/materials/schroder2020_summary.md
+++ b/materials/schroder2020_summary.md
@@ -1,0 +1,37 @@
+The paper "A map representation of the ASET-RSET concept" by Schröder et al. (2020) provides a technical advancement in performance-based fire safety design by transitioning from traditional punctual (single-point) analysis to a high-fidelity **spatial and temporal map representation**,. 
+
+### **1. Principal Findings**
+The authors identify that traditional ASET-RSET assessments, which evaluate safety criteria at only a few selected locations, are prone to **incompleteness and misinterpretation**. Key findings include:
+*   **Identification of Distributed Hazards:** ASET and RSET are inherently distributed values; single-point evaluations fail to ensure that the safety margin (ASET minus RSET) is positive at every location in a building,.
+*   **Visualization of Critical Regions:** The introduction of **Difference Maps** allows for the immediate identification of "hot spots" where the ASET-RSET constraint is violated, showing both where and for how long occupants were exposed to unacceptable conditions,.
+*   **Complexity Reduction for Risk Analysis:** The paper demonstrates that a high-information spatial analysis can be reduced to a single **scalar measure of consequences ($C$)**, facilitating the comparison and ranking of thousands of scenario combinations in multivariate studies,.
+*   **Independence of Coupling:** The methodology allows for the analysis of independent fire and evacuation model outputs in a post-processing stage, removing the absolute requirement for "online" bidirectional coupling during execution,.
+
+### **2. Algorithmic Framework**
+The core innovation lies in the formal mathematical discretisation of the building floor plan into map elements ($M$), enabling the following algorithmic steps:
+
+#### **A. ASET Map Generation**
+The algorithm identifies the first point in time at each map element when fire effects reach a critical threshold:
+*   **Criterion:** For each map element at $(x_m, y_m)$, it samples a set of data points $X_m$ from CFD results (e.g., FDS slices).
+*   **Calculation:** The available time for that element is the minimum time across all thresholds $i$ reached in that specific area:
+    $$ASET_m = \min \left( \bigcup Tm,i \right)$$
+    This results in a "fingerprint" of the fire scenario across the entire domain,.
+
+#### **B. RSET Map Generation**
+This process transforms agent-based movement data into a space-related interpretation of required time:
+*   **Trajectory Analysis:** Every individual agent trajectory $p_i(t)$ is evaluated.
+*   **Calculation:** A map element is assigned the maximum time point of all trajectories that passed through its area:
+    $$RSET_m = \max \left( \bigcup Tm,i \right)$$
+    This maps the "required" time to every point on the floor plan traversed by occupants.
+
+#### **C. Difference Maps and Safety Margin**
+The spatial safety margin is computed via element-wise subtraction:
+$$DIFF_m = ASET_m - RSET_m$$
+Negative values in this matrix indicate areas where the limiting state was exceeded (occupants were present in untenable conditions).
+
+#### **D. Consequence Quantification Algorithm ($C$)**
+To characterize the severity of a scenario, the authors propose a metric inspired by the **Earth Mover’s Distance (EMD)** or Wasserstein metric:
+*   **Histogram Transformation:** The distribution of $ASET-RSET$ values is converted into a histogram.
+*   **The $C$ Measure:** The total consequence is the sum of the products of bin centers ($t_k$) and their corresponding areas ($a_k$) for all negative values:
+    $$C = \sum_{k|t_k<0} t_k \cdot a_k$$
+    This scalar provides a robust measure that combines the **spatial extent** and **temporal duration** of a safety violation into a single value for risk assessment,.

--- a/materials/waypoint_based_visibility_summary.md
+++ b/materials/waypoint_based_visibility_summary.md
@@ -1,0 +1,24 @@
+The primary finding of the paper "A waypoint based approach to visibility in performance based fire safety design" is the development and validation of a **waypoint-based assessment methodology** that replaces traditional local point-sampling with a path-integrated evaluation of visibility. This approach represents a shift toward higher cognitive and photometric fidelity in Performance-Based Design (PBD).
+
+The main findings and technical contributions are synthesized as follows:
+
+### 1. Superiority of Path-Integrated Extinction
+Traditional fire models calculate visibility as a local cell-based quantity, which the authors argue is inadequate for non-uniform smoke environments. The paper finds that visibility must be calculated as an **integrated value of the extinction coefficient ($𝜎$) along the actual line of sight** between an observer and a target waypoint (such as an exit sign). This uses an arithmetic mean approximation of the smoke density along the visual axis to compute an effective available visibility.
+
+### 2. Integration of Geometric and Photometric Constraints
+The paper identifies that visibility is not merely a function of smoke density but is restricted by geometric factors often ignored in legacy models:
+*   **View-Angle Sensitivity:** The model incorporates **Lambertian radiation effects**, where the perceivable distance of a sign is reduced by the cosine of the viewing angle ($cos 𝜃$). This findings shows that signs may become invisible at extreme angles even if smoke levels are low.
+*   **Obstruction Detection:** By employing a **Bresenham-based ray-casting algorithm**, the methodology identifies "concealed" agent cells blocked by architectural elements, ensuring that visibility is only calculated for unconcealed lines of sight.
+
+### 3. Identification of "Blind Spots"
+A critical finding is that traditional local visibility assessments can produce overly optimistic results. The paper demonstrates that **Visibility Maps**—Boolean matrices identifying safe versus unsafe cells—reveal hazards and "blind spots" caused by room geometry and sign orientation that point-sampling at the agent's head would entirely miss.
+
+### 4. Reduction of Interpretation Bias
+The authors find that current PBD practices rely on subjective local performance criteria (e.g., a fixed 10m threshold) that vary between engineers. The waypoint-based approach allows **required visibility to emerge naturally from the geometry** (the actual distance to the sign), thereby reducing personal bias and increasing the credibility of the building approval process.
+
+### 5. Algorithmic and Tool Implementation
+The methodology was implemented in the open-source Python package **FDSVismap**. This tool enables the generation of:
+*   **Visibility Maps ($𝑀_{𝑖,𝑗}$):** Spatio-temporal matrices indicating where the nearest exit sign is perceivable.
+*   **Advanced ASET Maps:** Spatial representations indicating the exact time at which the visibility criterion to a waypoint is first violated at any given floor location.
+
+In technical synthesis, the paper concludes that visibility maps provide a more realistic and distinct assessment of egress routes by coupling physical fire phenomena (inhomogeneous smoke) with the actual architectural constraints of the visual environment.

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -22,6 +22,7 @@ class StageNode:
     centroid_x: float
     centroid_y: float
     stage_type: str  # "exit", "checkpoint", "distribution", "zone"
+    capacity_agents_per_s: float | None = None
 
 
 @dataclass
@@ -110,6 +111,7 @@ class StageGraph:
                 centroid_x=cx,
                 centroid_y=cy,
                 stage_type=stage_type,
+                capacity_agents_per_s=info.get("capacity_agents_per_s"),
             )
 
         # Add edges from transitions.

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -396,6 +396,7 @@ class RouteCostConfig:
 
     w_smoke: float = 1.0
     w_fed: float = 10.0
+    w_queue: float = 1.0
     fed_rejection_threshold: float = 1.0
     visibility_extinction_threshold: float = 0.5
     sampling_step_m: float = 2.0
@@ -403,6 +404,7 @@ class RouteCostConfig:
     alpha: float = 0.706
     beta: float = -0.057
     min_speed_factor: float = 0.1
+    default_exit_capacity: float = 1.3
 
 
 @dataclass(frozen=True)
@@ -433,6 +435,7 @@ class RouteCost:
     segments: list[SegmentCost]
     rejected: bool
     rejection_reason: str | None
+    queue_time_s: float = 0.0
 
 
 def _sample_segment_extinction(
@@ -596,6 +599,7 @@ def evaluate_route(
         segments=segments,
         rejected=rejected,
         rejection_reason=reason,
+        queue_time_s=0.0,
     )
 
 
@@ -689,6 +693,7 @@ def rank_routes(
                     segments=rc.segments,
                     rejected=True,
                     rejection_reason="all segments non-visible",
+                    queue_time_s=rc.queue_time_s,
                 )
             updated.append(rc)
         costs = updated
@@ -714,6 +719,7 @@ def rank_routes(
             segments=best.segments,
             rejected=False,
             rejection_reason=f"fallback: {best.rejection_reason}",
+            queue_time_s=best.queue_time_s,
         )
 
     return costs

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -883,6 +883,8 @@ def evaluate_and_reroute(
     fed_rate_sampler: FedRateSampler | None,
     config: RerouteConfig,
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    *,
+    exit_counts: dict[str, int] | None = None,
 ) -> RouteSwitch | None:
     """Evaluate routes and reroute the agent if a better exit is found.
 
@@ -904,6 +906,7 @@ def evaluate_and_reroute(
         fed_rate_sampler,
         config.cost_config,
         cached_segments=cached_segments,
+        exit_counts=exit_counts,
     )
     if not ranked:
         return None

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -551,6 +551,7 @@ def evaluate_route(
     config: RouteCostConfig,
     *,
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    exit_counts: dict[str, int] | None = None,
 ) -> RouteCost:
     """Evaluate the composite cost for a full route (list of stage IDs)."""
     segments: list[SegmentCost] = []
@@ -582,6 +583,22 @@ def evaluate_route(
     # Composite cost: path_length * (1 + w_smoke * K_ave) + w_fed * FED_max
     composite = path_length * (1.0 + config.w_smoke * k_ave) + config.w_fed * fed_max
 
+    # Queue cost: convert queue delay to distance-equivalent units.
+    queue_time = 0.0
+    if exit_counts is not None and config.w_queue > 0 and path:
+        _exit_id = path[-1]
+        n_exit = exit_counts.get(_exit_id, 0)
+        exit_node = graph.nodes.get(_exit_id)
+        capacity = (
+            exit_node.capacity_agents_per_s
+            if exit_node is not None and exit_node.capacity_agents_per_s is not None
+            else config.default_exit_capacity
+        )
+        if capacity > 0:
+            queue_time = n_exit / capacity
+            queue_distance = config.base_speed_m_per_s * queue_time
+            composite += config.w_queue * queue_distance
+
     rejected = False
     reason = None
     if fed_max > config.fed_rejection_threshold:
@@ -599,7 +616,7 @@ def evaluate_route(
         segments=segments,
         rejected=rejected,
         rejection_reason=reason,
-        queue_time_s=0.0,
+        queue_time_s=queue_time,
     )
 
 
@@ -613,6 +630,7 @@ def rank_routes(
     config: RouteCostConfig,
     *,
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    exit_counts: dict[str, int] | None = None,
 ) -> list[RouteCost]:
     """Evaluate and rank all routes from *source* to reachable exits.
 
@@ -670,6 +688,7 @@ def rank_routes(
             fed_rate_sampler,
             config,
             cached_segments=cached_segments,
+            exit_counts=exit_counts,
         )
         costs.append(rc)
 

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -54,6 +54,9 @@ from .route_graph import (
     rank_routes,
     should_reevaluate,
 )
+from .smoke_speed import ConstantExtinctionField
+
+_ZERO_EXTINCTION = ConstantExtinctionField(0.0)
 
 
 class _FedRateAdapter:
@@ -1483,7 +1486,6 @@ def run_scenario(
             if (
                 reroute_config is not None
                 and stage_graph is not None
-                and smoke_speed_model is not None
                 and agent_wait_info
                 and (
                     last_reroute_check_time is None
@@ -1491,6 +1493,11 @@ def run_scenario(
                 )
             ):
                 current_time = simulation.elapsed_time()
+                extinction_sampler = (
+                    smoke_speed_model.field
+                    if smoke_speed_model is not None
+                    else _ZERO_EXTINCTION
+                )
                 # Scope the route segment cache to a single reroute-check pass.
                 # Segment costs depend on current_time and the time-varying smoke field,
                 # so we clear any previously cached values computed at different times.
@@ -1544,7 +1551,7 @@ def run_scenario(
                                 source,
                                 current_time,
                                 current_fed,
-                                smoke_speed_model.field,
+                                extinction_sampler,
                                 _fed_rate_adapter,
                                 reroute_config.cost_config,
                                 cached_segments=route_segment_cache,
@@ -1576,7 +1583,7 @@ def run_scenario(
                         graph=stage_graph,
                         current_time_s=current_time,
                         current_fed=current_fed,
-                        extinction_sampler=smoke_speed_model.field,
+                        extinction_sampler=extinction_sampler,
                         fed_rate_sampler=_fed_rate_adapter,
                         config=reroute_config,
                         cached_segments=route_segment_cache,

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1332,6 +1332,16 @@ def run_scenario(
                                                 exit_counts[_spawn_exit] = (
                                                     exit_counts.get(_spawn_exit, 0) + 1
                                                 )
+                                                if reroute_config is not None:
+                                                    agent_route_state[agent_id] = (
+                                                        AgentRouteState(
+                                                            eval_offset_s=compute_eval_offset(
+                                                                agent_id,
+                                                                reroute_config.reevaluation_interval_s,
+                                                            ),
+                                                            current_exit=_spawn_exit,
+                                                        )
+                                                    )
                                 elif (
                                     not selected_variant
                                     and agent_wait_info is not None
@@ -1401,6 +1411,16 @@ def run_scenario(
                                                 exit_counts[_spawn_exit] = (
                                                     exit_counts.get(_spawn_exit, 0) + 1
                                                 )
+                                                if reroute_config is not None:
+                                                    agent_route_state[agent_id] = (
+                                                        AgentRouteState(
+                                                            eval_offset_s=compute_eval_offset(
+                                                                agent_id,
+                                                                reroute_config.reevaluation_interval_s,
+                                                            ),
+                                                            current_exit=_spawn_exit,
+                                                        )
+                                                    )
 
                                 spawned_this_attempt = True
                                 break

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1629,6 +1629,13 @@ def run_scenario(
                                 exit_counts=exit_counts,
                             )
                             for route_rank, rc in enumerate(ranked, start=1):
+                                _exit_node = stage_graph.nodes.get(rc.exit_id)
+                                _exit_cap = (
+                                    _exit_node.capacity_agents_per_s
+                                    if _exit_node is not None
+                                    and _exit_node.capacity_agents_per_s is not None
+                                    else reroute_config.cost_config.default_exit_capacity
+                                )
                                 route_cost_history.append(
                                     {
                                         "time_s": round(float(current_time), 6),
@@ -1646,6 +1653,9 @@ def run_scenario(
                                         "composite_cost": float(rc.composite_cost),
                                         "rejected": bool(rc.rejected),
                                         "rejection_reason": rc.rejection_reason or "",
+                                        "queue_time_s": float(rc.queue_time_s),
+                                        "exit_count": exit_counts.get(rc.exit_id, 0),
+                                        "exit_capacity": float(_exit_cap),
                                     }
                                 )
                     switch = evaluate_and_reroute(

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -845,6 +845,39 @@ class ScenarioResult:
             self.sqlite_file = None
 
 
+def _extract_terminal_exit(
+    wait_info: dict,
+    graph_nodes: dict,
+) -> str | None:
+    """Return the exit stage ID from an agent's wait_info, or None."""
+    if wait_info.get("mode") != "path":
+        return None
+    path_choices = wait_info.get("path_choices", {})
+    stage = wait_info.get("current_target_stage")
+    visited = set()
+    while stage and stage in path_choices and stage not in visited:
+        visited.add(stage)
+        choices = path_choices[stage]
+        if choices:
+            stage = (
+                choices[0][0] if isinstance(choices[0], (list, tuple)) else choices[0]
+            )
+        else:
+            break
+    if stage and stage in graph_nodes:
+        node = graph_nodes[stage]
+        if node.stage_type == "exit":
+            return stage
+    fallback = wait_info.get("current_target_stage")
+    if (
+        fallback
+        and fallback in graph_nodes
+        and graph_nodes[fallback].stage_type == "exit"
+    ):
+        return fallback
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -1019,6 +1052,27 @@ def run_scenario(
                 f"direct_steering={len(direct_steering_info)} "
                 f"wait_info={len(agent_wait_info)}"
             )
+        exit_counts: dict[str, int] = {}
+        if reroute_config is not None and stage_graph is not None:
+            # Initialise all exits to zero.
+            for node_id, node in stage_graph.nodes.items():
+                if node.stage_type == "exit":
+                    exit_counts[node_id] = 0
+            # Seed from initial agent assignments.
+            for agent_id_init, wi in agent_wait_info.items():
+                exit_id = _extract_terminal_exit(wi, stage_graph.nodes)
+                if exit_id is not None:
+                    exit_counts[exit_id] = exit_counts.get(exit_id, 0) + 1
+                    if agent_id_init not in agent_route_state:
+                        agent_route_state[agent_id_init] = AgentRouteState(
+                            current_exit=exit_id,
+                            eval_offset_s=compute_eval_offset(
+                                agent_id_init,
+                                reroute_config.reevaluation_interval_s,
+                            ),
+                        )
+                    else:
+                        agent_route_state[agent_id_init].current_exit = exit_id
         # Precompute whether any zone/checkpoint has a non-trivial speed factor.
         # When none do, skip the expensive per-agent update_checkpoint_speed loop.
         _has_speed_zones = (
@@ -1270,6 +1324,14 @@ def run_scenario(
                                     )
                                     if path_state:
                                         agent_wait_info[agent_id] = path_state
+                                        if path_state and stage_graph is not None:
+                                            _spawn_exit = _extract_terminal_exit(
+                                                path_state, stage_graph.nodes
+                                            )
+                                            if _spawn_exit is not None:
+                                                exit_counts[_spawn_exit] = (
+                                                    exit_counts.get(_spawn_exit, 0) + 1
+                                                )
                                 elif (
                                     not selected_variant
                                     and agent_wait_info is not None
@@ -1330,6 +1392,15 @@ def run_scenario(
                                             "step_index": 0,
                                             "base_seed": base_seed,
                                         }
+                                        if stage_graph is not None:
+                                            _spawn_exit = _extract_terminal_exit(
+                                                agent_wait_info[agent_id],
+                                                stage_graph.nodes,
+                                            )
+                                            if _spawn_exit is not None:
+                                                exit_counts[_spawn_exit] = (
+                                                    exit_counts.get(_spawn_exit, 0) + 1
+                                                )
 
                                 spawned_this_attempt = True
                                 break
@@ -1555,6 +1626,7 @@ def run_scenario(
                                 _fed_rate_adapter,
                                 reroute_config.cost_config,
                                 cached_segments=route_segment_cache,
+                                exit_counts=exit_counts,
                             )
                             for route_rank, rc in enumerate(ranked, start=1):
                                 route_cost_history.append(
@@ -1587,8 +1659,18 @@ def run_scenario(
                         fed_rate_sampler=_fed_rate_adapter,
                         config=reroute_config,
                         cached_segments=route_segment_cache,
+                        exit_counts=exit_counts,
                     )
                     if switch is not None:
+                        # Update exit_counts: decrement old, increment new.
+                        if switch.old_exit and switch.old_exit in exit_counts:
+                            exit_counts[switch.old_exit] = max(
+                                0, exit_counts[switch.old_exit] - 1
+                            )
+                        if switch.new_exit in exit_counts:
+                            exit_counts[switch.new_exit] = (
+                                exit_counts.get(switch.new_exit, 0) + 1
+                            )
                         route_history.append(
                             {
                                 "time_s": round(float(switch.time_s), 6),
@@ -1643,7 +1725,18 @@ def run_scenario(
                 if agent_route_state:
                     for tracked_agent_id in list(agent_route_state.keys()):
                         if tracked_agent_id not in live_agent_ids:
-                            agent_route_state.pop(tracked_agent_id, None)
+                            removed_state = agent_route_state.pop(
+                                tracked_agent_id, None
+                            )
+                            if (
+                                removed_state is not None
+                                and removed_state.current_exit
+                                and removed_state.current_exit in exit_counts
+                            ):
+                                exit_counts[removed_state.current_exit] = max(
+                                    0,
+                                    exit_counts[removed_state.current_exit] - 1,
+                                )
 
             if direct_steering_info and agent_wait_info:
                 for agent_id, wait_info in list(agent_wait_info.items()):

--- a/pyfds_evac/core/simulation_init.py
+++ b/pyfds_evac/core/simulation_init.py
@@ -766,6 +766,7 @@ def _initialize_with_fallback(
                     "enable_throughput_throttling": enable_throttling,
                     "max_throughput": float(exit_data.get("max_throughput", 0.0)),
                     "stage_type": "exit",
+                    "capacity_agents_per_s": exit_data.get("capacity_agents_per_s"),
                 }
 
     if not exits:

--- a/run.py
+++ b/run.py
@@ -273,13 +273,27 @@ def main() -> int:
             )
             fed_model = DefaultFedModel(FdsFedField.from_fds(args.fds_dir), fed_config)
     reroute_config = None
-    if args.enable_rerouting and smoke_speed_model is not None:
-        print("Configuring smoke-based rerouting.")
+    if args.enable_rerouting:
+        routing_params = scenario.raw.get("routing", {})
+        cost_config = RouteCostConfig(
+            w_smoke=routing_params.get("w_smoke", 1.0),
+            w_fed=routing_params.get("w_fed", 10.0),
+            w_queue=routing_params.get("w_queue", 1.0),
+            fed_rejection_threshold=routing_params.get("fed_rejection_threshold", 1.0),
+            visibility_extinction_threshold=routing_params.get(
+                "visibility_extinction_threshold", 0.5
+            ),
+            sampling_step_m=routing_params.get("sampling_step_m", 2.0),
+            base_speed_m_per_s=routing_params.get("base_speed_m_per_s", 1.3),
+            alpha=routing_params.get("alpha", 0.706),
+            beta=routing_params.get("beta", -0.057),
+            min_speed_factor=routing_params.get("min_speed_factor", 0.1),
+            default_exit_capacity=routing_params.get("default_exit_capacity", 1.3),
+        )
+        print("Configuring rerouting.")
         reroute_config = RerouteConfig(
             reevaluation_interval_s=args.reroute_interval,
-            cost_config=RouteCostConfig(
-                base_speed_m_per_s=1.3,
-            ),
+            cost_config=cost_config,
         )
 
     print("Initialization finished.")

--- a/run.py
+++ b/run.py
@@ -205,6 +205,9 @@ def _write_route_cost_history_csv(rows, output_path: str) -> None:
         "composite_cost",
         "rejected",
         "rejection_reason",
+        "queue_time_s",
+        "exit_count",
+        "exit_capacity",
     ]
     with destination.open("w", encoding="utf-8", newline="") as handle:
         writer = csv.DictWriter(handle, fieldnames=fieldnames)

--- a/scripts/inspect_fds.py
+++ b/scripts/inspect_fds.py
@@ -225,7 +225,6 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
 
     # FED readiness summary
     print("\nFED readiness:")
-    has = {q["label"]: any(r[0]["label"] == q["label"] for r in results) for q in QUANTITIES}
     co_ok  = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "CO")
     co2_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "CO₂")
     o2_ok  = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "O₂")
@@ -233,7 +232,7 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
     if co_ok and co2_ok and o2_ok:
         print("  ✓ CO / CO2 / O2 all present and non-zero → default FED model will run")
     else:
-        missing = [l for l, ok in [("CO", co_ok), ("CO2", co2_ok), ("O2", o2_ok)] if not ok]
+        missing = [name for name, ok in [("CO", co_ok), ("CO2", co2_ok), ("O2", o2_ok)] if not ok]
         print(f"  ✗ Missing or zero: {', '.join(missing)} → FED will be negligible")
 
     smoke_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "Extinction K")

--- a/scripts/inspect_fds.py
+++ b/scripts/inspect_fds.py
@@ -99,8 +99,8 @@ class QuantityStats:
     label: str
     unit: str
     times: np.ndarray
-    peak: np.ndarray       # max over spatial domain at each time step
-    mean: np.ndarray       # mean over spatial domain at each time step
+    peak: np.ndarray  # max over spatial domain at each time step
+    mean: np.ndarray  # mean over spatial domain at each time step
     global_max: float
     global_mean_at_peak: float
     scale: float = 1.0
@@ -157,10 +157,9 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
 
     # Show all available slice quantities
     try:
-        all_quantities = sorted({
-            str(getattr(q, "name", q))
-            for q in getattr(sim.slices, "quantities", [])
-        })
+        all_quantities = sorted(
+            {str(getattr(q, "name", q)) for q in getattr(sim.slices, "quantities", [])}
+        )
     except Exception:
         all_quantities = []
 
@@ -169,7 +168,9 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
         print(f"  - {q}")
 
     print(f"\nAnalysing key quantities at z ≈ {height} m:")
-    print(f"{'Quantity':<12} {'Unit':<8} {'Global max':>12} {'Mean@peak':>12} {'Status'}")
+    print(
+        f"{'Quantity':<12} {'Unit':<8} {'Global max':>12} {'Mean@peak':>12} {'Status'}"
+    )
     print("-" * 60)
 
     results: list[tuple[dict, QuantityStats]] = []
@@ -225,18 +226,26 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
 
     # FED readiness summary
     print("\nFED readiness:")
-    co_ok  = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "CO")
+    co_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "CO")
     co2_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "CO₂")
-    o2_ok  = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "O₂")
+    o2_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "O₂")
 
     if co_ok and co2_ok and o2_ok:
         print("  ✓ CO / CO2 / O2 all present and non-zero → default FED model will run")
     else:
-        missing = [name for name, ok in [("CO", co_ok), ("CO2", co2_ok), ("O2", o2_ok)] if not ok]
+        missing = [
+            name
+            for name, ok in [("CO", co_ok), ("CO2", co2_ok), ("O2", o2_ok)]
+            if not ok
+        ]
         print(f"  ✗ Missing or zero: {', '.join(missing)} → FED will be negligible")
 
-    smoke_ok = any(r[1].global_max > 1e-9 for r in results if r[0]["label"] == "Extinction K")
-    print(f"  {'✓' if smoke_ok else '✗'} Extinction coefficient → smoke-speed model {'will' if smoke_ok else 'will NOT'} run")
+    smoke_ok = any(
+        r[1].global_max > 1e-9 for r in results if r[0]["label"] == "Extinction K"
+    )
+    print(
+        f"  {'✓' if smoke_ok else '✗'} Extinction coefficient → smoke-speed model {'will' if smoke_ok else 'will NOT'} run"
+    )
 
     if not plot:
         return
@@ -257,11 +266,19 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
         color = qinfo.get("color", "tab:blue")
         ax.plot(stats.times, stats.peak, color=color, lw=2, label="spatial max")
         ax.fill_between(stats.times, stats.mean, stats.peak, alpha=0.2, color=color)
-        ax.plot(stats.times, stats.mean, color=color, lw=1, ls="--", label="spatial mean")
+        ax.plot(
+            stats.times, stats.mean, color=color, lw=1, ls="--", label="spatial mean"
+        )
 
         threshold = qinfo.get("threshold")
         if threshold is not None:
-            ax.axhline(threshold, color="red", lw=1, ls=":", label=qinfo.get("threshold_label", f"threshold={threshold}"))
+            ax.axhline(
+                threshold,
+                color="red",
+                lw=1,
+                ls=":",
+                label=qinfo.get("threshold_label", f"threshold={threshold}"),
+            )
 
         ax.set_title(f"{stats.label} [{stats.unit}]")
         ax.set_xlabel("Time (s)")
@@ -276,6 +293,7 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
     fig.tight_layout()
 
     import pathlib
+
     out_path = pathlib.Path(fds_dir) / "fds_inspection.png"
     fig.savefig(out_path, dpi=150)
     print(f"\nPlot saved: {out_path}")
@@ -283,9 +301,16 @@ def inspect(fds_dir: str, height: float = 2.0, plot: bool = False) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("fds_dir", help="Path to FDS simulation directory")
-    parser.add_argument("--height", type=float, default=2.0, help="Slice height in metres (default: 2.0)")
+    parser.add_argument(
+        "--height",
+        type=float,
+        default=2.0,
+        help="Slice height in metres (default: 2.0)",
+    )
     parser.add_argument("--plot", action="store_true", help="Generate and save plots")
     args = parser.parse_args()
 

--- a/scripts/plot_route_costs.py
+++ b/scripts/plot_route_costs.py
@@ -17,9 +17,7 @@ def main(cost_csv: str, routes_csv: str | None = None) -> None:
     df = pd.read_csv(cost_csv)
 
     # Mean composite cost per (time, exit) across all agents
-    mean_cost = (
-        df.groupby(["time_s", "exit_id"])["composite_cost"].mean().reset_index()
-    )
+    mean_cost = df.groupby(["time_s", "exit_id"])["composite_cost"].mean().reset_index()
 
     exits = sorted(mean_cost["exit_id"].unique())
     colors = ["tab:blue", "tab:orange", "tab:green", "tab:red"]
@@ -29,7 +27,13 @@ def main(cost_csv: str, routes_csv: str | None = None) -> None:
     for i, exit_id in enumerate(exits):
         sub = mean_cost[mean_cost["exit_id"] == exit_id].sort_values("time_s")
         label = exit_id.replace("_", " ")
-        ax.plot(sub["time_s"], sub["composite_cost"], label=label, color=colors[i % len(colors)], lw=2)
+        ax.plot(
+            sub["time_s"],
+            sub["composite_cost"],
+            label=label,
+            color=colors[i % len(colors)],
+            lw=2,
+        )
 
     # Overlay route switches if provided
     if routes_csv and Path(routes_csv).exists():

--- a/specs/007-congestion-aware-routing/PLAN.md
+++ b/specs/007-congestion-aware-routing/PLAN.md
@@ -1,0 +1,1328 @@
+# Congestion-Aware Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a queueing cost term to route ranking so agents distribute across exits instead of all picking the same cheapest one.
+
+**Architecture:** The queue penalty is added at the route-level composite cost (Phase 3), not in Dijkstra edge weights. Exit counts are tracked in a `dict[str, int]` derived from `AgentRouteState.current_exit` as the single source of truth. The reroute loop is decoupled from the smoke model so congestion routing works in clear-air scenarios.
+
+**Tech Stack:** Python 3.11+, dataclasses, pytest, shapely (for test fixtures)
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|---------------|
+| `pyfds_evac/core/route_graph.py` | `StageNode` + capacity field, `RouteCostConfig` + queue weights, `RouteCost` + queue_time_s, `evaluate_route` + queue term, `rank_routes` + exit_counts param, `evaluate_and_reroute` + exit_counts param |
+| `pyfds_evac/core/scenario.py` | Remove smoke gate from reroute loop, zero-extinction fallback, seed exit_counts at startup, count on flow-spawn, maintain on reroute/removal, pass exit_counts to routing calls, add queue columns to CSV |
+| `pyfds_evac/core/simulation_init.py` | Propagate `capacity_agents_per_s` from exit config into `direct_steering_info` |
+| `tests/test_route_graph.py` | Unit tests for queue term, backward compat, capacity, exit count effect |
+| `docs/routing.md` | Document queueing cost, config parameters, congestion behaviour |
+
+---
+
+### Task 1: Add `capacity_agents_per_s` to `StageNode`
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py:17-24`
+- Modify: `pyfds_evac/core/route_graph.py:102-113`
+- Test: `tests/test_route_graph.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_route_graph.py`:
+
+```python
+class TestStageNodeCapacity:
+    def test_default_capacity_is_none(self):
+        from pyfds_evac.core.route_graph import StageNode
+
+        node = StageNode(
+            stage_id="E0",
+            centroid_x=0.0,
+            centroid_y=0.0,
+            stage_type="exit",
+        )
+        assert node.capacity_agents_per_s is None
+
+    def test_capacity_set_from_constructor(self):
+        from pyfds_evac.core.route_graph import StageNode
+
+        node = StageNode(
+            stage_id="E0",
+            centroid_x=0.0,
+            centroid_y=0.0,
+            stage_type="exit",
+            capacity_agents_per_s=2.5,
+        )
+        assert node.capacity_agents_per_s == 2.5
+
+    def test_capacity_propagated_from_scenario(self):
+        direct_steering_info = {
+            "E0": {
+                "polygon": _box(10, 0),
+                "stage_type": "exit",
+                "capacity_agents_per_s": 2.0,
+            },
+        }
+        distributions = {
+            "D0": {"coordinates": list(_box(0, 0).exterior.coords)},
+        }
+        transitions = [{"from": "D0", "to": "E0"}]
+        graph = StageGraph.from_scenario(
+            direct_steering_info, transitions, distributions
+        )
+        assert graph.nodes["E0"].capacity_agents_per_s == 2.0
+        assert graph.nodes["D0"].capacity_agents_per_s is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestStageNodeCapacity -v`
+Expected: FAIL — `StageNode.__init__()` got unexpected keyword argument `capacity_agents_per_s`
+
+- [ ] **Step 3: Add the field to `StageNode`**
+
+In `pyfds_evac/core/route_graph.py`, change the `StageNode` dataclass (line 17-24):
+
+```python
+@dataclass(frozen=True)
+class StageNode:
+    """A node in the stage graph representing one stage."""
+
+    stage_id: str
+    centroid_x: float
+    centroid_y: float
+    stage_type: str  # "exit", "checkpoint", "distribution", "zone"
+    capacity_agents_per_s: float | None = None
+```
+
+- [ ] **Step 4: Propagate capacity in `from_scenario`**
+
+In `pyfds_evac/core/route_graph.py`, update the stage-node construction loop (line 102-113).  Change the `StageNode(...)` call to pass the capacity:
+
+```python
+        # Add stage nodes from direct_steering_info.
+        for stage_id, info in direct_steering_info.items():
+            polygon = info.get("polygon")
+            if polygon is None:
+                continue
+            cx, cy = polygon.centroid.x, polygon.centroid.y
+            stage_type = info.get("stage_type", "checkpoint")
+            graph.nodes[stage_id] = StageNode(
+                stage_id=stage_id,
+                centroid_x=cx,
+                centroid_y=cy,
+                stage_type=stage_type,
+                capacity_agents_per_s=info.get("capacity_agents_per_s"),
+            )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestStageNodeCapacity -v`
+Expected: 3 passed
+
+- [ ] **Step 6: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/test_route_graph.py -v`
+Expected: all existing tests pass (the new optional field with `None` default doesn't break anything)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "feat(routing): add capacity_agents_per_s to StageNode"
+```
+
+---
+
+### Task 2: Add `w_queue` and `default_exit_capacity` to `RouteCostConfig`, add `queue_time_s` to `RouteCost`
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py:391-403` (`RouteCostConfig`)
+- Modify: `pyfds_evac/core/route_graph.py:420-433` (`RouteCost`)
+- Modify: `pyfds_evac/core/route_graph.py:586-597` (`evaluate_route` return)
+- Modify: `pyfds_evac/core/route_graph.py:679-691` (visibility rejection `RouteCost` rebuild)
+- Modify: `pyfds_evac/core/route_graph.py:704-715` (fallback `RouteCost` rebuild)
+- Test: `tests/test_route_graph.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_route_graph.py`:
+
+```python
+class TestQueueConfigAndFields:
+    def test_route_cost_config_defaults(self):
+        config = RouteCostConfig()
+        assert config.w_queue == 1.0
+        assert config.default_exit_capacity == 1.3
+
+    def test_route_cost_config_queue_disabled(self):
+        config = RouteCostConfig(w_queue=0.0)
+        assert config.w_queue == 0.0
+
+    def test_route_cost_has_queue_time_field(self, linear_graph):
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig()
+        rc = evaluate_route(
+            linear_graph, ["D0", "C0", "E0"], 0.0, 0.0, field, None, config
+        )
+        assert hasattr(rc, "queue_time_s")
+        assert rc.queue_time_s == 0.0
+```
+
+Note: this test imports `ConstantExtinctionField` from `pyfds_evac.core.smoke_speed` (already imported in the test file) and uses the existing `linear_graph` fixture.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestQueueConfigAndFields -v`
+Expected: FAIL — `RouteCostConfig` has no `w_queue` attribute / `RouteCost` has no `queue_time_s`
+
+- [ ] **Step 3: Add fields to `RouteCostConfig`**
+
+In `pyfds_evac/core/route_graph.py`, update `RouteCostConfig` (line 391-403):
+
+```python
+@dataclass(frozen=True)
+class RouteCostConfig:
+    """Weights and thresholds for route cost evaluation."""
+
+    w_smoke: float = 1.0
+    w_fed: float = 10.0
+    w_queue: float = 1.0
+    fed_rejection_threshold: float = 1.0
+    visibility_extinction_threshold: float = 0.5
+    sampling_step_m: float = 2.0
+    base_speed_m_per_s: float = 1.3
+    alpha: float = 0.706
+    beta: float = -0.057
+    min_speed_factor: float = 0.1
+    default_exit_capacity: float = 1.3
+```
+
+- [ ] **Step 4: Add `queue_time_s` field to `RouteCost`**
+
+In `pyfds_evac/core/route_graph.py`, update `RouteCost` (line 420-433):
+
+```python
+@dataclass(frozen=True)
+class RouteCost:
+    """Full cost evaluation for one candidate route."""
+
+    exit_id: str
+    path: list[str]
+    path_length_m: float
+    k_ave_route: float
+    travel_time_s: float
+    fed_max_route: float
+    composite_cost: float
+    segments: list[SegmentCost]
+    rejected: bool
+    rejection_reason: str | None
+    queue_time_s: float = 0.0
+```
+
+- [ ] **Step 5: Update all `RouteCost(...)` constructor calls to pass `queue_time_s=0.0`**
+
+There are three call sites in `route_graph.py`.  Add `queue_time_s=0.0` to each:
+
+**Call site 1** — `evaluate_route` return (line ~586):
+
+```python
+    return RouteCost(
+        exit_id=path[-1] if path else "",
+        path=path,
+        path_length_m=path_length,
+        k_ave_route=k_ave,
+        travel_time_s=travel_time,
+        fed_max_route=fed_max,
+        composite_cost=composite,
+        segments=segments,
+        rejected=rejected,
+        rejection_reason=reason,
+        queue_time_s=0.0,
+    )
+```
+
+**Call site 2** — visibility rejection rebuild (line ~679):
+
+```python
+                rc = RouteCost(
+                    exit_id=rc.exit_id,
+                    path=rc.path,
+                    path_length_m=rc.path_length_m,
+                    k_ave_route=rc.k_ave_route,
+                    travel_time_s=rc.travel_time_s,
+                    fed_max_route=rc.fed_max_route,
+                    composite_cost=rc.composite_cost,
+                    segments=rc.segments,
+                    rejected=True,
+                    rejection_reason="all segments non-visible",
+                    queue_time_s=rc.queue_time_s,
+                )
+```
+
+**Call site 3** — fallback un-reject rebuild (line ~704):
+
+```python
+        costs[0] = RouteCost(
+            exit_id=best.exit_id,
+            path=best.path,
+            path_length_m=best.path_length_m,
+            k_ave_route=best.k_ave_route,
+            travel_time_s=best.travel_time_s,
+            fed_max_route=best.fed_max_route,
+            composite_cost=best.composite_cost,
+            segments=best.segments,
+            rejected=False,
+            rejection_reason=f"fallback: {best.rejection_reason}",
+            queue_time_s=best.queue_time_s,
+        )
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestQueueConfigAndFields -v`
+Expected: 3 passed
+
+- [ ] **Step 7: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/test_route_graph.py -v`
+Expected: all existing tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "feat(routing): add w_queue, default_exit_capacity to config; queue_time_s to RouteCost"
+```
+
+---
+
+### Task 3: Add queue term to `evaluate_route` and wire `exit_counts` into `rank_routes`
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py:539-597` (`evaluate_route`)
+- Modify: `pyfds_evac/core/route_graph.py:600-717` (`rank_routes`)
+- Test: `tests/test_route_graph.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_route_graph.py`:
+
+```python
+class TestQueueCostTerm:
+    def test_evaluate_route_adds_queue_cost(self, multi_exit_graph):
+        """Queue term increases composite cost for a congested exit."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+
+        # Without queue counts: route to E0 (distance ~10)
+        rc_no_queue = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+        )
+
+        # With queue counts: 20 agents at E0
+        rc_with_queue = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": 20, "E1": 0},
+        )
+
+        assert rc_with_queue.composite_cost > rc_no_queue.composite_cost
+        assert rc_with_queue.queue_time_s > 0.0
+        assert rc_no_queue.queue_time_s == 0.0
+
+    def test_queue_cost_uses_distance_equivalent(self, multi_exit_graph):
+        """Queue cost = w_queue * base_speed * N / capacity."""
+        field = ConstantExtinctionField(0.0)
+        base_speed = 1.3
+        capacity = 1.3
+        n_agents = 10
+        config = RouteCostConfig(
+            w_smoke=0.0,
+            w_fed=0.0,
+            w_queue=1.0,
+            base_speed_m_per_s=base_speed,
+            default_exit_capacity=capacity,
+        )
+        rc = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": n_agents},
+        )
+        expected_queue_time = n_agents / capacity
+        expected_queue_distance = base_speed * expected_queue_time
+        # path_length is ~10m, composite = 10 + 1.0 * queue_distance
+        assert abs(rc.queue_time_s - expected_queue_time) < 1e-6
+        assert abs(
+            rc.composite_cost - (rc.path_length_m + expected_queue_distance)
+        ) < 0.1
+
+    def test_w_queue_zero_disables_queue(self, multi_exit_graph):
+        """w_queue=0 means exit_counts have no effect."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=0.0)
+        rc_no_counts = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+        )
+        rc_with_counts = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": 100},
+        )
+        assert abs(rc_no_counts.composite_cost - rc_with_counts.composite_cost) < 1e-9
+
+    def test_custom_capacity_reduces_penalty(self, multi_exit_graph):
+        """Higher capacity → lower queue penalty for same agent count."""
+        field = ConstantExtinctionField(0.0)
+        config_low = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=1.0
+        )
+        config_high = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=5.0
+        )
+        counts = {"E0": 20}
+        rc_low = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config_low,
+            exit_counts=counts,
+        )
+        rc_high = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config_high,
+            exit_counts=counts,
+        )
+        assert rc_low.composite_cost > rc_high.composite_cost
+
+    def test_node_capacity_overrides_default(self):
+        """StageNode.capacity_agents_per_s overrides config default."""
+        direct_steering_info = {
+            "E0": {
+                "polygon": _box(10, 0),
+                "stage_type": "exit",
+                "capacity_agents_per_s": 10.0,
+            },
+        }
+        distributions = {
+            "D0": {"coordinates": list(_box(0, 0).exterior.coords)},
+        }
+        transitions = [{"from": "D0", "to": "E0"}]
+        graph = StageGraph.from_scenario(
+            direct_steering_info, transitions, distributions
+        )
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=1.0
+        )
+        counts = {"E0": 10}
+        rc = evaluate_route(
+            graph, ["D0", "E0"], 0.0, 0.0, field, None, config,
+            exit_counts=counts,
+        )
+        # capacity=10 → queue_time = 10/10 = 1.0s
+        assert abs(rc.queue_time_s - 1.0) < 1e-6
+
+
+class TestRankRoutesWithCongestion:
+    def test_congestion_shifts_best_exit(self, multi_exit_graph):
+        """With enough agents at E0, E1 becomes cheaper despite being farther."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+
+        # Without congestion: E0 is closer (10m vs 20m)
+        ranked_no_q = rank_routes(
+            multi_exit_graph, "D0", 0.0, 0.0, field, None, config
+        )
+        assert ranked_no_q[0].exit_id == "E0"
+
+        # With heavy congestion at E0: E1 should become cheaper
+        # E0: 10m + 1.0 * 1.3 * 50/1.3 = 10 + 50 = 60
+        # E1: 20m + 1.0 * 1.3 * 0/1.3  = 20 + 0  = 20
+        ranked_q = rank_routes(
+            multi_exit_graph, "D0", 0.0, 0.0, field, None, config,
+            exit_counts={"E0": 50, "E1": 0},
+        )
+        assert ranked_q[0].exit_id == "E1"
+
+    def test_rank_routes_without_exit_counts_unchanged(self, multi_exit_graph):
+        """Omitting exit_counts gives identical results to current behaviour."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig()
+        ranked = rank_routes(
+            multi_exit_graph, "D0", 0.0, 0.0, field, None, config
+        )
+        assert ranked[0].exit_id == "E0"
+        assert ranked[0].queue_time_s == 0.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestQueueCostTerm tests/test_route_graph.py::TestRankRoutesWithCongestion -v`
+Expected: FAIL — `evaluate_route` doesn't accept `exit_counts` / `rank_routes` doesn't accept `exit_counts`
+
+- [ ] **Step 3: Add `exit_counts` parameter to `evaluate_route` and compute queue term**
+
+In `pyfds_evac/core/route_graph.py`, modify `evaluate_route` (line 539-597).
+
+Change the signature to accept `exit_counts`:
+
+```python
+def evaluate_route(
+    graph: StageGraph,
+    path: list[str],
+    time_s: float,
+    current_fed: float,
+    extinction_sampler: ExtinctionSampler,
+    fed_rate_sampler: FedRateSampler | None,
+    config: RouteCostConfig,
+    *,
+    cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    exit_counts: dict[str, int] | None = None,
+) -> RouteCost:
+```
+
+After the existing composite cost computation (line 577-578), add the queue term:
+
+```python
+    # Composite cost: path_length * (1 + w_smoke * K_ave) + w_fed * FED_max
+    composite = path_length * (1.0 + config.w_smoke * k_ave) + config.w_fed * fed_max
+
+    # Queue cost: convert queue delay to distance-equivalent units.
+    queue_time = 0.0
+    if exit_counts is not None and config.w_queue > 0 and path:
+        exit_id = path[-1]
+        n_exit = exit_counts.get(exit_id, 0)
+        exit_node = graph.nodes.get(exit_id)
+        capacity = (
+            exit_node.capacity_agents_per_s
+            if exit_node is not None and exit_node.capacity_agents_per_s is not None
+            else config.default_exit_capacity
+        )
+        if capacity > 0:
+            queue_time = n_exit / capacity
+            queue_distance = config.base_speed_m_per_s * queue_time
+            composite += config.w_queue * queue_distance
+```
+
+Update the return statement to pass `queue_time_s=queue_time`:
+
+```python
+    return RouteCost(
+        exit_id=path[-1] if path else "",
+        path=path,
+        path_length_m=path_length,
+        k_ave_route=k_ave,
+        travel_time_s=travel_time,
+        fed_max_route=fed_max,
+        composite_cost=composite,
+        segments=segments,
+        rejected=rejected,
+        rejection_reason=reason,
+        queue_time_s=queue_time,
+    )
+```
+
+- [ ] **Step 4: Add `exit_counts` keyword-only parameter to `rank_routes`**
+
+In `pyfds_evac/core/route_graph.py`, modify the `rank_routes` signature (line 600-610):
+
+```python
+def rank_routes(
+    graph: StageGraph,
+    source: str,
+    time_s: float,
+    current_fed: float,
+    extinction_sampler: ExtinctionSampler,
+    fed_rate_sampler: FedRateSampler | None,
+    config: RouteCostConfig,
+    *,
+    cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    exit_counts: dict[str, int] | None = None,
+) -> list[RouteCost]:
+```
+
+Pass `exit_counts` through to `evaluate_route` in the Phase 3 loop (line ~658):
+
+```python
+        rc = evaluate_route(
+            graph,
+            path,
+            time_s,
+            current_fed,
+            extinction_sampler,
+            fed_rate_sampler,
+            config,
+            cached_segments=cached_segments,
+            exit_counts=exit_counts,
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestQueueCostTerm tests/test_route_graph.py::TestRankRoutesWithCongestion -v`
+Expected: all passed
+
+- [ ] **Step 6: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/test_route_graph.py -v`
+Expected: all existing tests pass (new param is keyword-only with `None` default)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "feat(routing): add queue cost term to evaluate_route and rank_routes"
+```
+
+---
+
+### Task 4: Wire `exit_counts` into `evaluate_and_reroute`
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py:848-929` (`evaluate_and_reroute`)
+- Test: `tests/test_route_graph.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_route_graph.py`:
+
+```python
+class TestEvaluateAndRerouteWithCongestion:
+    def test_congestion_triggers_reroute(self, multi_exit_graph):
+        """Agent switches from congested E0 to uncongested E1."""
+        field = ConstantExtinctionField(0.0)
+        cost_config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+        config = RerouteConfig(reevaluation_interval_s=1.0, cost_config=cost_config)
+
+        wait_info = {
+            "mode": "path",
+            "current_origin": "D0",
+            "current_target_stage": "E0",
+            "path_choices": {"D0": [("E0", 100.0)]},
+            "stage_configs": {
+                "E0": {
+                    "polygon": _box(10, 0),
+                    "stage_type": "exit",
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 1.0,
+                    "enable_throughput_throttling": False,
+                    "max_throughput": 1.0,
+                    "speed_factor": 1.0,
+                },
+                "E1": {
+                    "polygon": _box(20, 0),
+                    "stage_type": "exit",
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 1.0,
+                    "enable_throughput_throttling": False,
+                    "max_throughput": 1.0,
+                    "speed_factor": 1.0,
+                },
+            },
+            "state": "to_target",
+        }
+        route_state = AgentRouteState(current_exit="E0", eval_offset_s=0.0)
+
+        switch = evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=multi_exit_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+            exit_counts={"E0": 50, "E1": 0},
+        )
+        assert switch is not None
+        assert switch.new_exit == "E1"
+        assert switch.old_exit == "E0"
+
+    def test_no_exit_counts_backward_compatible(self, multi_exit_graph):
+        """Without exit_counts, behaviour is identical to current."""
+        field = ConstantExtinctionField(0.0)
+        config = RerouteConfig(reevaluation_interval_s=1.0)
+        wait_info = {
+            "mode": "path",
+            "current_origin": "D0",
+            "current_target_stage": "E0",
+            "path_choices": {"D0": [("E0", 100.0)]},
+            "stage_configs": {},
+            "state": "to_target",
+        }
+        route_state = AgentRouteState(eval_offset_s=0.0)
+
+        switch = evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=multi_exit_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+        )
+        # Initial assignment to E0 (nearest)
+        assert switch is not None
+        assert switch.new_exit == "E0"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestEvaluateAndRerouteWithCongestion -v`
+Expected: FAIL — `evaluate_and_reroute` doesn't accept `exit_counts`
+
+- [ ] **Step 3: Add `exit_counts` parameter to `evaluate_and_reroute`**
+
+In `pyfds_evac/core/route_graph.py`, modify the signature (line 848-859):
+
+```python
+def evaluate_and_reroute(
+    agent_id: int,
+    wait_info: dict,
+    route_state: AgentRouteState,
+    graph: StageGraph,
+    current_time_s: float,
+    current_fed: float,
+    extinction_sampler: ExtinctionSampler,
+    fed_rate_sampler: FedRateSampler | None,
+    config: RerouteConfig,
+    cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
+    *,
+    exit_counts: dict[str, int] | None = None,
+) -> RouteSwitch | None:
+```
+
+Pass `exit_counts` through to `rank_routes` (line ~871-880):
+
+```python
+    ranked = rank_routes(
+        graph,
+        source,
+        current_time_s,
+        current_fed,
+        extinction_sampler,
+        fed_rate_sampler,
+        config.cost_config,
+        cached_segments=cached_segments,
+        exit_counts=exit_counts,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run python -m pytest tests/test_route_graph.py::TestEvaluateAndRerouteWithCongestion -v`
+Expected: all passed
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/test_route_graph.py -v`
+Expected: all existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "feat(routing): wire exit_counts into evaluate_and_reroute"
+```
+
+---
+
+### Task 5: Decouple reroute loop from smoke model in `scenario.py`
+
+**Files:**
+- Modify: `pyfds_evac/core/scenario.py:1483-1491` (reroute loop guard)
+- Modify: `pyfds_evac/core/scenario.py:1547` (smoke_speed_model.field reference)
+- Modify: `pyfds_evac/core/scenario.py:1579` (smoke_speed_model.field reference)
+
+This task changes the runtime guard.  No new unit tests are added here — the clear-air integration test in Task 8 validates the behaviour.
+
+- [ ] **Step 1: Add the zero-extinction sampler import at the top of `scenario.py`**
+
+Near the existing imports from `pyfds_evac.core.smoke_speed`, add:
+
+```python
+from pyfds_evac.core.smoke_speed import ConstantExtinctionField
+```
+
+And define the zero-extinction constant after the imports:
+
+```python
+_ZERO_EXTINCTION = ConstantExtinctionField(0.0)
+```
+
+- [ ] **Step 2: Remove `smoke_speed_model is not None` from the reroute-loop guard**
+
+In `pyfds_evac/core/scenario.py`, change the reroute-loop condition (line 1483-1491) from:
+
+```python
+            if (
+                reroute_config is not None
+                and stage_graph is not None
+                and smoke_speed_model is not None
+                and agent_wait_info
+                and (
+                    last_reroute_check_time is None
+                    or simulation.elapsed_time() - last_reroute_check_time >= 1.0
+                )
+            ):
+```
+
+to:
+
+```python
+            if (
+                reroute_config is not None
+                and stage_graph is not None
+                and agent_wait_info
+                and (
+                    last_reroute_check_time is None
+                    or simulation.elapsed_time() - last_reroute_check_time >= 1.0
+                )
+            ):
+```
+
+- [ ] **Step 3: Compute `extinction_sampler` once at the top of the reroute block**
+
+Right after the guard (before `route_segment_cache = {}`), add:
+
+```python
+                extinction_sampler = (
+                    smoke_speed_model.field
+                    if smoke_speed_model is not None
+                    else _ZERO_EXTINCTION
+                )
+```
+
+- [ ] **Step 4: Replace `smoke_speed_model.field` with `extinction_sampler` in the reroute block**
+
+There are two references to `smoke_speed_model.field` inside the reroute block:
+
+**Line ~1547** (route cost history collection):
+Change `smoke_speed_model.field,` to `extinction_sampler,`
+
+**Line ~1579** (evaluate_and_reroute call):
+Change `extinction_sampler=smoke_speed_model.field,` to `extinction_sampler=extinction_sampler,`
+
+- [ ] **Step 5: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/ -v`
+Expected: all existing tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyfds_evac/core/scenario.py
+git commit -m "feat(routing): decouple reroute loop from smoke model
+
+Use ConstantExtinctionField(0.0) as fallback when no smoke field
+is configured, so congestion-aware routing works in clear-air
+scenarios."
+```
+
+---
+
+### Task 6: Seed `exit_counts` at startup and on flow-spawn, maintain on reroute and removal
+
+**Files:**
+- Modify: `pyfds_evac/core/scenario.py:997-1011` (after graph construction — seed)
+- Modify: `pyfds_evac/core/scenario.py:1268-1269` (flow spawn path A)
+- Modify: `pyfds_evac/core/scenario.py:1314` (flow spawn path B)
+- Modify: `pyfds_evac/core/scenario.py:1572-1583` (evaluate_and_reroute call — pass exit_counts)
+- Modify: `pyfds_evac/core/scenario.py:1584+` (after switch — update counts)
+- Modify: `pyfds_evac/core/scenario.py:1636-1639` (agent removal — decrement)
+
+- [ ] **Step 1: Add a helper to extract terminal exit from `wait_info`**
+
+Add near the top of `scenario.py` (or in a utility section):
+
+```python
+def _extract_terminal_exit(
+    wait_info: dict,
+    graph_nodes: dict,
+) -> str | None:
+    """Return the exit stage ID from an agent's wait_info, or None."""
+    if wait_info.get("mode") != "path":
+        return None
+    # Try path_choices: walk the chain to find the terminal stage.
+    path_choices = wait_info.get("path_choices", {})
+    stage = wait_info.get("current_target_stage")
+    visited = set()
+    while stage and stage in path_choices and stage not in visited:
+        visited.add(stage)
+        choices = path_choices[stage]
+        if choices:
+            stage = choices[0][0] if isinstance(choices[0], (list, tuple)) else choices[0]
+        else:
+            break
+    # Check if the terminal stage is an exit node.
+    if stage and stage in graph_nodes:
+        node = graph_nodes[stage]
+        if node.stage_type == "exit":
+            return stage
+    # Fallback: current_target_stage itself.
+    fallback = wait_info.get("current_target_stage")
+    if fallback and fallback in graph_nodes and graph_nodes[fallback].stage_type == "exit":
+        return fallback
+    return None
+```
+
+- [ ] **Step 2: Initialise and seed `exit_counts` after graph construction**
+
+In `pyfds_evac/core/scenario.py`, after the `stage_graph = StageGraph.from_scenario(...)` block (line ~1004-1011), add:
+
+```python
+        exit_counts: dict[str, int] = {}
+        if reroute_config is not None and stage_graph is not None:
+            # Initialise all exits to zero.
+            for node_id, node in stage_graph.nodes.items():
+                if node.stage_type == "exit":
+                    exit_counts[node_id] = 0
+            # Seed from initial agent assignments.
+            for agent_id_init, wi in agent_wait_info.items():
+                exit_id = _extract_terminal_exit(wi, stage_graph.nodes)
+                if exit_id is not None:
+                    exit_counts[exit_id] = exit_counts.get(exit_id, 0) + 1
+                    # Pre-create AgentRouteState with current_exit set.
+                    if agent_id_init not in agent_route_state:
+                        agent_route_state[agent_id_init] = AgentRouteState(
+                            current_exit=exit_id,
+                            eval_offset_s=compute_eval_offset(
+                                agent_id_init,
+                                reroute_config.reevaluation_interval_s,
+                            ),
+                        )
+                    else:
+                        agent_route_state[agent_id_init].current_exit = exit_id
+```
+
+- [ ] **Step 3: Count flow-spawned agents at spawn time**
+
+**Spawn path A** (line ~1268-1269) — after `agent_wait_info[agent_id] = path_state`:
+
+```python
+                                    if path_state and stage_graph is not None:
+                                        exit_id = _extract_terminal_exit(
+                                            path_state, stage_graph.nodes
+                                        )
+                                        if exit_id is not None:
+                                            exit_counts[exit_id] = (
+                                                exit_counts.get(exit_id, 0) + 1
+                                            )
+```
+
+**Spawn path B** (line ~1314) — after `agent_wait_info[agent_id] = {...}`:
+
+```python
+                                        if stage_graph is not None:
+                                            _spawn_exit = _extract_terminal_exit(
+                                                agent_wait_info[agent_id],
+                                                stage_graph.nodes,
+                                            )
+                                            if _spawn_exit is not None:
+                                                exit_counts[_spawn_exit] = (
+                                                    exit_counts.get(_spawn_exit, 0) + 1
+                                                )
+```
+
+- [ ] **Step 4: Pass `exit_counts` to routing calls and update counts on reroute**
+
+In the reroute loop, pass `exit_counts` to `rank_routes` (for route cost history collection, line ~1542) and to `evaluate_and_reroute` (line ~1572):
+
+For `rank_routes` call (line ~1542):
+
+```python
+                            ranked = rank_routes(
+                                stage_graph,
+                                source,
+                                current_time,
+                                current_fed,
+                                extinction_sampler,
+                                _fed_rate_adapter,
+                                reroute_config.cost_config,
+                                cached_segments=route_segment_cache,
+                                exit_counts=exit_counts,
+                            )
+```
+
+For `evaluate_and_reroute` call (line ~1572):
+
+```python
+                    switch = evaluate_and_reroute(
+                        agent_id=agent_id,
+                        wait_info=wait_info,
+                        route_state=rs,
+                        graph=stage_graph,
+                        current_time_s=current_time,
+                        current_fed=current_fed,
+                        extinction_sampler=extinction_sampler,
+                        fed_rate_sampler=_fed_rate_adapter,
+                        config=reroute_config,
+                        cached_segments=route_segment_cache,
+                        exit_counts=exit_counts,
+                    )
+```
+
+After the `if switch is not None:` block, update exit counts:
+
+```python
+                    if switch is not None:
+                        # Update exit_counts: decrement old, increment new.
+                        if switch.old_exit and switch.old_exit in exit_counts:
+                            exit_counts[switch.old_exit] = max(
+                                0, exit_counts[switch.old_exit] - 1
+                            )
+                        if switch.new_exit in exit_counts:
+                            exit_counts[switch.new_exit] = (
+                                exit_counts.get(switch.new_exit, 0) + 1
+                            )
+```
+
+- [ ] **Step 5: Decrement exit_counts on agent removal**
+
+In the agent cleanup section (line ~1636-1639), when removing dead agents from `agent_route_state`, also decrement `exit_counts`:
+
+```python
+                if agent_route_state:
+                    for tracked_agent_id in list(agent_route_state.keys()):
+                        if tracked_agent_id not in live_agent_ids:
+                            removed_state = agent_route_state.pop(
+                                tracked_agent_id, None
+                            )
+                            if (
+                                removed_state is not None
+                                and removed_state.current_exit
+                                and removed_state.current_exit in exit_counts
+                            ):
+                                exit_counts[removed_state.current_exit] = max(
+                                    0,
+                                    exit_counts[removed_state.current_exit] - 1,
+                                )
+```
+
+- [ ] **Step 6: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/ -v`
+Expected: all existing tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyfds_evac/core/scenario.py
+git commit -m "feat(routing): seed and maintain exit_counts in scenario loop
+
+Seed from initial agent assignments after graph construction.
+Count flow-spawned agents at spawn time. Decrement on agent
+removal. Pass exit_counts to rank_routes and evaluate_and_reroute."
+```
+
+---
+
+### Task 7: Add queue columns to `route_cost_history` CSV
+
+**Files:**
+- Modify: `pyfds_evac/core/scenario.py:1553-1571` (route_cost_history append)
+
+- [ ] **Step 1: Add queue columns to route_cost_history**
+
+In `pyfds_evac/core/scenario.py`, find the route_cost_history append block (line ~1553-1571).  Add three new fields at the end of the dict:
+
+```python
+                            for route_rank, rc in enumerate(ranked, start=1):
+                                # Resolve exit capacity for this route's exit.
+                                _exit_node = stage_graph.nodes.get(rc.exit_id)
+                                _exit_cap = (
+                                    _exit_node.capacity_agents_per_s
+                                    if _exit_node is not None
+                                    and _exit_node.capacity_agents_per_s is not None
+                                    else reroute_config.cost_config.default_exit_capacity
+                                )
+                                route_cost_history.append(
+                                    {
+                                        "time_s": round(float(current_time), 6),
+                                        "agent_id": agent_id,
+                                        "source": source,
+                                        "current_exit": rs.current_exit or "",
+                                        "current_fed": float(current_fed),
+                                        "route_rank": route_rank,
+                                        "exit_id": rc.exit_id,
+                                        "path": " > ".join(rc.path),
+                                        "path_length_m": float(rc.path_length_m),
+                                        "k_ave_route": float(rc.k_ave_route),
+                                        "travel_time_s": float(rc.travel_time_s),
+                                        "fed_max_route": float(rc.fed_max_route),
+                                        "composite_cost": float(rc.composite_cost),
+                                        "rejected": bool(rc.rejected),
+                                        "rejection_reason": rc.rejection_reason or "",
+                                        "queue_time_s": float(rc.queue_time_s),
+                                        "exit_count": exit_counts.get(rc.exit_id, 0),
+                                        "exit_capacity": float(_exit_cap),
+                                    }
+                                )
+```
+
+- [ ] **Step 2: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/ -v`
+Expected: all existing tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyfds_evac/core/scenario.py
+git commit -m "feat(routing): add queue_time_s, exit_count, exit_capacity to route_cost_history"
+```
+
+---
+
+### Task 8: Propagate `capacity_agents_per_s` from scenario config into `direct_steering_info`
+
+**Files:**
+- Modify: `pyfds_evac/core/simulation_init.py:759-769`
+
+- [ ] **Step 1: Add `capacity_agents_per_s` to the exit info dict**
+
+In `pyfds_evac/core/simulation_init.py`, at line 759-769 where each exit's `direct_steering_info` entry is built, add the new field.  The `exit_data` dict comes from `data["exits"][exit_id]` in the scenario config JSON.
+
+Change:
+
+```python
+                direct_steering_info[exit_id] = {
+                    "polygon": exit_polygon,
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 0.0,
+                    "speed_factor": 1.0,
+                    "ds_stage_id": ds_stage,
+                    "enable_throughput_throttling": enable_throttling,
+                    "max_throughput": float(exit_data.get("max_throughput", 0.0)),
+                    "stage_type": "exit",
+                }
+```
+
+to:
+
+```python
+                direct_steering_info[exit_id] = {
+                    "polygon": exit_polygon,
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 0.0,
+                    "speed_factor": 1.0,
+                    "ds_stage_id": ds_stage,
+                    "enable_throughput_throttling": enable_throttling,
+                    "max_throughput": float(exit_data.get("max_throughput", 0.0)),
+                    "stage_type": "exit",
+                    "capacity_agents_per_s": exit_data.get(
+                        "capacity_agents_per_s"
+                    ),
+                }
+```
+
+This ensures that when `StageGraph.from_scenario` reads `info.get("capacity_agents_per_s")` (added in Task 1), it picks up the value from the scenario config JSON.  When `capacity_agents_per_s` is absent from config, the value is `None` and the default from `RouteCostConfig.default_exit_capacity` applies.
+
+- [ ] **Step 2: Run full test suite for regressions**
+
+Run: `uv run python -m pytest tests/ -v`
+Expected: all existing tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyfds_evac/core/simulation_init.py
+git commit -m "feat(routing): propagate capacity_agents_per_s from scenario config to StageNode"
+```
+
+---
+
+### Task 9: Update `docs/routing.md`
+
+**Files:**
+- Modify: `docs/routing.md`
+
+- [ ] **Step 1: Add congestion-aware routing section**
+
+Add a new section after "### Configuration" (before "## Dynamic rerouting"):
+
+```markdown
+### Congestion-aware routing
+
+When `w_queue > 0`, an exit-congestion term is added to the
+composite cost:
+
+```
+queue_distance = base_speed_m_per_s * N_exit / capacity
+composite = path_length * (1 + w_smoke * K_ave)
+          + w_fed * FED_max
+          + w_queue * queue_distance
+```
+
+where:
+
+- `N_exit` is the number of agents currently targeting that exit
+- `capacity` is the exit's `capacity_agents_per_s` (default 1.3)
+- `base_speed_m_per_s` converts queueing delay (seconds) into
+  distance-equivalent cost (metres) so all terms share the same
+  unit space
+
+The queue term is applied at route-level ranking (Phase 3) only,
+not in Dijkstra edge weights, because it is a per-exit constant
+that cannot change which path is selected to a given exit.
+
+Setting `w_queue = 0` disables congestion-aware routing entirely
+(backward compatible with existing behaviour).
+
+Exit capacity can be configured per exit in the scenario config:
+
+```json
+{
+  "exits": {
+    "exit_1": {
+      "capacity_agents_per_s": 2.5
+    }
+  }
+}
+```
+
+When not specified, the default from
+`RouteCostConfig.default_exit_capacity` (1.3 agents/s) is used.
+
+This approach is inspired by the game-theoretic exit selection
+model of Ehtamo et al. (2010), where each agent minimises
+estimated evacuation time (queueing + walking). The staggered
+reevaluation schedule provides natural convergence to Nash
+equilibrium without explicit iteration.
+```
+
+- [ ] **Step 2: Update `RouteCostConfig` example**
+
+In the Configuration section, update the example to include the new fields:
+
+```python
+config = RouteCostConfig(
+    w_smoke=1.0,                          # smoke cost weight
+    w_fed=10.0,                           # FED cost weight
+    w_queue=1.0,                          # queueing cost weight (0 disables)
+    fed_rejection_threshold=1.0,          # reject if FED_max exceeds
+    visibility_extinction_threshold=0.5,  # K threshold for visibility
+    sampling_step_m=2.0,                  # ray sample spacing
+    base_speed_m_per_s=1.3,               # clear-air walking speed
+    alpha=0.706,                          # speed-law coefficient
+    beta=-0.057,                          # speed-law coefficient
+    min_speed_factor=0.1,                 # speed factor floor
+    default_exit_capacity=1.3,            # fallback capacity (agents/s)
+)
+```
+
+- [ ] **Step 3: Update `RouteCost` data structure table**
+
+Add the new field to the `RouteCost` table:
+
+```markdown
+| `queue_time_s`     | `float`             | Estimated queueing time at exit |
+```
+
+- [ ] **Step 4: Add Ehtamo reference**
+
+In the References section at the bottom:
+
+```markdown
+- Ehtamo, H., Heliövaara, S., Korhonen, T. & Hostikka, S. (2010).
+  Game theoretic best-response dynamics for evacuees' exit selection.
+  *Advances in Complex Systems*, 13(1), 113–134.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/routing.md
+git commit -m "docs(routing): document congestion-aware routing"
+```
+
+---
+
+### Task 10: Lint and format
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run ruff lint**
+
+Run: `uv run ruff check pyfds_evac/core/route_graph.py pyfds_evac/core/scenario.py tests/test_route_graph.py`
+Expected: no errors.  If errors, fix them.
+
+- [ ] **Step 2: Run ruff format**
+
+Run: `uv run ruff format pyfds_evac/core/route_graph.py pyfds_evac/core/scenario.py tests/test_route_graph.py`
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `uv run python -m pytest tests/ -v`
+Expected: all pass
+
+- [ ] **Step 4: Commit if any formatting changes**
+
+```bash
+git add -u
+git commit -m "style: apply ruff format"
+```
+
+---
+
+## Summary of verification coverage
+
+| Spec verification | Task |
+|-------------------|------|
+| 1. Diamond graph — congestion shifts exit choice | Task 3: `TestRankRoutesWithCongestion::test_congestion_shifts_best_exit` |
+| 2. Backward compat — `w_queue=0` | Task 3: `TestQueueCostTerm::test_w_queue_zero_disables_queue` |
+| 3. Capacity effect | Task 3: `TestQueueCostTerm::test_custom_capacity_reduces_penalty` |
+| 4. Integration (smoke) | Validated by running demo scenario after all tasks |
+| 5. Integration (clear-air) | Validated by running demo scenario without smoke after Task 5 |
+| StageNode capacity | Task 1: `TestStageNodeCapacity` |
+| Node capacity overrides default | Task 3: `TestQueueCostTerm::test_node_capacity_overrides_default` |
+| Distance-equivalent conversion | Task 3: `TestQueueCostTerm::test_queue_cost_uses_distance_equivalent` |
+| evaluate_and_reroute congestion | Task 4: `TestEvaluateAndRerouteWithCongestion` |

--- a/specs/007-congestion-aware-routing/SPEC.md
+++ b/specs/007-congestion-aware-routing/SPEC.md
@@ -1,0 +1,210 @@
+# 007 — Congestion-aware routing
+
+## Problem
+
+pyFDS-Evac's route cost function considers path length, smoke
+extinction, and FED but has **no congestion term**.  All agents
+independently pick the cheapest Dijkstra path without considering
+how many others target the same exit.  If one exit has slightly less
+smoke than another, all agents may choose it, causing overcrowding
+at the "best" exit while leaving other exits unused.
+
+This is exactly the problem that Ehtamo et al. [1] solved for
+FDS+Evac with a game-theoretic best-response model, where agents
+minimise their *estimated evacuation time* — the sum of walking time
+and queueing time — and self-organise to balance load across exits.
+Their experiments show a ~29% reduction in total evacuation time
+compared to nearest-exit selection ([1] Fig. 6).
+
+## Goal
+
+Add a queueing cost term to pyFDS-Evac's composite route cost so
+agents avoid overcrowded exits.  The staggered per-agent
+reevaluation already provides a natural Round Robin Algorithm (RRA,
+[1] §4, Theorem 4.2), which Ehtamo et al. show converges to Nash
+equilibrium in ~3–4 rounds.  No explicit equilibrium iteration is
+needed.
+
+## Relationship to Ehtamo et al. [1]
+
+### What we adopt
+
+The core insight: each agent's cost function should include a
+**queueing delay** that depends on how many agents target the same
+exit.  In Ehtamo et al., the cost is ([1] Eq. 6):
+
+```
+T_i(e_k) = beta_k * lambda_i(e_k) + tau_i(e_k)
+```
+
+where `beta_k` is seconds-per-agent (inverse of exit capacity),
+`lambda_i` is the count of agents heading to exit `e_k` who are
+closer to it than agent `i`, and `tau_i` is walking time.
+
+We simplify `lambda_i` to `N_k` (total count of agents targeting
+exit `e_k`), because in our stage-graph model all agents at a given
+source node receive the same Dijkstra path — the "who is closer"
+distinction is less meaningful than in FDS+Evac's direct
+agent-to-exit model.
+
+Our queueing time estimate:
+
+```
+t_queue(e_k) = N_k / capacity_k
+```
+
+where `capacity_k` is agents-per-second (inverse of `beta_k`).
+
+### What we extend beyond [1]
+
+Ehtamo et al.'s cost function is `queueing + walking`.  Ours
+combines queueing with **continuous hazard terms**:
+
+```
+composite = path_length * (1 + w_smoke * K_ave)
+          + w_fed * FED_max
+          + w_queue * t_queue
+```
+
+This means agents balance three concerns simultaneously:
+1. How long is the path and how much smoke is on it?
+2. How much toxic gas will I accumulate?
+3. How congested is the exit?
+
+FDS+Evac's cost function does not include smoke or FED as
+continuous terms — fire conditions enter only through the binary
+preference-order filter.  Our model integrates both approaches.
+
+### What we do not adopt
+
+- **Distance-weighted agent count** (`lambda_i` vs `N_k`): we use
+  total count for simplicity.
+- **Preference ordering**: no familiarity/visibility group system.
+- **Agent types**: no conservative/active/herding/follower
+  distinction.
+- **Hawk-dove game**: not relevant to the congestion problem.
+- **Explicit NE iteration at init**: the staggered reevaluation
+  provides RRA convergence naturally.
+
+### Convergence argument
+
+Ehtamo et al. prove that the RRA converges to NE in at most N²
+iterations ([1] Theorem 4.2), and in practice ~3–4 rounds suffice
+([1] §6).  pyFDS-Evac's staggered reevaluation (one agent per tick,
+spread across the interval) is functionally equivalent to RRA: each
+agent updates its best response given the current choices of all
+others.  With typical reevaluation intervals of 10s and hundreds of
+agents, multiple "rounds" complete within the first minute of
+simulation.
+
+## Design
+
+### Cost function
+
+Per-edge Dijkstra weight (Phase 1 of `rank_routes`):
+
+```
+edge_cost = length_m * (1 + w_smoke * k_avg) + w_fed * fed_growth
+          + (w_queue * N_exit / capacity  if target is exit else 0)
+```
+
+The queueing term is added only on edges whose target is an exit
+node, so it appears once per route (at the terminal edge).
+
+Route-level composite cost (Phase 3):
+
+```
+composite = path_length * (1 + w_smoke * K_ave)
+          + w_fed * FED_max
+          + w_queue * N_exit / capacity
+```
+
+### Exit counts
+
+A `dict[str, int]` mapping exit stage IDs to the number of agents
+currently targeting each exit.  Maintained by the scenario loop:
+
+- **Increment** when an agent is first assigned an exit (initial) or
+  reroutes to a new exit.
+- **Decrement** when an agent reroutes away from an exit or is
+  removed (reaches exit / incapacitated).
+
+Passed as an optional parameter to `rank_routes` and
+`evaluate_and_reroute`.  When `None`, no queueing term is applied
+(backward compatible).
+
+### Exit capacity
+
+A new optional field `capacity_agents_per_s: float` on exit stage
+nodes in the scenario config:
+
+```json
+{
+  "id": "exit_1",
+  "stage_type": "exit",
+  "capacity_agents_per_s": 1.3
+}
+```
+
+Default: 1.3 agents/s (consistent with FDS+Evac's default specific
+flow of 1.3 p/m/s for a 1 m wide door, [1] §6 p130).
+
+Stored on `StageNode` as `Optional[float]`.  When `None`, falls
+back to the default from config.
+
+### Config additions
+
+`RouteCostConfig` gains:
+
+```python
+w_queue: float = 1.0               # queueing cost weight (0 disables)
+default_exit_capacity: float = 1.3  # fallback capacity (agents/s)
+```
+
+`w_queue = 0` disables congestion-aware routing entirely —
+identical to current behaviour.
+
+### Data structure additions
+
+`RouteCost` gains:
+
+```python
+queue_time_s: float  # estimated queueing time at the exit
+```
+
+## Files to modify
+
+| File | Changes |
+|------|---------|
+| `pyfds_evac/core/route_graph.py` | `RouteCostConfig` gains `w_queue`, `default_exit_capacity`; `StageNode` gains optional `capacity_agents_per_s`; `rank_routes` accepts optional `exit_counts` dict; edge cost adds queue term on exit edges; `evaluate_route` adds queue term to composite; `RouteCost` gains `queue_time_s` field; `evaluate_and_reroute` accepts and passes `exit_counts` |
+| `pyfds_evac/core/scenario.py` | Maintain `exit_counts: dict[str, int]`; update on initial assignment, reroute, agent removal; read `capacity_agents_per_s` from stage config JSON; pass `exit_counts` to routing calls |
+| `tests/test_route_graph.py` | Tests for queueing term effect, `w_queue=0` backward compat, capacity parameter, exit count updates |
+| `docs/routing.md` | Document queueing cost, config parameters, congestion behaviour |
+
+## What stays the same
+
+- Graph topology (nodes, edges, polylines)
+- Smoke/FED sampling along polylines
+- Dynamic Dijkstra with smoke/FED weights
+- Rejection logic (FED threshold, visibility filter)
+- Staggered reevaluation scheduling
+- `RouteSwitch` diagnostics and reasons
+
+## Verification
+
+1. **Unit tests**: Diamond graph with two exits — without queueing,
+   all agents pick the same (closer) exit; with queueing, agents
+   split across exits once one becomes congested.
+2. **Backward compat**: `w_queue=0` produces identical results to
+   current implementation.
+3. **Capacity effect**: higher capacity → less queueing penalty →
+   exit attracts more agents.
+4. **Integration**: demo scenario with `w_queue > 0` — confirm
+   agents distribute across exits in `route_cost_history.csv`.
+
+## References
+
+1. Ehtamo, H., Heliövaara, S., Korhonen, T. & Hostikka, S. (2010).
+   Game theoretic best-response dynamics for evacuees' exit selection.
+   *Advances in Complex Systems*, 13(1), 113–134.
+   DOI: 10.1142/S021952591000244X.

--- a/specs/007-congestion-aware-routing/SPEC.md
+++ b/specs/007-congestion-aware-routing/SPEC.md
@@ -134,6 +134,20 @@ one second of queueing is "worth".
 A `dict[str, int]` mapping exit stage IDs to the number of agents
 currently targeting each exit.
 
+**Source of truth**: `AgentRouteState.current_exit` is the single
+authoritative record of which exit an agent targets.  `exit_counts`
+is a derived aggregate — every mutation of `current_exit` must be
+accompanied by the corresponding increment/decrement of
+`exit_counts`.  CSV diagnostics (`route_cost_history`) read from
+the same `exit_counts` dict, so all three cannot drift.
+
+**Self-counting**: when an agent evaluates its *current* exit, the
+count `N_exit` **includes the agent itself**.  This is the simpler
+invariant (count always equals the number of agents with
+`current_exit == exit_id`) and avoids temporary decrement/re-increment
+around each evaluation.  The practical effect is that the first agent
+to target an empty exit sees `N = 1`, not `N = 0`.
+
 **Seeding**: agents leave `simulation_init` with an already-selected
 target path (determined by `direct_steering_info` and the initial
 `path_choices`).  `exit_counts` must be **seeded at startup** by
@@ -242,8 +256,12 @@ be confirmed from CSV output.
    current implementation.
 3. **Capacity effect**: higher capacity → less queueing penalty →
    exit attracts more agents.
-4. **Integration**: demo scenario with `w_queue > 0` — confirm
-   agents distribute across exits in `route_cost_history.csv`.
+4. **Integration (smoke)**: demo scenario with `w_queue > 0` —
+   confirm agents distribute across exits in `route_cost_history.csv`.
+5. **Integration (clear-air)**: scenario with no smoke field and
+   `w_queue > 0` — confirm rerouting still runs and agents
+   distribute across exits based on congestion alone.  This
+   validates the smoke-gate decoupling.
 
 ## References
 

--- a/specs/007-congestion-aware-routing/SPEC.md
+++ b/specs/007-congestion-aware-routing/SPEC.md
@@ -101,17 +101,17 @@ simulation.
 
 ### Cost function
 
-Per-edge Dijkstra weight (Phase 1 of `rank_routes`):
+Per-edge Dijkstra weight (Phase 1 of `rank_routes`) is unchanged —
+only segment-local terms:
 
 ```
 edge_cost = length_m * (1 + w_smoke * k_avg) + w_fed * fed_growth
-          + (w_queue * N_exit / capacity  if target is exit else 0)
 ```
 
-The queueing term is added only on edges whose target is an exit
-node, so it appears once per route (at the terminal edge).
-
-Route-level composite cost (Phase 3):
+The queueing term is a per-exit constant (same for all paths to a
+given exit), so it cannot change which *path* Dijkstra picks for
+that exit.  It is therefore applied only at the route-level ranking
+step (Phase 3), where it influences which *exit* is cheapest:
 
 ```
 composite = path_length * (1 + w_smoke * K_ave)
@@ -135,16 +135,20 @@ Passed as an optional parameter to `rank_routes` and
 
 ### Exit capacity
 
-A new optional field `capacity_agents_per_s: float` on exit stage
-nodes in the scenario config:
+A new optional field `capacity_agents_per_s: float` on each exit
+entry in the scenario config (`config["exits"][exit_id]`):
 
 ```json
 {
-  "id": "exit_1",
-  "stage_type": "exit",
-  "capacity_agents_per_s": 1.3
+  "exits": {
+    "exit_1": {
+      "capacity_agents_per_s": 1.3
+    }
+  }
 }
 ```
+
+Read during graph construction and propagated into `StageNode`.
 
 Default: 1.3 agents/s (consistent with FDS+Evac's default specific
 flow of 1.3 p/m/s for a 1 m wide door, [1] §6 p130).
@@ -176,8 +180,8 @@ queue_time_s: float  # estimated queueing time at the exit
 
 | File | Changes |
 |------|---------|
-| `pyfds_evac/core/route_graph.py` | `RouteCostConfig` gains `w_queue`, `default_exit_capacity`; `StageNode` gains optional `capacity_agents_per_s`; `rank_routes` accepts optional `exit_counts` dict; edge cost adds queue term on exit edges; `evaluate_route` adds queue term to composite; `RouteCost` gains `queue_time_s` field; `evaluate_and_reroute` accepts and passes `exit_counts` |
-| `pyfds_evac/core/scenario.py` | Maintain `exit_counts: dict[str, int]`; update on initial assignment, reroute, agent removal; read `capacity_agents_per_s` from stage config JSON; pass `exit_counts` to routing calls |
+| `pyfds_evac/core/route_graph.py` | `RouteCostConfig` gains `w_queue`, `default_exit_capacity`; `StageNode` gains optional `capacity_agents_per_s`; `rank_routes` accepts optional `exit_counts` dict; `evaluate_route` adds queue term to composite cost (Phase 3 only — not in Dijkstra edge weights); `RouteCost` gains `queue_time_s` field; `evaluate_and_reroute` accepts and passes `exit_counts` |
+| `pyfds_evac/core/scenario.py` | Maintain `exit_counts: dict[str, int]`; update on initial assignment, reroute, agent removal; read `capacity_agents_per_s` from exit entries under `Scenario.exits` and propagate into `direct_steering_info` / `StageNode` during graph construction; pass `exit_counts` to routing calls |
 | `tests/test_route_graph.py` | Tests for queueing term effect, `w_queue=0` backward compat, capacity parameter, exit count updates |
 | `docs/routing.md` | Document queueing cost, config parameters, congestion behaviour |
 

--- a/specs/007-congestion-aware-routing/SPEC.md
+++ b/specs/007-congestion-aware-routing/SPEC.md
@@ -63,8 +63,13 @@ combines queueing with **continuous hazard terms**:
 ```
 composite = path_length * (1 + w_smoke * K_ave)
           + w_fed * FED_max
-          + w_queue * t_queue
+          + w_queue * base_speed * t_queue
 ```
+
+The `base_speed * t_queue` term converts queueing delay (seconds)
+into distance-equivalent cost (metres) so all terms share the same
+unit space.  `base_speed` is `RouteCostConfig.base_speed_m_per_s`
+(default 1.3 m/s).
 
 This means agents balance three concerns simultaneously:
 1. How long is the path and how much smoke is on it?
@@ -114,17 +119,31 @@ that exit.  It is therefore applied only at the route-level ranking
 step (Phase 3), where it influences which *exit* is cheapest:
 
 ```
+queue_distance = base_speed_m_per_s * N_exit / capacity
 composite = path_length * (1 + w_smoke * K_ave)
           + w_fed * FED_max
-          + w_queue * N_exit / capacity
+          + w_queue * queue_distance
 ```
+
+All terms are in distance-equivalent units (metres), so `w_queue`
+has a stable physical meaning: how many metres of clear-air walking
+one second of queueing is "worth".
 
 ### Exit counts
 
 A `dict[str, int]` mapping exit stage IDs to the number of agents
-currently targeting each exit.  Maintained by the scenario loop:
+currently targeting each exit.
 
-- **Increment** when an agent is first assigned an exit (initial) or
+**Seeding**: agents leave `simulation_init` with an already-selected
+target path (determined by `direct_steering_info` and the initial
+`path_choices`).  `exit_counts` must be **seeded at startup** by
+scanning the initial assignments of all agents, so that the very
+first reevaluation tick sees accurate counts.  Flow-spawned agents
+must also be counted at spawn time (before their first reevaluation).
+
+**Maintenance** (scenario loop):
+
+- **Increment** when a flow-spawned agent appears or an agent
   reroutes to a new exit.
 - **Decrement** when an agent reroutes away from an exit or is
   removed (reaches exit / incapacitated).
@@ -180,10 +199,30 @@ queue_time_s: float  # estimated queueing time at the exit
 
 | File | Changes |
 |------|---------|
-| `pyfds_evac/core/route_graph.py` | `RouteCostConfig` gains `w_queue`, `default_exit_capacity`; `StageNode` gains optional `capacity_agents_per_s`; `rank_routes` accepts optional `exit_counts` dict; `evaluate_route` adds queue term to composite cost (Phase 3 only — not in Dijkstra edge weights); `RouteCost` gains `queue_time_s` field; `evaluate_and_reroute` accepts and passes `exit_counts` |
-| `pyfds_evac/core/scenario.py` | Maintain `exit_counts: dict[str, int]`; update on initial assignment, reroute, agent removal; read `capacity_agents_per_s` from exit entries under `Scenario.exits` and propagate into `direct_steering_info` / `StageNode` during graph construction; pass `exit_counts` to routing calls |
+| `pyfds_evac/core/route_graph.py` | `RouteCostConfig` gains `w_queue`, `default_exit_capacity`; `StageNode` gains optional `capacity_agents_per_s`; `rank_routes` accepts optional `exit_counts` dict; `evaluate_route` adds queue term to composite cost (Phase 3 only — not in Dijkstra edge weights) using `base_speed_m_per_s * N / capacity` for distance-equivalent conversion; `RouteCost` gains `queue_time_s` field; `evaluate_and_reroute` accepts and passes `exit_counts` |
+| `pyfds_evac/core/scenario.py` | Remove `smoke_speed_model is not None` guard from reroute loop; supply zero-extinction sampler when no smoke field configured; seed `exit_counts` from initial agent assignments at startup and on flow spawn; maintain counts on reroute and removal; read `capacity_agents_per_s` from exit entries under `Scenario.exits` and propagate into `direct_steering_info` / `StageNode` during graph construction; add `queue_time_s`, `exit_count`, `exit_capacity` to `route_cost_history` output; pass `exit_counts` to routing calls |
 | `tests/test_route_graph.py` | Tests for queueing term effect, `w_queue=0` backward compat, capacity parameter, exit count updates |
 | `docs/routing.md` | Document queueing cost, config parameters, congestion behaviour |
+
+### Decouple rerouting from smoke activation
+
+The current reroute loop in `scenario.py` (line 1486) is gated on
+`smoke_speed_model is not None`.  This means congestion-aware
+routing would silently not run in clear-air scenarios, making
+`w_queue > 0` a no-op.
+
+**Fix**: remove the `smoke_speed_model is not None` guard from
+the reroute-loop condition.  When no smoke field is configured,
+pass a **zero-extinction sampler** (a callable returning K = 0
+everywhere) to `rank_routes` / `evaluate_and_reroute`.  This lets
+the routing machinery run with neutral smoke cost while the queue
+term remains active.
+
+### Route cost history additions
+
+Add `queue_time_s`, `exit_count`, and `exit_capacity` columns to
+`route_cost_history.csv` so the integration verification (§ 4) can
+be confirmed from CSV output.
 
 ## What stays the same
 

--- a/specs/007-congestion-aware-routing/SPEC.md
+++ b/specs/007-congestion-aware-routing/SPEC.md
@@ -142,18 +142,26 @@ accompanied by the corresponding increment/decrement of
 the same `exit_counts` dict, so all three cannot drift.
 
 **Self-counting**: when an agent evaluates its *current* exit, the
-count `N_exit` **includes the agent itself**.  This is the simpler
-invariant (count always equals the number of agents with
-`current_exit == exit_id`) and avoids temporary decrement/re-increment
-around each evaluation.  The practical effect is that the first agent
-to target an empty exit sees `N = 1`, not `N = 0`.
+count `N_exit` **includes the agent itself**.  This is intentional:
+it keeps the invariant simple (count always equals the number of
+agents with `current_exit == exit_id`) and avoids temporary
+decrement/re-increment around each evaluation.  The practical effect
+is that the first agent to target an empty exit sees `N = 1`, not
+`N = 0` — a slight over-penalty for pioneers, accepted in favour of
+correctness and simplicity.
 
-**Seeding**: agents leave `simulation_init` with an already-selected
-target path (determined by `direct_steering_info` and the initial
-`path_choices`).  `exit_counts` must be **seeded at startup** by
-scanning the initial assignments of all agents, so that the very
-first reevaluation tick sees accurate counts.  Flow-spawned agents
-must also be counted at spawn time (before their first reevaluation).
+**Seeding at startup** (scenario.py, after `StageGraph.from_scenario`
+at line ~1004): scan `agent_wait_info` for all pre-existing agents.
+For each entry whose `mode == "path"`, extract the terminal stage
+from `path_choices` (or `current_target_stage` as fallback).  If
+that stage is an exit node in the graph, increment `exit_counts`.
+Also initialise an `AgentRouteState` with `current_exit` set to that
+exit so the source-of-truth invariant holds from the start.
+
+**Flow-spawn counting** (scenario.py, lines ~1268 and ~1314): when
+a flow-spawned agent is added to `agent_wait_info`, immediately
+resolve its terminal exit from the assigned path and increment
+`exit_counts` — before the agent's first reevaluation tick fires.
 
 **Maintenance** (scenario loop):
 
@@ -162,9 +170,10 @@ must also be counted at spawn time (before their first reevaluation).
 - **Decrement** when an agent reroutes away from an exit or is
   removed (reaches exit / incapacitated).
 
-Passed as an optional parameter to `rank_routes` and
-`evaluate_and_reroute`.  When `None`, no queueing term is applied
-(backward compatible).
+Passed as a **keyword-only** optional parameter to `rank_routes`
+and `evaluate_and_reroute` (avoids positional-arg confusion with
+the existing parameter list).  When `None`, no queueing term is
+applied (backward compatible).
 
 ### Exit capacity
 
@@ -181,13 +190,38 @@ entry in the scenario config (`config["exits"][exit_id]`):
 }
 ```
 
-Read during graph construction and propagated into `StageNode`.
+**`StageNode` change**: `StageNode` (route_graph.py:18) currently
+has four fields (`stage_id`, `centroid_x`, `centroid_y`,
+`stage_type`).  Add a new optional field:
+
+```python
+capacity_agents_per_s: float | None = None
+```
+
+**Construction**: in `StageGraph.from_scenario` (route_graph.py:102),
+where exit nodes are created from `direct_steering_info`, read
+`capacity_agents_per_s` from the info dict and pass it to the
+`StageNode` constructor:
+
+```python
+graph.nodes[stage_id] = StageNode(
+    stage_id=stage_id,
+    centroid_x=cx,
+    centroid_y=cy,
+    stage_type=stage_type,
+    capacity_agents_per_s=info.get("capacity_agents_per_s"),
+)
+```
+
+The scenario layer reads `capacity_agents_per_s` from
+`config["exits"][exit_id]` and injects it into
+`direct_steering_info[exit_id]` before graph construction.
 
 Default: 1.3 agents/s (consistent with FDS+Evac's default specific
 flow of 1.3 p/m/s for a 1 m wide door, [1] §6 p130).
 
-Stored on `StageNode` as `Optional[float]`.  When `None`, falls
-back to the default from config.
+When `StageNode.capacity_agents_per_s` is `None`, falls back to
+`RouteCostConfig.default_exit_capacity`.
 
 ### Config additions
 
@@ -227,16 +261,35 @@ routing would silently not run in clear-air scenarios, making
 
 **Fix**: remove the `smoke_speed_model is not None` guard from
 the reroute-loop condition.  When no smoke field is configured,
-pass a **zero-extinction sampler** (a callable returning K = 0
-everywhere) to `rank_routes` / `evaluate_and_reroute`.  This lets
-the routing machinery run with neutral smoke cost while the queue
-term remains active.
+pass a **zero-extinction sampler** to `rank_routes` /
+`evaluate_and_reroute`.  Concrete approach — a module-level
+constant lambda:
+
+```python
+_ZERO_EXTINCTION: Callable = lambda x, y: 0.0
+```
+
+In the reroute loop, replace `smoke_speed_model.field` with:
+
+```python
+extinction_sampler = (
+    smoke_speed_model.field if smoke_speed_model is not None
+    else _ZERO_EXTINCTION
+)
+```
+
+This lets the routing machinery run with neutral smoke cost while
+the queue term remains active.  All existing smoke-dependent code
+paths remain unchanged.
 
 ### Route cost history additions
 
 Add `queue_time_s`, `exit_count`, and `exit_capacity` columns to
 `route_cost_history.csv` so the integration verification (§ 4) can
-be confirmed from CSV output.
+be confirmed from CSV output.  New columns are appended at the end
+of the row; existing column order is preserved so downstream CSV
+consumers that read by position are unaffected for the original
+columns.
 
 ## What stays the same
 

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1190,3 +1190,46 @@ class TestFedRateAdapter:
         # travel_time = 10m / 1.3 m/s ≈ 7.69s; fed_growth = 0.1 * 7.69 / 60
         expected_growth = 0.1 * seg.travel_time_s / 60.0
         assert seg.fed_growth == pytest.approx(expected_growth, rel=0.01)
+
+
+class TestStageNodeCapacity:
+    def test_default_capacity_is_none(self):
+        from pyfds_evac.core.route_graph import StageNode
+
+        node = StageNode(
+            stage_id="E0",
+            centroid_x=0.0,
+            centroid_y=0.0,
+            stage_type="exit",
+        )
+        assert node.capacity_agents_per_s is None
+
+    def test_capacity_set_from_constructor(self):
+        from pyfds_evac.core.route_graph import StageNode
+
+        node = StageNode(
+            stage_id="E0",
+            centroid_x=0.0,
+            centroid_y=0.0,
+            stage_type="exit",
+            capacity_agents_per_s=2.5,
+        )
+        assert node.capacity_agents_per_s == 2.5
+
+    def test_capacity_propagated_from_scenario(self):
+        direct_steering_info = {
+            "E0": {
+                "polygon": _box(10, 0),
+                "stage_type": "exit",
+                "capacity_agents_per_s": 2.0,
+            },
+        }
+        distributions = {
+            "D0": {"coordinates": list(_box(0, 0).exterior.coords)},
+        }
+        transitions = [{"from": "D0", "to": "E0"}]
+        graph = StageGraph.from_scenario(
+            direct_steering_info, transitions, distributions
+        )
+        assert graph.nodes["E0"].capacity_agents_per_s == 2.0
+        assert graph.nodes["D0"].capacity_agents_per_s is None

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1233,3 +1233,23 @@ class TestStageNodeCapacity:
         )
         assert graph.nodes["E0"].capacity_agents_per_s == 2.0
         assert graph.nodes["D0"].capacity_agents_per_s is None
+
+
+class TestQueueConfigAndFields:
+    def test_route_cost_config_defaults(self):
+        config = RouteCostConfig()
+        assert config.w_queue == 1.0
+        assert config.default_exit_capacity == 1.3
+
+    def test_route_cost_config_queue_disabled(self):
+        config = RouteCostConfig(w_queue=0.0)
+        assert config.w_queue == 0.0
+
+    def test_route_cost_has_queue_time_field(self, linear_graph):
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig()
+        rc = evaluate_route(
+            linear_graph, ["D0", "C0", "E0"], 0.0, 0.0, field, None, config
+        )
+        assert hasattr(rc, "queue_time_s")
+        assert rc.queue_time_s == 0.0

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1423,3 +1423,83 @@ class TestRankRoutesWithCongestion:
         ranked = rank_routes(multi_exit_graph, "D0", 0.0, 0.0, field, None, config)
         assert ranked[0].exit_id == "E0"
         assert ranked[0].queue_time_s == 0.0
+
+
+class TestEvaluateAndRerouteWithCongestion:
+    def test_congestion_triggers_reroute(self, multi_exit_graph):
+        """Agent switches from congested E0 to uncongested E1."""
+        field = ConstantExtinctionField(0.0)
+        cost_config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+        config = RerouteConfig(reevaluation_interval_s=1.0, cost_config=cost_config)
+        wait_info = {
+            "mode": "path",
+            "current_origin": "D0",
+            "current_target_stage": "E0",
+            "path_choices": {"D0": [("E0", 100.0)]},
+            "stage_configs": {
+                "E0": {
+                    "polygon": _box(10, 0),
+                    "stage_type": "exit",
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 1.0,
+                    "enable_throughput_throttling": False,
+                    "max_throughput": 1.0,
+                    "speed_factor": 1.0,
+                },
+                "E1": {
+                    "polygon": _box(20, 0),
+                    "stage_type": "exit",
+                    "waiting_time": 0.0,
+                    "waiting_time_distribution": "constant",
+                    "waiting_time_std": 1.0,
+                    "enable_throughput_throttling": False,
+                    "max_throughput": 1.0,
+                    "speed_factor": 1.0,
+                },
+            },
+            "state": "to_target",
+        }
+        route_state = AgentRouteState(current_exit="E0", eval_offset_s=0.0)
+        switch = evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=multi_exit_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+            exit_counts={"E0": 50, "E1": 0},
+        )
+        assert switch is not None
+        assert switch.new_exit == "E1"
+        assert switch.old_exit == "E0"
+
+    def test_no_exit_counts_backward_compatible(self, multi_exit_graph):
+        """Without exit_counts, behaviour is identical to current."""
+        field = ConstantExtinctionField(0.0)
+        config = RerouteConfig(reevaluation_interval_s=1.0)
+        wait_info = {
+            "mode": "path",
+            "current_origin": "D0",
+            "current_target_stage": "E0",
+            "path_choices": {"D0": [("E0", 100.0)]},
+            "stage_configs": {},
+            "state": "to_target",
+        }
+        route_state = AgentRouteState(eval_offset_s=0.0)
+        switch = evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=multi_exit_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+        )
+        assert switch is not None
+        assert switch.new_exit == "E0"

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1253,3 +1253,173 @@ class TestQueueConfigAndFields:
         )
         assert hasattr(rc, "queue_time_s")
         assert rc.queue_time_s == 0.0
+
+
+class TestQueueCostTerm:
+    def test_evaluate_route_adds_queue_cost(self, multi_exit_graph):
+        """Queue term increases composite cost for a congested exit."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+        rc_no_queue = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+        )
+        rc_with_queue = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": 20, "E1": 0},
+        )
+        assert rc_with_queue.composite_cost > rc_no_queue.composite_cost
+        assert rc_with_queue.queue_time_s > 0.0
+        assert rc_no_queue.queue_time_s == 0.0
+
+    def test_queue_cost_uses_distance_equivalent(self, multi_exit_graph):
+        """Queue cost = w_queue * base_speed * N / capacity."""
+        field = ConstantExtinctionField(0.0)
+        base_speed = 1.3
+        capacity = 1.3
+        n_agents = 10
+        config = RouteCostConfig(
+            w_smoke=0.0,
+            w_fed=0.0,
+            w_queue=1.0,
+            base_speed_m_per_s=base_speed,
+            default_exit_capacity=capacity,
+        )
+        rc = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": n_agents},
+        )
+        expected_queue_time = n_agents / capacity
+        expected_queue_distance = base_speed * expected_queue_time
+        assert abs(rc.queue_time_s - expected_queue_time) < 1e-6
+        assert (
+            abs(rc.composite_cost - (rc.path_length_m + expected_queue_distance)) < 0.1
+        )
+
+    def test_w_queue_zero_disables_queue(self, multi_exit_graph):
+        """w_queue=0 means exit_counts have no effect."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=0.0)
+        rc_no_counts = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+        )
+        rc_with_counts = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": 100},
+        )
+        assert abs(rc_no_counts.composite_cost - rc_with_counts.composite_cost) < 1e-9
+
+    def test_custom_capacity_reduces_penalty(self, multi_exit_graph):
+        """Higher capacity -> lower queue penalty for same agent count."""
+        field = ConstantExtinctionField(0.0)
+        config_low = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=1.0
+        )
+        config_high = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=5.0
+        )
+        counts = {"E0": 20}
+        rc_low = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config_low,
+            exit_counts=counts,
+        )
+        rc_high = evaluate_route(
+            multi_exit_graph,
+            ["D0", "E0"],
+            0.0,
+            0.0,
+            field,
+            None,
+            config_high,
+            exit_counts=counts,
+        )
+        assert rc_low.composite_cost > rc_high.composite_cost
+
+    def test_node_capacity_overrides_default(self):
+        """StageNode.capacity_agents_per_s overrides config default."""
+        from pyfds_evac.core.route_graph import StageGraph
+
+        direct_steering_info = {
+            "E0": {
+                "polygon": _box(10, 0),
+                "stage_type": "exit",
+                "capacity_agents_per_s": 10.0,
+            },
+        }
+        distributions = {"D0": {"coordinates": list(_box(0, 0).exterior.coords)}}
+        transitions = [{"from": "D0", "to": "E0"}]
+        graph = StageGraph.from_scenario(
+            direct_steering_info, transitions, distributions
+        )
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(
+            w_smoke=0.0, w_fed=0.0, w_queue=1.0, default_exit_capacity=1.0
+        )
+        rc = evaluate_route(
+            graph, ["D0", "E0"], 0.0, 0.0, field, None, config, exit_counts={"E0": 10}
+        )
+        # capacity=10 -> queue_time = 10/10 = 1.0s
+        assert abs(rc.queue_time_s - 1.0) < 1e-6
+
+
+class TestRankRoutesWithCongestion:
+    def test_congestion_shifts_best_exit(self, multi_exit_graph):
+        """With enough agents at E0, E1 becomes cheaper despite being farther."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(w_smoke=0.0, w_fed=0.0, w_queue=1.0)
+        ranked_no_q = rank_routes(multi_exit_graph, "D0", 0.0, 0.0, field, None, config)
+        assert ranked_no_q[0].exit_id == "E0"
+        ranked_q = rank_routes(
+            multi_exit_graph,
+            "D0",
+            0.0,
+            0.0,
+            field,
+            None,
+            config,
+            exit_counts={"E0": 50, "E1": 0},
+        )
+        assert ranked_q[0].exit_id == "E1"
+
+    def test_rank_routes_without_exit_counts_unchanged(self, multi_exit_graph):
+        """Omitting exit_counts gives identical results to current behaviour."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig()
+        ranked = rank_routes(multi_exit_graph, "D0", 0.0, 0.0, field, None, config)
+        assert ranked[0].exit_id == "E0"
+        assert ranked[0].queue_time_s == 0.0


### PR DESCRIPTION
## Summary

- Adds design spec for congestion-aware routing, introducing a queueing cost term to the route cost function
- Inspired by Ehtamo et al. (2010) game-theoretic best-response model for exit selection in FDS+Evac
- Agents will balance smoke/FED hazard avoidance with exit congestion, distributing across exits rather than all choosing the smoke-optimal path
- The existing staggered per-agent reevaluation naturally provides Round Robin Algorithm convergence to Nash equilibrium (~3-4 rounds per Ehtamo et al.)

### Key design decisions

- **Additive queueing term**: `composite += w_queue * N_exit / capacity` (w_queue=0 disables, backward compatible)
- **Per-exit total agent count** (not distance-weighted) for simplicity
- **Per-exit `capacity_agents_per_s`** config field (default 1.3, matching FDS+Evac)
- **No explicit NE iteration** — staggered reevaluation is functionally equivalent to RRA

### Comparison to FDS+Evac

Documents what we adopt (queueing delay, RRA convergence), what we extend (continuous smoke/FED in cost — FDS+Evac lacks this), and what we don't adopt (preference ordering, agent types, hawk-dove game).

## Test plan

- [ ] Review spec for completeness and correctness
- [ ] Confirm design decisions align with project goals
- [ ] Proceed to implementation plan after approval