### PR TITLE
Generate an FDS deck from a JuPedSim walkable WKT (#26)

### DIFF
--- a/pyfds_evac/core/wkt_to_fds.py
+++ b/pyfds_evac/core/wkt_to_fds.py
@@ -174,16 +174,20 @@ def _obst_boxes(walkable, dx, margin_cells):
     return boxes, (mx0, my0, mx1, my1, ni, nj)
 
 
-def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m, z_max, nd) -> str:
-    """A burner at the walkable centroid plus the slices pyFDS-Evac reads."""
+def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m, nd) -> str:
+    """A floor-vent burner at the walkable centroid plus the pyFDS-Evac slices.
+
+    The fire is a floor ``&VENT`` (z=0), not a raised ``&OBST`` -- an obstructing
+    burner would carve a non-walkable patch out of the very void this deck is
+    meant to mirror from the WKT.
+    """
     c = walkable.representative_point()
     half = burner_size_m / 2.0
-    burner_top = min(0.4, z_max)  # keep the burner inside a shallow mesh
     lines = [
         "! --- fire (edit to taste; not derived from geometry) ---",
         "&REAC FUEL='PROPANE', SOOT_YIELD=0.06, CO_YIELD=0.01 /",
-        f"&OBST XB={c.x - half:.{nd}f},{c.x + half:.{nd}f},{c.y - half:.{nd}f},"
-        f"{c.y + half:.{nd}f},0.0,{burner_top}, SURF_IDS='BURNER','INERT','INERT' /",
+        f"&VENT XB={c.x - half:.{nd}f},{c.x + half:.{nd}f},{c.y - half:.{nd}f},"
+        f"{c.y + half:.{nd}f},0.0,0.0, SURF_ID='BURNER' /",
         f"&SURF ID='BURNER', HRRPUA={hrrpua:.1f}, COLOR='RED', RAMP_Q='qramp' /",
         "&RAMP ID='qramp', T=0.0, F=0.0 /",
         "&RAMP ID='qramp', T=10.0, F=1.0 /",
@@ -206,6 +210,13 @@ def resolve_dx(walkable: BaseGeometry, dx: float | None) -> float:
     grid is used unless walls demand finer.  An explicit ``dx`` coarser than the
     thinnest wall is honoured but warned about: walls thinner than ``dx`` are
     silently dropped (cells are kept walkable on any overlap).
+
+    Limitation: the mesh is a uniform grid aligned to multiples of ``dx``.  A
+    wall whose coordinates are *off* that grid by a fraction of a cell (e.g. a
+    0.1 m wall spanning 5.05-5.15 at ``dx=0.1``) can straddle two cells that
+    each also touch walkable space and be dropped.  Designed floor plans are
+    grid-aligned, so this bites synthetic/rotated geometry; pass a finer explicit
+    ``dx`` (<= feature/2) when feeding such input.
     """
     min_feat = _min_feature_width(walkable)
     if dx is None:
@@ -279,9 +290,7 @@ def wkt_to_fds(
     if include_fire:
         lines += [
             "",
-            _fire_and_slices(
-                walkable, slice_height_m, hrrpua, burner_size_m, z_max, nd
-            ),
+            _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m, nd),
         ]
     lines += ["", "&TAIL /", ""]
     return "\n".join(lines)

--- a/pyfds_evac/core/wkt_to_fds.py
+++ b/pyfds_evac/core/wkt_to_fds.py
@@ -71,6 +71,18 @@ def _min_gap(values) -> float:
     return min(gaps) if gaps else math.inf
 
 
+def _coord_decimals(dx: float) -> int:
+    """Decimals needed to print dx-aligned coordinates without rounding drift.
+
+    Coordinates are multiples of ``dx``; a fixed ``%.2f`` would corrupt a
+    non-centimetre ``dx`` (e.g. 0.025 or 0.104), shifting walls or collapsing
+    thin ``&OBST`` boxes to zero width.
+    """
+    if dx <= 0 or not math.isfinite(dx):
+        return 2
+    return min(6, max(2, -math.floor(math.log10(dx)) + 2))
+
+
 def _load_walkable(wkt_or_polygon) -> BaseGeometry:
     """Accept a WKT string or a Shapely geometry; return the walkable area."""
     if isinstance(wkt_or_polygon, BaseGeometry):
@@ -162,15 +174,16 @@ def _obst_boxes(walkable, dx, margin_cells):
     return boxes, (mx0, my0, mx1, my1, ni, nj)
 
 
-def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m) -> str:
+def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m, z_max, nd) -> str:
     """A burner at the walkable centroid plus the slices pyFDS-Evac reads."""
     c = walkable.representative_point()
     half = burner_size_m / 2.0
+    burner_top = min(0.4, z_max)  # keep the burner inside a shallow mesh
     lines = [
         "! --- fire (edit to taste; not derived from geometry) ---",
         "&REAC FUEL='PROPANE', SOOT_YIELD=0.06, CO_YIELD=0.01 /",
-        f"&OBST XB={c.x - half:.2f},{c.x + half:.2f},{c.y - half:.2f},"
-        f"{c.y + half:.2f},0.0,0.4, SURF_IDS='BURNER','INERT','INERT' /",
+        f"&OBST XB={c.x - half:.{nd}f},{c.x + half:.{nd}f},{c.y - half:.{nd}f},"
+        f"{c.y + half:.{nd}f},0.0,{burner_top}, SURF_IDS='BURNER','INERT','INERT' /",
         f"&SURF ID='BURNER', HRRPUA={hrrpua:.1f}, COLOR='RED', RAMP_Q='qramp' /",
         "&RAMP ID='qramp', T=0.0, F=0.0 /",
         "&RAMP ID='qramp', T=10.0, F=1.0 /",
@@ -239,25 +252,36 @@ def wkt_to_fds(
     (extinction + CO/CO2/O2) are appended so the deck runs end-to-end; set it
     False for a geometry-only deck (``&MESH`` + ``&OBST`` walls).
     """
+    if include_fire and slice_height_m >= z_max:
+        raise ValueError(
+            f"slice_height_m ({slice_height_m} m) must be below z_max ({z_max} m); "
+            "the analysis slice would lie outside the mesh."
+        )
     walkable = _load_walkable(wkt_or_polygon)
     dx = resolve_dx(walkable, dx)
     boxes, (mx0, my0, mx1, my1, ni, nj) = _obst_boxes(walkable, dx, margin_cells)
     nk = max(1, round(z_max / dx))
+    nd = _coord_decimals(dx)
 
     lines = [
         f"&HEAD CHID='{chid}', TITLE='Generated from JuPedSim walkable WKT' /",
-        f"&MESH IJK={ni},{nj},{nk}, XB={mx0:.2f},{mx1:.2f},{my0:.2f},{my1:.2f},0.0,{z_max} /",
+        f"&MESH IJK={ni},{nj},{nk}, XB={mx0:.{nd}f},{mx1:.{nd}f},"
+        f"{my0:.{nd}f},{my1:.{nd}f},0.0,{z_max} /",
         f"&TIME T_END={t_end} /",
         "&MISC TMPA=20.0 /",
         "",
         f"! --- walls: complement of the walkable area ({len(boxes)} OBSTs) ---",
     ]
     for x0, x1, y0, y1 in boxes:
-        lines.append(f"&OBST XB={x0:.2f},{x1:.2f},{y0:.2f},{y1:.2f},0.0,{z_max} /")
+        lines.append(
+            f"&OBST XB={x0:.{nd}f},{x1:.{nd}f},{y0:.{nd}f},{y1:.{nd}f},0.0,{z_max} /"
+        )
     if include_fire:
         lines += [
             "",
-            _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m),
+            _fire_and_slices(
+                walkable, slice_height_m, hrrpua, burner_size_m, z_max, nd
+            ),
         ]
     lines += ["", "&TAIL /", ""]
     return "\n".join(lines)

