### PR TITLE
feat(webapp): FDS smoke overlay in the trajectory viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ web GUI exposes the same model behind a form: pick a scenario, set any
 `run.py` flag (the `fds dir` field has a folder browser), run it, watch
 live progress, and explore the results as interactive
 [Plotly](https://plotly.com/python/) charts (trajectories coloured by
-exit, cumulative FED, smoke, and route cost).
+exit, cumulative FED, smoke, and route cost). When a run is given an
+`fds dir`, the canvas trajectory animation overlays the FDS soot
+extinction slice as a smoke layer beneath the agents (clipped to the
+walkable area, with an on/off toggle).
 
 Install the optional GUI dependencies and launch:
 

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -345,7 +345,13 @@ async def post(request: Request):
         def post_run(result):
             return cli.apply_outputs(result, scenario, opts, log=lambda _m: None)
 
-        manager.start(scenario, run_kwargs, scenario_name, post_run=post_run)
+        manager.start(
+            scenario,
+            run_kwargs,
+            scenario_name,
+            post_run=post_run,
+            fds_dir=getattr(opts, "fds_dir", None),
+        )
     except Exception as exc:
         return Alert(f"{type(exc).__name__}: {exc}", cls=AlertT.error)
 
@@ -427,7 +433,7 @@ def _finished_view() -> Div:
 
     return Div(
         summary,
-        trajviz.trajectory_component(result, scenario),
+        trajviz.trajectory_component(result, scenario, fds_dir=manager.fds_dir),
         plot_card("Cumulative FED", plots.fed_figure(result), "fig-fed"),
         plot_card("Smoke", plots.smoke_figure(result), "fig-smoke"),
         plot_card("Route cost", plots.route_cost_figure(result), "fig-route"),

--- a/pyfds_evac/webapp/runner.py
+++ b/pyfds_evac/webapp/runner.py
@@ -62,6 +62,7 @@ class RunManager:
         self.result: Optional[ScenarioResult] = None
         self.error: Optional[str] = None
         self.scenario_name: Optional[str] = None
+        self.fds_dir: Optional[str] = None
         self.artifacts: List[str] = []
         self.last_event: Optional[ProgressEvent] = None
         self.log_lines: List[str] = []
@@ -76,6 +77,7 @@ class RunManager:
         run_kwargs: Dict[str, Any],
         scenario_name: str,
         post_run: Optional[Callable[[ScenarioResult], List[str]]] = None,
+        fds_dir: Optional[str] = None,
     ) -> None:
         """Start a run on a background thread. Raises if one is already active.
 
@@ -90,6 +92,7 @@ class RunManager:
         self.result = None
         self.error = None
         self.scenario_name = scenario_name
+        self.fds_dir = fds_dir
         self.artifacts = []
         self.last_event = None
         self.log_lines = []

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -260,7 +260,7 @@ _JS = """
     smCtx = smCanvas.getContext('2d');
   }
   function drawSmoke(fi, p) {
-    if (!SM || !showSmoke || !smBytes) return;
+    if (!SM || !showSmoke || !smBytes || !smCtx) return;
     var W = SM.W, H = SM.H, off = fi * W * H, kmax = SM.kmax;
     var id = smCtx.createImageData(W, H);
     var d = id.data;

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -8,6 +8,7 @@ small payload. Geometry (walkable area, exits) is drawn once per frame.
 
 from __future__ import annotations
 
+import base64
 import bisect
 import json
 from pathlib import Path
@@ -20,6 +21,97 @@ from .plots import _PALETTE, _agent_exit_map
 # Number of position samples sent to the browser; the JS interpolates between
 # them, so this stays small while playback stays smooth.
 _N_SAMPLES = 120
+
+# Extinction-slice quantity names, in preference order. FDS names the soot
+# extinction coefficient differently across cases ("SOOT EXTINCTION
+# COEFFICIENT" in newer decks, bare "EXTINCTION" in older ones). This mirrors
+# load_slice_sampler's multi-name lookup, but _smoke_payload samples the raw
+# grid via to_global() rather than a SliceFieldSampler, so it filters inline.
+_EXTINCTION_QUANTITIES = ("SOOT EXTINCTION COEFFICIENT", "EXTINCTION")
+
+# Largest grid dimension shipped to the browser. The FDS slice is downsampled
+# to at most this many cells on its long axis; canvas image-smoothing blurs the
+# result so a coarse grid still looks like a continuous smoke field.
+_SMOKE_MAX_CELLS = 70
+
+
+def _smoke_payload(
+    fds_dir: str | None,
+    times: list[float],
+    slice_height_m: float = 2.0,
+    simulation: Any = None,
+) -> dict | None:
+    """Sample the FDS extinction slice onto a coarse grid for each render time.
+
+    Returns a dict with the grid dimensions, world extent, per-frame extinction
+    packed as base64 uint8 (scaled to ``kmax``), and ``kmax`` itself — or
+    ``None`` when no FDS directory / extinction slice is available. Any failure
+    is swallowed so the trajectory viewer never breaks on smoke rendering.
+
+    ``simulation`` accepts a pre-loaded ``fdsreader.Simulation`` (used by tests
+    to inject a fake slice); when ``None`` the directory is parsed from disk.
+    """
+    if simulation is None and (not fds_dir or not Path(fds_dir).exists()):
+        return None
+    try:
+        import numpy as np
+
+        if simulation is not None:
+            sim = simulation
+        else:
+            from fdsreader import Simulation
+
+            sim = Simulation(str(fds_dir))
+        matches: list = []
+        for quantity in _EXTINCTION_QUANTITIES:
+            matches = list(sim.slices.filter_by_quantity(quantity))
+            if matches:
+                break
+        if not matches:
+            return None
+
+        # Horizontal slice nearest the sampling height (agents' breathing zone).
+        def _zmid(s: Any) -> float:
+            return (s.extent.z_start + s.extent.z_end) / 2.0
+
+        sl = min(matches, key=lambda s: abs(_zmid(s) - slice_height_m))
+        grid, coords = sl.to_global(masked=True, return_coordinates=True)
+        grid = np.nan_to_num(np.asarray(grid, dtype=float), nan=0.0)  # (T, X, Y)
+        slice_times = np.asarray(sl.times, dtype=float)
+        xs = np.asarray(coords["x"], dtype=float)
+        ys = np.asarray(coords["y"], dtype=float)
+        if grid.ndim != 3 or xs.size < 2 or ys.size < 2:
+            return None
+
+        n_x, n_y = grid.shape[1], grid.shape[2]
+        step = max(1, int(np.ceil(max(n_x, n_y) / _SMOKE_MAX_CELLS)))
+        grid = grid[:, ::step, ::step]
+        xs = xs[::step]
+        ys = ys[::step]
+        w, h = grid.shape[1], grid.shape[2]
+
+        kmax = float(grid.max())
+        if kmax <= 0.0:
+            kmax = 1.0  # uniform-clear field: keep a valid scale, layer is blank
+
+        # One uint8 frame per render time, using the nearest FDS timestep.
+        # Bytes are row-major over (x, y): index = ix * h + iy.
+        buf = bytearray()
+        for t in times:
+            ti = int(np.argmin(np.abs(slice_times - float(t))))
+            frame = grid[ti]
+            u8 = np.clip(frame / kmax * 255.0, 0, 255).astype(np.uint8)
+            buf += u8.tobytes()
+
+        return {
+            "W": int(w),
+            "H": int(h),
+            "ext": [float(xs[0]), float(ys[0]), float(xs[-1]), float(ys[-1])],
+            "kmax": kmax,
+            "b64": base64.b64encode(bytes(buf)).decode("ascii"),
+        }
+    except Exception:
+        return None
 
 
 def _bounds(walkable, data) -> list[float]:
@@ -35,7 +127,7 @@ def _bounds(walkable, data) -> list[float]:
         ]
 
 
