### PR TITLE
fix(fed): O2 hypoxia rate 60x too slow + multi-name slice lookup

### DIFF
--- a/pyfds_evac/core/fds_sampling.py
+++ b/pyfds_evac/core/fds_sampling.py
@@ -75,7 +75,7 @@ class SliceFieldSampler:
 
 def load_slice_sampler(
     fds_dir: str,
-    quantity: str,
+    quantity: str | tuple[str, ...] | list[str],
     *,
     simulation=None,
     slice_height_m: float | None = None,
@@ -84,6 +84,11 @@ def load_slice_sampler(
 
     Parameters
     ----------
+    quantity :
+        The FDS slice quantity name, or a sequence of candidate names tried
+        in order (the first that matches wins).  A sequence lets callers cope
+        with decks that spell the same field differently, e.g.
+        ``("SOOT EXTINCTION COEFFICIENT", "EXTINCTION")``.
     simulation : optional
         A pre-loaded ``fdsreader.Simulation`` instance.  When provided the
         expensive directory parse is skipped.
@@ -92,7 +97,7 @@ def load_slice_sampler(
         whose z-extent is closest to this value is selected.
 
     Raises ModuleNotFoundError if fdsreader is not installed, or
-    IndexError if the requested quantity is not found in the FDS case.
+    IndexError if none of the requested quantities are found in the FDS case.
     """
     if simulation is not None:
         sim = simulation
@@ -100,9 +105,15 @@ def load_slice_sampler(
         if Simulation is None:
             raise ModuleNotFoundError("fdsreader is required to load FDS slice data.")
         sim = Simulation(str(fds_dir))
-    matches = sim.slices.filter_by_quantity(quantity)
+    candidates = (quantity,) if isinstance(quantity, str) else tuple(quantity)
+    matches = []
+    for name in candidates:
+        matches = sim.slices.filter_by_quantity(name)
+        if matches:
+            break
     if not matches:
-        raise IndexError(f"No slice with quantity '{quantity}' found in {fds_dir}")
+        tried = ", ".join(f"'{c}'" for c in candidates)
+        raise IndexError(f"No slice with quantity {tried} found in {fds_dir}")
     if slice_height_m is not None and len(matches) > 1:
         best = min(
             matches,

--- a/pyfds_evac/core/fed.py
+++ b/pyfds_evac/core/fed.py
@@ -79,6 +79,9 @@ misleading accumulation under safe ambient conditions.
 def _o2_hypoxia_rate_per_minute(o2_percent: float) -> float:
     """Return the O2 hypoxia FED contribution in 1/min from guide Eq. 18.
 
+    t_incap [min] = exp(8.13 - 0.54 * (20.9 - C_O2%))   (Purser / FDS Tech Ref)
+    rate [1/min]  = 1 / t_incap
+
     Returns 0 when O2 is at or above ``_O2_HYPOXIA_THRESHOLD_PERCENT``
     (default 19.5 %) to prevent spurious accumulation under safe ambient
     conditions.
@@ -88,10 +91,10 @@ def _o2_hypoxia_rate_per_minute(o2_percent: float) -> float:
         o2_percent = 20.9
     if float(o2_percent) >= _O2_HYPOXIA_THRESHOLD_PERCENT:
         return 0.0
-    denominator = 60.0 * math.exp(8.13 - 0.54 * (20.9 - float(o2_percent)))
-    if denominator <= 0.0:
+    t_incap_min = math.exp(8.13 - 0.54 * (20.9 - float(o2_percent)))
+    if t_incap_min <= 0.0:
         return 0.0
-    return 1.0 / denominator
+    return 1.0 / t_incap_min
 
 
 def _cn_fed_rate_per_minute(hcn_ppm: float, no2_ppm: float) -> float:

--- a/pyfds_evac/core/smoke_speed.py
+++ b/pyfds_evac/core/smoke_speed.py
@@ -119,7 +119,7 @@ class ExtinctionField:
         """Load extinction slices from an FDS case directory via fdsreader."""
         sampler = load_slice_sampler(
             fds_dir,
-            "SOOT EXTINCTION COEFFICIENT",
+            ("SOOT EXTINCTION COEFFICIENT", "EXTINCTION"),
             simulation=simulation,
             slice_height_m=slice_height_m,
         )

--- a/tests/test_fed.py
+++ b/tests/test_fed.py
@@ -276,7 +276,7 @@ class TestO2HypoxiaRate:
 
     def test_low_o2(self):
         rate = _o2_hypoxia_rate_per_minute(12.0)
-        expected = 1.0 / (60.0 * math.exp(8.13 - 0.54 * (20.9 - 12.0)))
+        expected = 1.0 / math.exp(8.13 - 0.54 * (20.9 - 12.0))
         assert rate == pytest.approx(expected, rel=1e-10)
 
 
@@ -301,7 +301,7 @@ class TestFullFormulaClosedForm:
         nox_rate = (30.0 + 10.0) / 1500.0
         fld_irr = 200.0 / 114000.0 + 50.0 / 12000.0 + 10.0 / 1900.0
         hv = math.exp(0.1903 * 3.0 + 2.0004) / 7.1
-        o2_rate = 1.0 / (60.0 * math.exp(8.13 - 0.54 * (20.9 - 15.0)))
+        o2_rate = 1.0 / math.exp(8.13 - 0.54 * (20.9 - 15.0))
         expected = (co_rate + cn_rate + nox_rate + fld_irr) * hv + o2_rate
 
         assert default_fed_rate_per_minute(inputs) == pytest.approx(expected, rel=1e-10)
@@ -316,7 +316,7 @@ class TestFullFormulaClosedForm:
         co_ppm = _co_percent_to_ppm(0.10)
         co_rate = 2.764e-5 * (co_ppm**1.036)
         hv = math.exp(0.1903 * 2.0 + 2.0004) / 7.1
-        o2_rate = 1.0 / (60.0 * math.exp(8.13 - 0.54 * (20.9 - 18.0)))
+        o2_rate = 1.0 / math.exp(8.13 - 0.54 * (20.9 - 18.0))
         expected = co_rate * hv + o2_rate
 
         assert default_fed_rate_per_minute(inputs) == pytest.approx(expected, rel=1e-10)
@@ -514,7 +514,7 @@ def test_fds_evac_guide_stationary_fed_cases_reach_fed_one_consistently(
         )
     elif expected_dominant_term == "o2":
         assert analytic_time_s < time_to_fed_threshold_s(DefaultFedInputs())
-        assert analytic_time_s > 10000.0
+        assert analytic_time_s > 1000.0
     elif expected_dominant_term == "co":
         assert analytic_time_s > 1000.0
     elif expected_dominant_term == "co2_hv":


### PR DESCRIPTION
## Summary
Two small, self-contained FED-model fixes salvaged from #29 (`gregory/smokerender`), lifted out of that PR's ~65k-line diff so the real bug can land immediately without pulling in the webapp re-theme, Smokeview exporter, or the familiarity work.

## Fixes
- **O2 hypoxia rate was 60x too slow.** `_o2_hypoxia_rate_per_minute` (`pyfds_evac/core/fed.py`) divided by an extra factor of 60, turning the guide's per-minute incapacitation rate (Eq. 18, `t_incap [min] = exp(8.13 - 0.54*(20.9 - C_O2%))`) into a per-hour rate before accumulating on a per-minute clock. Below the 19.5% O2 suppression threshold this understated incapacitation risk by 60x — a true ~2.6 s incapacitation was reported as ~155 s. `tests/test_fed.py` expected values updated to the corrected formula.
- **Multi-name slice lookup.** `load_slice_sampler` (`pyfds_evac/core/fds_sampling.py`) now accepts a tuple/list of candidate quantity names and returns the first that matches; `ExtinctionField` passes `("SOOT EXTINCTION COEFFICIENT", "EXTINCTION")`, so decks that spell the soot-extinction slice either way load instead of raising `IndexError`. Backward compatible (a plain `str` still works).

## Testing
- `pytest tests/test_fed.py` — 61 passed
- `pytest -k "smoke or sampl or extinct"` — 49 passed
- `ruff format --check` + `ruff check` clean on all changed files

## Notes
Does not touch the familiarity/cognitive-map work or the Smokeview exporter — those stay in #29/#30 pending a clean rebase. Refs #32.