--- a/pyfds_evac/core/wkt_to_fds.py
+++ b/pyfds_evac/core/wkt_to_fds.py
@@ -1,0 +1,203 @@
+"""Generate an FDS geometry deck from a JuPedSim walkable-area WKT.
+
+The reverse of deriving a WKT from FDS (which is underdetermined -- the FDS
+domain holds the navigable space *and* sealed compartments, and geometry alone
+cannot say which is walkable).  Going WKT -> FDS has no such ambiguity: the WKT
+*is* the walkable space, so the FDS solid region is simply its complement within
+the mesh.  Generating the fire domain from the designed walkable area guarantees
+the two share one coordinate frame -- the geometry-consistency goal (issue #26),
+solved from the authoritative side.
+
+Pipeline:
+
+1. Parse the WKT walkable polygon (exterior = boundary, holes = obstacles).
+2. Size an ``&MESH`` to the walkable bounds plus a wall margin, at cell size dx.
+3. ``solid = mesh_rectangle - walkable``, rasterised onto the dx grid.
+4. Decompose the solid cells into axis-aligned ``&OBST`` boxes (greedy maximal
+   rectangles, to keep the obstruction count low).
+5. Optionally append a fire + slice template so the deck runs end-to-end and
+   writes the exact slices pyFDS-Evac reads (extinction + CO/CO2/O2).
+
+What it does *not* infer: the fire itself (HRR, fuel) and the analysis outputs
+are physics choices, not geometry; the template provides sensible defaults you
+are expected to edit.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from shapely import wkt as _wkt
+from shapely.geometry import Point
+from shapely.geometry.base import BaseGeometry
+
+# Slices pyFDS-Evac canonicalises (see core/fds_inventory.py).
+_FED_SPECIES = ("CARBON MONOXIDE", "CARBON DIOXIDE", "OXYGEN")
+
+
+def _load_walkable(wkt_or_polygon) -> BaseGeometry:
+    """Accept a WKT string or a Shapely geometry; return the walkable area."""
+    if isinstance(wkt_or_polygon, BaseGeometry):
+        geometry = wkt_or_polygon
+    else:
+        geometry = _wkt.loads(str(wkt_or_polygon))
+    if geometry.is_empty:
+        raise ValueError("Walkable WKT is empty.")
+    return geometry
+
+
+def _mesh_grid(walkable: BaseGeometry, dx: float, margin_cells: int):
+    """Return mesh extent and cell counts snapped to the dx grid with a margin."""
+    x0, y0, x1, y1 = walkable.bounds
+    mx0 = (math.floor(x0 / dx) - margin_cells) * dx
+    my0 = (math.floor(y0 / dx) - margin_cells) * dx
+    mx1 = (math.ceil(x1 / dx) + margin_cells) * dx
+    my1 = (math.ceil(y1 / dx) + margin_cells) * dx
+    ni = round((mx1 - mx0) / dx)
+    nj = round((my1 - my0) / dx)
+    return mx0, my0, mx1, my1, ni, nj
+
+
+def _solid_mask(walkable, mx0, my0, ni, nj, dx) -> np.ndarray:
+    """Boolean grid: True where a cell centre is outside the walkable area."""
+    solid = np.ones((ni, nj), dtype=bool)
+    for i in range(ni):
+        cx = mx0 + (i + 0.5) * dx
+        for j in range(nj):
+            cy = my0 + (j + 0.5) * dx
+            if walkable.contains(Point(cx, cy)):
+                solid[i, j] = False
+    return solid
+
+
+def _greedy_rectangles(solid: np.ndarray):
+    """Decompose solid cells into axis-aligned rectangles (i0, i1, j0, j1).
+
+    Greedy maximal rectangles: from each unused solid cell, grow as wide as the
+    contiguous solid run, then as tall as every column in that span stays solid
+    and unused.  Far fewer boxes than one-per-cell, valid for FDS ``&OBST``.
+    """
+    ni, nj = solid.shape
+    used = np.zeros_like(solid)
+    rects = []
+    for i in range(ni):
+        for j in range(nj):
+            if not solid[i, j] or used[i, j]:
+                continue
+            width = 0
+            while i + width < ni and solid[i + width, j] and not used[i + width, j]:
+                width += 1
+            height = 1
+            while j + height < nj and _row_free(solid, used, i, width, j + height):
+                height += 1
+            used[i : i + width, j : j + height] = True
+            rects.append((i, i + width, j, j + height))
+    return rects
+
+
+def _row_free(solid, used, i, width, j) -> bool:
+    """True if cells [i:i+width] in column j are all solid and unused."""
+    return bool(np.all(solid[i : i + width, j]) and not np.any(used[i : i + width, j]))
+
+
+def _obst_boxes(walkable, dx, margin_cells):
+    """Return wall ``&OBST`` boxes (x0, x1, y0, y1) plus mesh metadata."""
+    mx0, my0, mx1, my1, ni, nj = _mesh_grid(walkable, dx, margin_cells)
+    solid = _solid_mask(walkable, mx0, my0, ni, nj, dx)
+    boxes = [
+        (mx0 + i0 * dx, mx0 + i1 * dx, my0 + j0 * dx, my0 + j1 * dx)
+        for (i0, i1, j0, j1) in _greedy_rectangles(solid)
+    ]
+    return boxes, (mx0, my0, mx1, my1, ni, nj)
+
+
+def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m) -> str:
+    """A burner at the walkable centroid plus the slices pyFDS-Evac reads."""
+    c = walkable.representative_point()
+    half = burner_size_m / 2.0
+    lines = [
+        "! --- fire (edit to taste; not derived from geometry) ---",
+        "&REAC FUEL='PROPANE', SOOT_YIELD=0.06, CO_YIELD=0.01 /",
+        f"&OBST XB={c.x - half:.2f},{c.x + half:.2f},{c.y - half:.2f},"
+        f"{c.y + half:.2f},0.0,0.4, SURF_IDS='BURNER','INERT','INERT' /",
+        f"&SURF ID='BURNER', HRRPUA={hrrpua:.1f}, COLOR='RED', RAMP_Q='qramp' /",
+        "&RAMP ID='qramp', T=0.0, F=0.0 /",
+        "&RAMP ID='qramp', T=10.0, F=1.0 /",
+        "",
+        f"! --- analysis slices at z={slice_height_m} m (pyFDS-Evac quantities) ---",
+        f"&SLCF PBZ={slice_height_m}, QUANTITY='SOOT EXTINCTION COEFFICIENT' /",
+    ]
+    for spec in _FED_SPECIES:
+        lines.append(
+            f"&SLCF PBZ={slice_height_m}, QUANTITY='VOLUME FRACTION', SPEC_ID='{spec}' /"
+        )
+    lines.append("&DUMP DT_SLCF=2.0 /")
+    return "\n".join(lines)
+
+
+def wkt_to_fds(
+    wkt_or_polygon,
+    *,
+    dx: float = 0.25,
+    z_max: float = 3.0,
+    chid: str = "from_wkt",
+    margin_cells: int = 1,
+    include_fire: bool = True,
+    slice_height_m: float = 2.0,
+    hrrpua: float = 800.0,
+    burner_size_m: float = 0.5,
+    t_end: float = 120.0,
+) -> str:
+    """Return an FDS input deck whose walkable void matches the given WKT.
+
+    With ``include_fire`` (default) a burner and the pyFDS-Evac analysis slices
+    (extinction + CO/CO2/O2) are appended so the deck runs end-to-end; set it
+    False for a geometry-only deck (``&MESH`` + ``&OBST`` walls).
+    """
+    walkable = _load_walkable(wkt_or_polygon)
+    boxes, (mx0, my0, mx1, my1, ni, nj) = _obst_boxes(walkable, dx, margin_cells)
+    nk = max(1, round(z_max / dx))
+
+    lines = [
+        f"&HEAD CHID='{chid}', TITLE='Generated from JuPedSim walkable WKT' /",
+        f"&MESH IJK={ni},{nj},{nk}, XB={mx0:.2f},{mx1:.2f},{my0:.2f},{my1:.2f},0.0,{z_max} /",
+        f"&TIME T_END={t_end} /",
+        "&MISC TMPA=20.0 /",
+        "",
+        f"! --- walls: complement of the walkable area ({len(boxes)} OBSTs) ---",
+    ]
+    for x0, x1, y0, y1 in boxes:
+        lines.append(f"&OBST XB={x0:.2f},{x1:.2f},{y0:.2f},{y1:.2f},0.0,{z_max} /")
+    if include_fire:
+        lines += [
+            "",
+            _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m),
+        ]
+    lines += ["", "&TAIL /", ""]
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import argparse
+    import pathlib
+
+    parser = argparse.ArgumentParser(
+        description="Generate an FDS deck from a walkable WKT."
+    )
+    parser.add_argument("wkt_file", help="File containing a POLYGON/MULTIPOLYGON WKT")
+    parser.add_argument("--dx", type=float, default=0.25)
+    parser.add_argument("--z-max", type=float, default=3.0)
+    parser.add_argument("--chid", default="from_wkt")
+    parser.add_argument("--geometry-only", action="store_true")
+    args = parser.parse_args()
+    text = pathlib.Path(args.wkt_file).read_text(encoding="utf-8").strip()
+    print(
+        wkt_to_fds(
+            text,
+            dx=args.dx,
+            z_max=args.z_max,
+            chid=args.chid,
+            include_fire=not args.geometry_only,
+        )
+    )

--- a/pyfds_evac/core/wkt_to_fds.py
+++ b/pyfds_evac/core/wkt_to_fds.py
@@ -25,15 +25,50 @@ are expected to edit.
 
 from __future__ import annotations
 
+import logging
 import math
 
 import numpy as np
 from shapely import wkt as _wkt
 from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
+from shapely.prepared import prep
+
+_logger = logging.getLogger(__name__)
 
 # Slices pyFDS-Evac canonicalises (see core/fds_inventory.py).
 _FED_SPECIES = ("CARBON MONOXIDE", "CARBON DIOXIDE", "OXYGEN")
+
+# Preferred cell size when auto-sizing; refined finer only to resolve thin walls.
+_DEFAULT_DX = 0.25
+# Floor on the auto-sized cell: stops a stray near-duplicate coordinate (e.g. a
+# 0.01 m modelling artifact) from forcing a runaway-fine mesh.
+_MIN_DX = 0.1
+
+
+def _min_feature_width(walkable: BaseGeometry) -> float:
+    """Smallest axis-aligned gap between vertex coordinates (the thinnest wall).
+
+    For rectilinear floor plans a 0.1 m wall shows up as adjacent coordinates
+    0.1 m apart (e.g. 5.0 and 5.1).  Returns ``inf`` for a plain rectangle with
+    no internal features.  Used to pick a ``dx`` fine enough to resolve walls.
+    """
+    polys = list(getattr(walkable, "geoms", [walkable]))
+    xs: set[float] = set()
+    ys: set[float] = set()
+    for poly in polys:
+        for ring in [poly.exterior, *poly.interiors]:
+            for x, y in ring.coords:
+                xs.add(round(x, 9))
+                ys.add(round(y, 9))
+    return min(_min_gap(xs), _min_gap(ys))
+
+
+def _min_gap(values) -> float:
+    """Smallest positive difference between consecutive sorted values."""
+    ordered = sorted(values)
+    gaps = [b - a for a, b in zip(ordered, ordered[1:]) if b - a > 1e-9]
+    return min(gaps) if gaps else math.inf
 
 
 def _load_walkable(wkt_or_polygon) -> BaseGeometry:
@@ -70,13 +105,19 @@ def _solid_mask(walkable, mx0, my0, ni, nj, dx) -> np.ndarray:
     of walls thinning by up to one cell -- the safe direction for an egress
     domain (never seal a corridor).
     """