-def _payload(result: Any, scenario: Any) -> dict | None:
+def _payload(result: Any, scenario: Any, fds_dir: str | None = None) -> dict | None:
     if not result.sqlite_file or not Path(result.sqlite_file).exists():
         return None
 
@@ -134,6 +226,7 @@ def _payload(result: Any, scenario: Any) -> dict | None:
         "walk": walk,
         "exits": exits,
         "bounds": _bounds(walkable, data),
+        "smoke": _smoke_payload(fds_dir, times),
     }
 
 
@@ -152,6 +245,56 @@ _JS = """
   var simT = t0, playing = false, lastTs = null;
   var bx = D.bounds, pad = 0.06;
   var mode = D.hasFed ? 'fed' : 'exit';
+
+  // Smoke field: decode base64 uint8 frames into an offscreen canvas we can
+  // scale onto the main canvas under the agents. Each frame is W*H bytes,
+  // row-major over (x, y): byte at ix*H + iy holds K scaled to 0..255 of kmax.
+  var SM = D.smoke, smBytes = null, smCanvas = null, smCtx = null;
+  var showSmoke = !!SM;
+  if (SM) {
+    var raw = atob(SM.b64);
+    smBytes = new Uint8Array(raw.length);
+    for (var si = 0; si < raw.length; si++) smBytes[si] = raw.charCodeAt(si);
+    smCanvas = document.createElement('canvas');
+    smCanvas.width = SM.W; smCanvas.height = SM.H;
+    smCtx = smCanvas.getContext('2d');
+  }
+  function drawSmoke(fi, p) {
+    if (!SM || !showSmoke || !smBytes) return;
+    var W = SM.W, H = SM.H, off = fi * W * H, kmax = SM.kmax;
+    var id = smCtx.createImageData(W, H);
+    var d = id.data;
+    for (var ix = 0; ix < W; ix++) {
+      for (var iy = 0; iy < H; iy++) {
+        var K = (smBytes[off + ix * H + iy] / 255) * kmax;
+        var a = 1 - Math.exp(-K * 0.6);      // Beer-Lambert-ish opacity
+        if (a > 0.9) a = 0.9;                 // keep agents visible through it
+        var pi = ((H - 1 - iy) * W + ix) * 4; // flip y: world +y is screen up
+        // Neutral gray smoke, dark enough to read on the light canvas theme.
+        d[pi] = 74; d[pi + 1] = 72; d[pi + 2] = 78; d[pi + 3] = Math.round(a * 255);
+      }
+    }
+    smCtx.putImageData(id, 0, 0);
+    var tl = p(SM.ext[0], SM.ext[3]);          // world (xmin, ymax) -> top-left
+    var br = p(SM.ext[2], SM.ext[1]);          // world (xmax, ymin) -> bot-right
+    ctx.imageSmoothingEnabled = true;
+    // Clip to the walkable area so smoke never bleeds outside the geometry
+    // (the FDS domain is a bounding box larger than the walkable polygon).
+    var clipped = false;
+    if (D.walk.length) {
+      ctx.save();
+      ctx.beginPath();
+      for (var i = 0; i < D.walk.length; i++) {
+        var q = p(D.walk[i][0], D.walk[i][1]);
+        i ? ctx.lineTo(q[0], q[1]) : ctx.moveTo(q[0], q[1]);
+      }
+      ctx.closePath();
+      ctx.clip();
+      clipped = true;
+    }
+    ctx.drawImage(smCanvas, tl[0], tl[1], br[0] - tl[0], br[1] - tl[1]);
+    if (clipped) ctx.restore();
+  }
 
   // FED dose -> tier colour (green -> amber -> orange -> red).
   var STOPS = [[0, '#3f8f57'], [0.3, '#d19a2e'], [0.6, '#d2722b'], [1, '#c23b2e']];
@@ -215,10 +358,11 @@ _JS = """
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
     ctx.clearRect(0, 0, w, h);
     poly(D.walk, p, 'rgba(20,20,19,0.035)', 'rgba(20,20,19,0.18)', 1);
+    var b = bracket(simT), a = S[b[0]], c = S[b[1]], f = b[2];
+    drawSmoke(b[0], p);
     D.exits.forEach(function (e) {
       poly(e.poly, p, e.color + '28', e.color, 2);
     });
-    var b = bracket(simT), a = S[b[0]], c = S[b[1]], f = b[2];
     for (var i = 0; i < n; i++) {
       var ax = a[2 * i], ay = a[2 * i + 1], cx = c[2 * i], cy = c[2 * i + 1];
       var X, Y;
@@ -259,6 +403,14 @@ _JS = """
     playing = false; playBtn.textContent = '▶';
     simT = t0 + (parseFloat(slider.value) / 1000) * span;
   });
+  var smBtn = document.getElementById('traj-smoke');
+  if (smBtn) {
+    smBtn.addEventListener('click', function () {
+      showSmoke = !showSmoke;
+      smBtn.classList.toggle('active', showSmoke);
+      draw();
+    });
+  }
   var bf = document.getElementById('traj-mode-fed');
   var be = document.getElementById('traj-mode-exit');
   if (bf && be) {
@@ -275,11 +427,11 @@ _JS = """
 """
 
 
-def trajectory_component(result: Any, scenario: Any) -> Any:
+def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None) -> Any:
     """A Card with a canvas trajectory animation (smooth interpolated playback)."""
     from monsterui.all import Card, DivLAligned, H3, UkIcon
 
-    payload = _payload(result, scenario)
+    payload = _payload(result, scenario, fds_dir)
     if payload is None:
         return Card(
             DivLAligned(UkIcon("route"), H3("Trajectories", cls="m-0")),
@@ -296,6 +448,13 @@ def trajectory_component(result: Any, scenario: Any) -> Any:
             '<span class="traj-color-lbl">colour</span>'
             '<button id="traj-mode-fed" type="button" class="cmode active">FED</button>'
             '<button id="traj-mode-exit" type="button" class="cmode">exit</button>'
+            "</div>"
+        )
+    if payload.get("smoke"):
+        toggle += (
+            '<div class="traj-color">'
+            '<span class="traj-color-lbl">smoke</span>'
+            '<button id="traj-smoke" type="button" class="cmode active">on</button>'
             "</div>"
         )
     markup = (

--- a/tests/test_trajviz.py
+++ b/tests/test_trajviz.py
@@ -1,0 +1,128 @@
+"""Tests for the trajectory viewer's FDS smoke overlay payload.
+
+``_smoke_payload`` samples an FDS extinction slice into a compact base64 grid
+shipped to the browser. fdsreader is not required here: the tests inject a fake
+``Simulation`` so the packing/geometry logic is exercised without an FDS deck.
+"""
+
+import base64
+
+import numpy as np
+import pytest
+
+pytest.importorskip("fasthtml")
+
+from pyfds_evac.webapp.trajviz import _smoke_payload  # noqa: E402
+
+
+class _FakeExtent:
+    def __init__(self, z_start, z_end):
+        self.z_start = z_start
+        self.z_end = z_end
+
+
+class _FakeSlice:
+    def __init__(self, grid, xs, ys, times, z_start=1.9, z_end=2.1):
+        self._grid = np.asarray(grid, dtype=float)  # (T, X, Y)
+        self._xs = np.asarray(xs, dtype=float)
+        self._ys = np.asarray(ys, dtype=float)
+        self.times = np.asarray(times, dtype=float)
+        self.extent = _FakeExtent(z_start, z_end)
+
+    def to_global(self, masked=True, return_coordinates=True):
+        return self._grid, {"x": self._xs, "y": self._ys}
+
+
+class _FakeSlices:
+    def __init__(self, by_quantity):
+        self._by_quantity = by_quantity
+
+    def filter_by_quantity(self, name):
+        return self._by_quantity.get(name, [])
+
+
+class _FakeSim:
+    def __init__(self, by_quantity):
+        self.slices = _FakeSlices(by_quantity)
+
+
+def _sim_with_slice(slice_obj, quantity="SOOT EXTINCTION COEFFICIENT"):
+    return _FakeSim({quantity: [slice_obj]})
+
+
+def test_returns_none_without_fds_dir():
+    assert _smoke_payload(None, [0.0, 1.0]) is None
+    assert _smoke_payload("/no/such/fds/dir", [0.0, 1.0]) is None
+
+
+def test_returns_none_when_no_extinction_slice():
+    sim = _FakeSim({})  # no matching quantity
+    assert _smoke_payload("ignored", [0.0, 1.0], simulation=sim) is None
+
+
+def test_packs_one_uint8_frame_per_render_time():
+    # 4x3 grid over two FDS timesteps; three render times.
+    grid = np.arange(2 * 4 * 3, dtype=float).reshape(2, 4, 3)
+    sl = _FakeSlice(grid, xs=[0, 1, 2, 3], ys=[0, 1, 2], times=[0.0, 10.0])
+    times = [0.0, 5.0, 10.0]
+
+    payload = _smoke_payload("ignored", times, simulation=_sim_with_slice(sl))
+
+    assert payload is not None
+    assert (payload["W"], payload["H"]) == (4, 3)
+    assert payload["ext"] == [0.0, 0.0, 3.0, 2.0]
+    assert payload["kmax"] == float(grid.max())
+    # Packing invariant: one W*H byte frame per render time (catches row/col
+    # transposition and frame-count bugs a browser-free test would miss).
+    decoded = base64.b64decode(payload["b64"])
+    assert len(decoded) == payload["W"] * payload["H"] * len(times)
+
+
+def test_multi_name_lookup_falls_back_to_bare_extinction():
+    grid = np.ones((1, 3, 3), dtype=float)
+    sl = _FakeSlice(grid, xs=[0, 1, 2], ys=[0, 1, 2], times=[0.0])
+    sim = _FakeSim({"EXTINCTION": [sl]})  # only the older alias present
+    payload = _smoke_payload("ignored", [0.0], simulation=sim)
+    assert payload is not None
+    assert (payload["W"], payload["H"]) == (3, 3)
+
+
+def test_downsamples_large_grid_to_cell_cap():
+    # 200 cells on the long axis must be downsampled below the cap.
+    grid = np.zeros((1, 200, 10), dtype=float)
+    sl = _FakeSlice(grid, xs=np.arange(200), ys=np.arange(10), times=[0.0])
+    payload = _smoke_payload("ignored", [0.0], simulation=_sim_with_slice(sl))
+    assert payload is not None
+    assert payload["W"] <= 70
+
+
+def _base_payload(**extra):
+    payload = {
+        "times": [0.0, 1.0],
+        "samples": [[0.0, 0.0], [1.0, 1.0]],
+        "colors": ["#cc785c"],
+        "fed": [[0.0], [0.0]],
+        "hasFed": False,
+        "walk": [[0, 0], [1, 0], [1, 1]],
+        "exits": [],
+        "bounds": [0, 0, 1, 1],
+        "smoke": None,
+    }
+    payload.update(extra)
+    return payload
+
+
+def test_component_shows_smoke_toggle_only_when_smoke_present(monkeypatch):
+    from fasthtml.common import to_xml
+
+    from pyfds_evac.webapp import trajviz
+
+    smoke = {"W": 2, "H": 2, "ext": [0, 0, 1, 1], "kmax": 1.0, "b64": "AAAAAA=="}
+
+    monkeypatch.setattr(trajviz, "_payload", lambda *a, **k: _base_payload(smoke=smoke))
+    with_smoke = to_xml(trajviz.trajectory_component(object(), object()))
+    assert 'id="traj-smoke"' in with_smoke
+
+    monkeypatch.setattr(trajviz, "_payload", lambda *a, **k: _base_payload(smoke=None))
+    without_smoke = to_xml(trajviz.trajectory_component(object(), object()))
+    assert 'id="traj-smoke"' not in without_smoke

--- a/tests/test_trajviz.py
+++ b/tests/test_trajviz.py
@@ -50,9 +50,10 @@ def _sim_with_slice(slice_obj, quantity="SOOT EXTINCTION COEFFICIENT"):
     return _FakeSim({quantity: [slice_obj]})
 
 
-def test_returns_none_without_fds_dir():
+def test_returns_none_without_fds_dir(tmp_path):
     assert _smoke_payload(None, [0.0, 1.0]) is None
-    assert _smoke_payload("/no/such/fds/dir", [0.0, 1.0]) is None
+    missing = tmp_path / "no-such-fds-dir"
+    assert _smoke_payload(str(missing), [0.0, 1.0]) is None
 
 
 def test_returns_none_when_no_extinction_slice():


### PR DESCRIPTION
## Summary

Adds a **2D FDS smoke overlay** to the canvas trajectory viewer — the first extracted piece of the stalled #29 (`gregory/smokerender`), rebased cleanly onto `main`.

When a run is given an `fds dir`, the viewer renders the FDS soot-extinction slice as a smoke layer beneath the agent dots:
- Slice sampled onto a coarse grid (≤70 cells/axis), shipped as per-frame base64 `uint8` scaled to `kmax`.
- Client decodes it, applies Beer-Lambert-ish opacity, and **clips to the walkable polygon** so the FDS bounding box can't bleed outside the geometry.
- **On/off toggle** next to the existing colour toggle.
- **Fails safe** to the pre-existing view when no `fds_dir` / extinction slice is available.

`fds_dir` is persisted on `RunManager` and threaded through to `trajectory_component` (mirrors how the merged FED wiring reaches render time — `opts` isn't in scope at `_finished_view`).

## Scope / what's intentionally excluded

Extracted from #29 and adapted onto `main`'s existing **MonsterUI card**. Deliberately **not** included from that branch:
- The web-GUI dark-theme re-skin (all of main's current colours preserved).
- The Smokeview/PRT5 particle exporter (3D vis is delegated to the fds-viewer fork now).
- The playback-speed controls and FED live panel — separable follow-up PRs if wanted.

The multi-name extinction lookup (`SOOT EXTINCTION COEFFICIENT` / `EXTINCTION`) mirrors the `load_slice_sampler` fix already merged in #35; `_smoke_payload` needs the raw grid via `to_global()` rather than a `SliceFieldSampler`, so it filters inline (noted in a comment).

## Tests

`tests/test_trajviz.py` (6 tests, inject a fake `fdsreader.Simulation` — no FDS deck required):
- Returns `None` without `fds_dir` / when no extinction slice matches.
- **Packing invariant:** `len(b64decode(b64)) == W * H * len(times)` (catches row/col transposition and frame-count bugs).
- Multi-name fallback to the bare `EXTINCTION` alias.
- Large grid downsampled below the cell cap.
- Component renders the smoke toggle only when a smoke payload exists.

Local: `ruff format --check` + `ruff check` clean; new tests pass. Hand-edited viewer JS validated with `node --check`.