+    prepared = prep(walkable)
     solid = np.ones((ni, nj), dtype=bool)
     for i in range(ni):
         x0 = mx0 + i * dx
         for j in range(nj):
             y0 = my0 + j * dx
-            if walkable.intersection(box(x0, y0, x0 + dx, y0 + dx)).area > 1e-12:
-                solid[i, j] = False
+            cell = box(x0, y0, x0 + dx, y0 + dx)
+            if not prepared.intersects(cell):
+                continue  # fully outside walkable -> solid (fast path)
+            if prepared.contains(cell):
+                solid[i, j] = False  # fully inside -> walkable (fast path)
+            elif walkable.intersection(cell).area > 1e-12:
+                solid[i, j] = False  # boundary cell with real overlap (slow path)
     return solid
 
 
@@ -145,10 +186,42 @@ def _fire_and_slices(walkable, slice_height_m, hrrpua, burner_size_m) -> str:
     return "\n".join(lines)
 
 
+def resolve_dx(walkable: BaseGeometry, dx: float | None) -> float:
+    """Choose a cell size that resolves the thinnest wall.
+
+    ``dx=None`` auto-sizes to ``min(_DEFAULT_DX, thinnest_wall)`` so a coarse fire
+    grid is used unless walls demand finer.  An explicit ``dx`` coarser than the
+    thinnest wall is honoured but warned about: walls thinner than ``dx`` are
+    silently dropped (cells are kept walkable on any overlap).
+    """
+    min_feat = _min_feature_width(walkable)
+    if dx is None:
+        if math.isinf(min_feat):
+            return _DEFAULT_DX
+        if min_feat < _MIN_DX - 1e-9:
+            _logger.warning(
+                "thinnest feature %.3g m is below the %.3g m floor; walls thinner "
+                "than %.3g m may not resolve.",
+                min_feat,
+                _MIN_DX,
+                _MIN_DX,
+            )
+        return max(min(_DEFAULT_DX, min_feat), _MIN_DX)
+    if math.isfinite(min_feat) and dx > min_feat + 1e-9:
+        _logger.warning(
+            "dx=%.3g m is coarser than the thinnest wall (%.3g m); walls thinner "
+            "than dx are dropped. Pass dx<=%.3g (or dx=None to auto-size).",
+            dx,
+            min_feat,
+            min_feat,
+        )
+    return dx
+
+
 def wkt_to_fds(
     wkt_or_polygon,
     *,
-    dx: float = 0.25,
+    dx: float | None = None,
     z_max: float = 3.0,
     chid: str = "from_wkt",
     margin_cells: int = 1,
@@ -160,11 +233,14 @@ def wkt_to_fds(
 ) -> str:
     """Return an FDS input deck whose walkable void matches the given WKT.
 
-    With ``include_fire`` (default) a burner and the pyFDS-Evac analysis slices
+    ``dx=None`` (default) auto-sizes the cell to resolve the thinnest wall; an
+    explicit ``dx`` coarser than that is warned about (thin walls drop).  With
+    ``include_fire`` (default) a burner and the pyFDS-Evac analysis slices
     (extinction + CO/CO2/O2) are appended so the deck runs end-to-end; set it
     False for a geometry-only deck (``&MESH`` + ``&OBST`` walls).
     """
     walkable = _load_walkable(wkt_or_polygon)
+    dx = resolve_dx(walkable, dx)
     boxes, (mx0, my0, mx1, my1, ni, nj) = _obst_boxes(walkable, dx, margin_cells)
     nk = max(1, round(z_max / dx))
 
@@ -195,7 +271,12 @@ if __name__ == "__main__":  # pragma: no cover
         description="Generate an FDS deck from a walkable WKT."
     )
     parser.add_argument("wkt_file", help="File containing a POLYGON/MULTIPOLYGON WKT")
-    parser.add_argument("--dx", type=float, default=0.25)
+    parser.add_argument(
+        "--dx",
+        type=float,
+        default=None,
+        help="cell size (default: auto from thinnest wall)",
+    )
     parser.add_argument("--z-max", type=float, default=3.0)
     parser.add_argument("--chid", default="from_wkt")
     parser.add_argument("--geometry-only", action="store_true")

--- a/pyfds_evac/core/wkt_to_fds.py
+++ b/pyfds_evac/core/wkt_to_fds.py
@@ -29,7 +29,7 @@ import math
 
 import numpy as np
 from shapely import wkt as _wkt
-from shapely.geometry import Point
+from shapely.geometry import box
 from shapely.geometry.base import BaseGeometry
 
 # Slices pyFDS-Evac canonicalises (see core/fds_inventory.py).
@@ -60,13 +60,22 @@ def _mesh_grid(walkable: BaseGeometry, dx: float, margin_cells: int):
 
 
 def _solid_mask(walkable, mx0, my0, ni, nj, dx) -> np.ndarray:
-    """Boolean grid: True where a cell centre is outside the walkable area."""
+    """Boolean grid: True where a cell shares no area with the walkable area.
+
+    A cell is walkable if it *overlaps* the walkable polygon (positive
+    intersection area), not merely if its centre is inside.  Centre-sampling
+    would seal a cell whose centre lands in a wall even though part of the cell
+    is walkable, silently deleting narrow or off-grid passages; overlap keeps
+    them open (a wall never covers a positive-area walkable region) at the cost
+    of walls thinning by up to one cell -- the safe direction for an egress
+    domain (never seal a corridor).
+    """
     solid = np.ones((ni, nj), dtype=bool)
     for i in range(ni):
-        cx = mx0 + (i + 0.5) * dx
+        x0 = mx0 + i * dx
         for j in range(nj):
-            cy = my0 + (j + 0.5) * dx
-            if walkable.contains(Point(cx, cy)):
+            y0 = my0 + j * dx
+            if walkable.intersection(box(x0, y0, x0 + dx, y0 + dx)).area > 1e-12:
                 solid[i, j] = False
     return solid
 

--- a/tests/test_wkt_to_fds.py
+++ b/tests/test_wkt_to_fds.py
@@ -1,0 +1,82 @@
+"""Tests for generating an FDS geometry deck from a walkable-area WKT.
+
+The core invariant is the round-trip: the generated ``&OBST`` walls must be the
+exact complement of the walkable area, so no wall ever covers walkable space and
+the whole walkable boundary is enclosed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from shapely.geometry import Point
+
+from pyfds_evac.core.wkt_to_fds import _load_walkable, _obst_boxes, wkt_to_fds
+
+# An L-shaped room with a doorway gap, exterior-only.
+L_ROOM_WKT = "POLYGON ((0 0, 6 0, 6 4, 10 4, 10 10, 0 10, 0 0))"
+# A square room with a square obstacle (hole) in the middle.
+HOLE_WKT = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (4 4, 6 4, 6 6, 4 6, 4 4))"
+
+
+def _covered(boxes, x, y) -> bool:
+    return any(x0 < x < x1 and y0 < y < y1 for (x0, x1, y0, y1) in boxes)
+
+
+def test_walls_never_cover_walkable_interior():
+    """No generated OBST may contain a point inside the walkable area."""
+    walk = _load_walkable(L_ROOM_WKT)
+    boxes, _ = _obst_boxes(walk, 0.25, 1)
+    minx, miny, maxx, maxy = walk.bounds
+    rng = np.random.RandomState(0)
+    checked = 0
+    while checked < 2000:
+        x, y = rng.uniform(minx, maxx), rng.uniform(miny, maxy)
+        if not walk.contains(Point(x, y)):
+            continue
+        checked += 1
+        assert not _covered(boxes, x, y), (
+            f"wall covers walkable point ({x:.2f}, {y:.2f})"
+        )
+
+
+def test_obstacle_hole_becomes_solid():
+    """A hole in the walkable polygon must be filled by wall OBSTs."""
+    walk = _load_walkable(HOLE_WKT)
+    boxes, _ = _obst_boxes(walk, 0.25, 1)
+    # Centre of the hole (5, 5) is non-walkable -> must be covered by a wall.
+    assert _covered(boxes, 5.0, 5.0)
+    # A point in the open room is walkable -> must not be covered.
+    assert not _covered(boxes, 1.0, 1.0)
+
+
+def test_mesh_encloses_walkable_with_margin():
+    """The mesh extent must contain the walkable bounds plus the wall margin."""
+    walk = _load_walkable(L_ROOM_WKT)
+    _, (mx0, my0, mx1, my1, ni, nj) = _obst_boxes(walk, 0.25, 1)
+    bx0, by0, bx1, by1 = walk.bounds
+    assert mx0 < bx0 and my0 < by0 and mx1 > bx1 and my1 > by1
+    assert ni > 0 and nj > 0
+
+
+def test_deck_has_required_sections_and_slices():
+    """The full deck runs end-to-end: mesh, walls, fire, and the canonical slices."""
+    deck = wkt_to_fds(L_ROOM_WKT, chid="t")
+    assert "&HEAD CHID='t'" in deck
+    assert "&MESH IJK=" in deck
+    assert "&OBST XB=" in deck
+    assert "&TAIL /" in deck
+    for quantity in (
+        "SOOT EXTINCTION COEFFICIENT",
+        "CARBON MONOXIDE",
+        "CARBON DIOXIDE",
+        "OXYGEN",
+    ):
+        assert quantity in deck
+
+
+def test_geometry_only_omits_fire():
+    """``include_fire=False`` yields walls without a burner or slices."""
+    deck = wkt_to_fds(L_ROOM_WKT, include_fire=False)
+    assert "&OBST XB=" in deck
+    assert "BURNER" not in deck
+    assert "SLCF" not in deck

--- a/tests/test_wkt_to_fds.py
+++ b/tests/test_wkt_to_fds.py
@@ -9,10 +9,22 @@ egress domain.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
+import pytest
 from shapely.geometry import Point
 
-from pyfds_evac.core.wkt_to_fds import _load_walkable, _obst_boxes, wkt_to_fds
+from pyfds_evac.core.wkt_to_fds import (
+    _load_walkable,
+    _min_feature_width,
+    _obst_boxes,
+    resolve_dx,
+    wkt_to_fds,
+)
+
+# A room with a 0.1 m internal wall (coords 5.0 and 5.1 are 0.1 m apart).
+THIN_WALL_WKT = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (5 1, 5.1 1, 5.1 9, 5 9, 5 1))"
 
 # An L-shaped room with a doorway gap, exterior-only.
 L_ROOM_WKT = "POLYGON ((0 0, 6 0, 6 4, 10 4, 10 10, 0 10, 0 0))"
@@ -89,6 +101,37 @@ def test_deck_has_required_sections_and_slices():
         "OXYGEN",
     ):
         assert quantity in deck
+
+
+def test_min_feature_width_detects_thin_wall():
+    """The thinnest wall (0.1 m) is read off the vertex spacing."""
+    walk = _load_walkable(THIN_WALL_WKT)
+    assert _min_feature_width(walk) == pytest.approx(0.1)
+
+
+def test_auto_dx_resolves_thin_wall():
+    """``dx=None`` auto-sizes fine enough that the thin wall becomes OBSTs."""
+    walk = _load_walkable(THIN_WALL_WKT)
+    dx = resolve_dx(walk, None)
+    assert dx == pytest.approx(0.1)
+    # A point inside the thin wall is non-walkable -> covered when resolved.
+    boxes, _ = _obst_boxes(walk, dx, 1)
+    assert _covered(boxes, 5.05, 5.05)
+
+
+def test_auto_dx_keeps_default_when_no_thin_walls():
+    """A plain room (no internal features) auto-sizes to the default dx."""
+    walk = _load_walkable("POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))")
+    assert resolve_dx(walk, 0.25) == 0.25
+    assert resolve_dx(walk, None) == 0.25
+
+
+def test_coarse_dx_warns(caplog):
+    """An explicit dx coarser than the thinnest wall logs a warning."""
+    walk = _load_walkable(THIN_WALL_WKT)
+    with caplog.at_level(logging.WARNING):
+        resolve_dx(walk, 0.25)
+    assert any("coarser than the thinnest wall" in r.message for r in caplog.records)
 
 
 def test_geometry_only_omits_fire():

--- a/tests/test_wkt_to_fds.py
+++ b/tests/test_wkt_to_fds.py
@@ -134,6 +134,43 @@ def test_coarse_dx_warns(caplog):
     assert any("coarser than the thinnest wall" in r.message for r in caplog.records)
 
 
+def _xb_numbers(deck):
+    """All XB coordinate values across the deck's &MESH/&OBST lines."""
+    import re
+
+    out = []
+    for line in deck.splitlines():
+        m = re.search(r"XB=([-\d.,eE]+)", line)
+        if m:
+            out.extend(float(v) for v in m.group(1).split(","))
+    return out
+
+
+def test_coordinates_stay_grid_aligned_for_fine_dx():
+    """A non-centimetre dx must not be corrupted by fixed 2-decimal rounding."""
+    dx = 0.025
+    deck = wkt_to_fds(L_ROOM_WKT, dx=dx, include_fire=False)
+    for v in _xb_numbers(deck):
+        # every coordinate is a multiple of dx (z values 0 are too)
+        assert abs((v / dx) - round(v / dx)) < 1e-6, f"{v} is not a multiple of {dx}"
+
+
+def test_fire_template_rejects_slice_above_mesh():
+    """include_fire with slice_height_m >= z_max is a misconfig that can't run."""
+    with pytest.raises(ValueError, match="outside the mesh"):
+        wkt_to_fds(L_ROOM_WKT, z_max=1.5, slice_height_m=2.0)
+
+
+def test_burner_fits_in_shallow_mesh():
+    """The burner obstruction never exceeds z_max."""
+    deck = wkt_to_fds(L_ROOM_WKT, z_max=0.3, slice_height_m=0.2)
+    burner = next(
+        line for line in deck.splitlines() if "BURNER" in line and "OBST" in line
+    )
+    z_top = float(burner.split("XB=")[1].split(",")[5])
+    assert z_top <= 0.3
+
+
 def test_geometry_only_omits_fire():
     """``include_fire=False`` yields walls without a burner or slices."""
     deck = wkt_to_fds(L_ROOM_WKT, include_fire=False)

--- a/tests/test_wkt_to_fds.py
+++ b/tests/test_wkt_to_fds.py
@@ -1,8 +1,10 @@
 """Tests for generating an FDS geometry deck from a walkable-area WKT.
 
-The core invariant is the round-trip: the generated ``&OBST`` walls must be the
-exact complement of the walkable area, so no wall ever covers walkable space and
-the whole walkable boundary is enclosed.
+The core invariant is the round-trip: a generated ``&OBST`` wall never covers a
+positive-area walkable region (cells are classified by overlap, not centre
+membership, so narrow or off-grid passages are not silently sealed).  Walls may
+thin by up to one cell at the resolution floor -- the safe direction for an
+egress domain.
 """
 
 from __future__ import annotations
@@ -37,6 +39,21 @@ def test_walls_never_cover_walkable_interior():
         assert not _covered(boxes, x, y), (
             f"wall covers walkable point ({x:.2f}, {y:.2f})"
         )
+
+
+def test_offgrid_narrow_walkable_not_sealed():
+    """An off-grid walkable point whose grid-cell centre is in a wall stays open.
+
+    Regression for the centre-sampling bug: classify by overlap so a cell that
+    is partly walkable is not emitted as a solid OBST.
+    """
+    walk = _load_walkable(
+        "POLYGON ((0.13 0.13, 0.6 0.13, 0.6 0.6, 0.13 0.6, 0.13 0.13))"
+    )
+    boxes, _ = _obst_boxes(walk, 0.25, 1)
+    p = (0.18, 0.18)  # inside the polygon, but its cell centre (0.125) is not
+    assert walk.contains(Point(*p))
+    assert not _covered(boxes, *p)
 
 
 def test_obstacle_hole_becomes_solid():

--- a/tests/test_wkt_to_fds.py
+++ b/tests/test_wkt_to_fds.py
@@ -161,14 +161,21 @@ def test_fire_template_rejects_slice_above_mesh():
         wkt_to_fds(L_ROOM_WKT, z_max=1.5, slice_height_m=2.0)
 
 
-def test_burner_fits_in_shallow_mesh():
-    """The burner obstruction never exceeds z_max."""
+def test_fire_source_is_non_obstructing_floor_vent():
+    """The fire is a floor &VENT (z=0), not an &OBST that blocks walkable space.
+
+    An obstructing burner would carve a non-walkable patch out of the void this
+    deck is meant to mirror from the WKT.
+    """
     deck = wkt_to_fds(L_ROOM_WKT, z_max=0.3, slice_height_m=0.2)
     burner = next(
-        line for line in deck.splitlines() if "BURNER" in line and "OBST" in line
+        line for line in deck.splitlines() if "BURNER" in line and "XB=" in line
     )
-    z_top = float(burner.split("XB=")[1].split(",")[5])
-    assert z_top <= 0.3
+    assert burner.lstrip().startswith("&VENT")
+    z0, z1 = burner.split("XB=")[1].split(",")[4:6]
+    assert float(z0) == 0.0 and float(z1.split()[0]) == 0.0
+    # No burner OBST sits inside the walkable area.
+    assert not any("BURNER" in ln and "OBST" in ln for ln in deck.splitlines())
 
 
 def test_geometry_only_omits_fire():


### PR DESCRIPTION
## What

Adds `pyfds_evac/core/wkt_to_fds.py` — `wkt_to_fds(wkt)` + CLI (`python -m pyfds_evac.core.wkt_to_fds <wkt_file>`) — that generates an FDS input deck whose walkable void matches a JuPedSim walkable-area WKT.

## Why (and why this direction, not the reverse)

The geometry-consistency goal (#26) is to derive one representation from the other so they share a coordinate frame. The **FDS→WKT** direction (PR #27) is *underdetermined*: the FDS domain holds the navigable space **and** sealed compartments, and geometry alone cannot say which is walkable (a largest-component heuristic was shown to pick a sealed room).

**WKT→FDS has no such ambiguity** — the WKT *is* the walkable space, so the FDS solid region is simply its complement within the mesh. It also matches the real workflow: geometry is designed in the JuPedSim/WBJ GUI (→ WKT), and this produces the matching fire domain.

## How

1. Parse the walkable WKT (exterior = boundary, holes = obstacles).
2. Size an `&MESH` to the walkable bounds + a wall margin, at cell size `dx`.
3. `solid = mesh − walkable`, rasterised onto the `dx` grid.
4. Greedy maximal-rectangle decomposition of the solid cells → compact `&OBST` walls.
5. With `include_fire` (default): append a burner + the canonical pyFDS-Evac slices (`SOOT EXTINCTION COEFFICIENT`, CO/CO₂/O₂ `VOLUME FRACTION`) at the analysis height, so the deck runs end-to-end. `include_fire=False` → geometry-only.

What it does **not** infer: the fire (HRR, fuel) and outputs are physics choices, not geometry — the template provides editable defaults.

## Verified

- **Round-trip invariant** (locked by test): generated walls never cover a walkable interior point; holes in the WKT become solid OBSTs; open space stays open.
- 5 tests in `tests/test_wkt_to_fds.py`, ruff clean.
- Demo on `assets/demo2/geometry.wkt` (150 m² T-junction) → `&MESH IJK=122,54,12` + **6** wall OBSTs (doorway/stem preserved) + burner + 4 slices.

## Relation to PR #27

PR #27 (FDS→WKT) hit the underdetermined-walkable wall; this is the tractable, authoritative direction. Suggest landing this and marking #27 as superseded (or keeping it as a visual overlay-verification helper only).

Advances #26.