### PR TITLE
feat(webapp): playback-speed controls + live FED-dose panel in the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ live progress, and explore the results as interactive
 exit, cumulative FED, smoke, and route cost). When a run is given an
 `fds dir`, the canvas trajectory animation overlays the FDS soot
 extinction slice as a smoke layer beneath the agents (clipped to the
-walkable area, with an on/off toggle).
+walkable area, with an on/off toggle). The animation has ¼×–4×
+playback-speed controls, and — for runs with tenability enabled — a live
+FED-dose panel showing the current max/mean dose and a sparkline of the
+crowd's FED over time.
 
 Install the optional GUI dependencies and launch:
 

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -343,6 +343,55 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   background: hsl(var(--accent) / .6);
 }
 
+/* ---- FED live dose panel ---- */
+.fed-panel {
+  margin-top: .9rem; padding: .8rem 1rem;
+  border: 1px solid hsl(var(--border)); border-radius: .5rem;
+  background: hsl(var(--card));
+}
+.fed-head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: .6rem;
+}
+.fed-title {
+  font-family: var(--font-mono); font-size: .56rem; letter-spacing: .14em;
+  text-transform: uppercase; color: hsl(var(--muted-foreground));
+}
+.fed-legend { display: flex; gap: .7rem; }
+.fed-leg { font-family: var(--font-mono); font-size: .55rem; letter-spacing: .04em; }
+.fed-leg::before { content: "\2022  "; }
+.fed-leg.safe { color: var(--tier-safe); }
+.fed-leg.alert { color: var(--tier-alert); }
+.fed-leg.critical { color: var(--tier-critical); }
+.fed-leg.severe { color: var(--tier-severe); }
+.fed-stats {
+  display: flex; gap: 1.5rem; align-items: baseline; margin-bottom: .7rem;
+}
+.fed-stat-lbl {
+  font-family: var(--font-mono); font-size: .55rem; letter-spacing: .06em;
+  text-transform: uppercase; color: hsl(var(--muted-foreground)); margin-bottom: .1rem;
+}
+.fed-val {
+  font-family: var(--font-mono); font-size: 1.5rem; font-weight: 500;
+  color: var(--tier-safe); transition: color .3s;
+}
+.fed-bar {
+  position: relative; height: 6px; border-radius: 99px;
+  background: hsl(var(--secondary)); border: 1px solid hsl(var(--border));
+  overflow: hidden; margin-bottom: .3rem;
+}
+.fed-bar-fill {
+  position: absolute; inset: 0; width: 0%; border-radius: 99px;
+  transition: width .15s;
+  background: linear-gradient(90deg,
+    var(--tier-safe), var(--tier-alert), var(--tier-critical), var(--tier-severe));
+}
+.fed-scale {
+  display: flex; justify-content: space-between; margin-bottom: .6rem;
+  font-family: var(--font-mono); font-size: .55rem; color: hsl(var(--muted-foreground));
+}
+.fed-spark { width: 100%; height: 60px; display: block; }
+
 /* ---- streaming console (warm-dark inset terminal) ---- */
 .console-box {
   max-height: 20rem; overflow: auto;

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -371,9 +371,12 @@ _JS = """
       return c > 0 ? s / c : 0;
     });
   }
-  // FED dose -> tier colour, matching the agent-dot STOPS palette above.
+  // FED dose -> tier colour: the discrete STOPS tier the dose falls into
+  // (derived from the same palette the agent dots use, no duplicated hex).
   function fc(v) {
-    return v >= 1.0 ? '#c23b2e' : v >= 0.6 ? '#d2722b' : v >= 0.3 ? '#d19a2e' : '#3f8f57';
+    var c = STOPS[0][1];
+    for (var i = 0; i < STOPS.length; i++) { if (v >= STOPS[i][0]) c = STOPS[i][1]; }
+    return c;
   }
   function drawFedPanel() {
     if (!D.hasFed || !fedMaxByTime) return;
@@ -391,7 +394,11 @@ _JS = """
     var dpr = window.devicePixelRatio || 1;
     var sw = sc.clientWidth, sh = sc.clientHeight;
     if (!sw || !sh) return;
-    sc.width = sw * dpr; sc.height = sh * dpr;
+    // Only resize when the CSS size / DPR actually changed: setting width/height
+    // resets the canvas, so doing it every RAF frame is wasteful.
+    if (sc.width !== sw * dpr || sc.height !== sh * dpr) {
+      sc.width = sw * dpr; sc.height = sh * dpr;
+    }
     var sctx = sc.getContext('2d');
     if (!sctx) return;
     sctx.setTransform(dpr, 0, 0, dpr, 0, 0);

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -243,6 +243,7 @@ _JS = """
   var t0 = T[0], t1 = T[T.length - 1], span = Math.max(1e-6, t1 - t0);
   var PLAYBACK = 16;            // seconds of wall time to play the whole run
   var simT = t0, playing = false, lastTs = null;
+  var speedMult = 1;           // playback rate multiplier (speed buttons)
   var bx = D.bounds, pad = 0.06;
   var mode = D.hasFed ? 'fed' : 'exit';
 
@@ -354,6 +355,86 @@ _JS = """
     var f = (t - T[lo]) / Math.max(1e-9, T[hi] - T[lo]);
     return [lo, hi, f];
   }
+  // Per-sample FED max/mean across agents, for the live dose panel.
+  var fedMaxByTime = null, fedMeanByTime = null;
+  if (D.hasFed) {
+    fedMaxByTime = T.map(function (_, ti) {
+      var row = FED[ti]; if (!row) return 0;
+      var m = 0;
+      for (var k = 0; k < n; k++) { if (row[k] != null && row[k] > m) m = row[k]; }
+      return m;
+    });
+    fedMeanByTime = T.map(function (_, ti) {
+      var row = FED[ti]; if (!row) return 0;
+      var s = 0, c = 0;
+      for (var k = 0; k < n; k++) { if (row[k] != null) { s += row[k]; c++; } }
+      return c > 0 ? s / c : 0;
+    });
+  }
+  // FED dose -> tier colour, matching the agent-dot STOPS palette above.
+  function fc(v) {
+    return v >= 1.0 ? '#c23b2e' : v >= 0.6 ? '#d2722b' : v >= 0.3 ? '#d19a2e' : '#3f8f57';
+  }
+  function drawFedPanel() {
+    if (!D.hasFed || !fedMaxByTime) return;
+    var b = bracket(simT), lo = b[0], hi = b[1], f = b[2];
+    var curMax  = fedMaxByTime[lo]  + (fedMaxByTime[hi]  - fedMaxByTime[lo])  * f;
+    var curMean = fedMeanByTime[lo] + (fedMeanByTime[hi] - fedMeanByTime[lo]) * f;
+    var maxEl = document.getElementById('fed-val-max');
+    if (maxEl) { maxEl.textContent = curMax.toFixed(4); maxEl.style.color = fc(curMax); }
+    var meanEl = document.getElementById('fed-val-mean');
+    if (meanEl) { meanEl.textContent = curMean.toFixed(4); meanEl.style.color = fc(curMean); }
+    var barEl = document.getElementById('fed-bar-fill');
+    if (barEl) barEl.style.width = Math.min(100, curMax * 100) + '%';
+    var sc = document.getElementById('fed-spark');
+    if (!sc) return;
+    var dpr = window.devicePixelRatio || 1;
+    var sw = sc.clientWidth, sh = sc.clientHeight;
+    if (!sw || !sh) return;
+    sc.width = sw * dpr; sc.height = sh * dpr;
+    var sctx = sc.getContext('2d');
+    if (!sctx) return;
+    sctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    sctx.clearRect(0, 0, sw, sh);
+    var N = fedMaxByTime.length;
+    var maxV = 0;
+    for (var i = 0; i < N; i++) { if (fedMaxByTime[i] > maxV) maxV = fedMaxByTime[i]; }
+    maxV = Math.max(1.05, maxV * 1.12);
+    function px(i) { return N > 1 ? (i / (N - 1)) * sw : sw / 2; }
+    function py(v) { return sh - (v / maxV) * (sh - 2); }
+    var grad = sctx.createLinearGradient(0, 0, 0, sh);
+    grad.addColorStop(0, 'rgba(204,120,92,.20)');   // clay wash under the max curve
+    grad.addColorStop(1, 'rgba(204,120,92,0)');
+    sctx.beginPath();
+    sctx.moveTo(px(0), sh);
+    for (var i = 0; i < N; i++) sctx.lineTo(px(i), py(fedMaxByTime[i]));
+    sctx.lineTo(px(N - 1), sh); sctx.closePath();
+    sctx.fillStyle = grad; sctx.fill();
+    sctx.beginPath();
+    for (var i = 0; i < N; i++) { i === 0 ? sctx.moveTo(px(i), py(fedMaxByTime[i])) : sctx.lineTo(px(i), py(fedMaxByTime[i])); }
+    sctx.strokeStyle = '#cc785c'; sctx.lineWidth = 1.5; sctx.stroke();   // max: clay
+    sctx.beginPath();
+    for (var i = 0; i < N; i++) { i === 0 ? sctx.moveTo(px(i), py(fedMeanByTime[i])) : sctx.lineTo(px(i), py(fedMeanByTime[i])); }
+    sctx.strokeStyle = 'rgba(204,120,92,.6)'; sctx.lineWidth = 1;        // mean: faded clay
+    sctx.setLineDash([3, 3]); sctx.stroke(); sctx.setLineDash([]);
+    var threshs = [[0.3, 'rgba(209,154,46,.6)', '0.3'], [1.0, 'rgba(194,59,46,.6)', '1.0']];
+    for (var ti2 = 0; ti2 < threshs.length; ti2++) {
+      var ty = py(threshs[ti2][0]);
+      if (ty >= 0 && ty <= sh) {
+        sctx.beginPath(); sctx.moveTo(0, ty); sctx.lineTo(sw, ty);
+        sctx.strokeStyle = threshs[ti2][1]; sctx.lineWidth = 1;
+        sctx.setLineDash([4, 4]); sctx.stroke(); sctx.setLineDash([]);
+        sctx.fillStyle = threshs[ti2][1]; sctx.font = "9px 'IBM Plex Mono', monospace";
+        sctx.textAlign = 'right'; sctx.fillText(threshs[ti2][2], sw - 3, ty - 3); sctx.textAlign = 'left';
+      }
+    }
+    var curFrac = T.length > 1 ? (simT - T[0]) / (T[T.length - 1] - T[0]) : 0;
+    var cx = Math.max(0, Math.min(sw, curFrac * sw));
+    sctx.beginPath(); sctx.moveTo(cx, 0); sctx.lineTo(cx, sh);
+    sctx.strokeStyle = 'rgba(20,20,19,.45)'; sctx.lineWidth = 1.5; sctx.stroke();
+    sctx.beginPath(); sctx.arc(cx, py(curMax), 3.5, 0, 6.2832);
+    sctx.fillStyle = fc(curMax); sctx.fill();
+  }
   function draw() {
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
     ctx.clearRect(0, 0, w, h);
@@ -384,10 +465,11 @@ _JS = """
     }
     tlabel.textContent = 't = ' + (simT - t0).toFixed(0) + ' s';
     slider.value = String(((simT - t0) / span) * 1000);
+    if (D.hasFed) drawFedPanel();
   }
   function loop(ts) {
     if (playing) {
-      if (lastTs != null) simT += ((ts - lastTs) / 1000) * (span / PLAYBACK);
+      if (lastTs != null) simT += ((ts - lastTs) / 1000) * (span / PLAYBACK) * speedMult;
       lastTs = ts;
       if (simT >= t1) { simT = t1; playing = false; playBtn.textContent = '▶'; }
     }
@@ -402,6 +484,14 @@ _JS = """
   slider.addEventListener('input', function () {
     playing = false; playBtn.textContent = '▶';
     simT = t0 + (parseFloat(slider.value) / 1000) * span;
+  });
+  document.querySelectorAll('.speed-btn').forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      speedMult = parseFloat(this.dataset.speed);
+      document.querySelectorAll('.speed-btn').forEach(function (b) {
+        b.classList.toggle('active', b === btn);
+      });
+    });
   });
   var smBtn = document.getElementById('traj-smoke');
   if (smBtn) {
@@ -457,6 +547,41 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
             '<button id="traj-smoke" type="button" class="cmode active">on</button>'
             "</div>"
         )
+    panel = ""
+    if payload["hasFed"]:
+        panel = (
+            '<div class="fed-panel">'
+            '<div class="fed-head">'
+            '<span class="fed-title">FED dose</span>'
+            '<div class="fed-legend">'
+            '<span class="fed-leg safe">safe</span>'
+            '<span class="fed-leg alert">alert 0.3</span>'
+            '<span class="fed-leg critical">critical 0.6</span>'
+            '<span class="fed-leg severe">severe 1.0</span>'
+            "</div></div>"
+            '<div class="fed-stats">'
+            '<div class="fed-stat"><div class="fed-stat-lbl">max</div>'
+            '<div id="fed-val-max" class="fed-val">0.0000</div></div>'
+            '<div class="fed-stat"><div class="fed-stat-lbl">mean</div>'
+            '<div id="fed-val-mean" class="fed-val">0.0000</div></div>'
+            "</div>"
+            '<div class="fed-bar"><div id="fed-bar-fill" class="fed-bar-fill"></div></div>'
+            '<div class="fed-scale">'
+            "<span>0</span><span>0.3</span><span>0.6</span><span>1.0+</span>"
+            "</div>"
+            '<canvas id="fed-spark" class="fed-spark"></canvas>'
+            "</div>"
+        )
+    speed = (
+        '<div class="traj-color">'
+        '<span class="traj-color-lbl">speed</span>'
+        '<button type="button" class="cmode speed-btn" data-speed="0.25">&frac14;&times;</button>'
+        '<button type="button" class="cmode speed-btn" data-speed="0.5">&frac12;&times;</button>'
+        '<button type="button" class="cmode speed-btn active" data-speed="1">1&times;</button>'
+        '<button type="button" class="cmode speed-btn" data-speed="2">2&times;</button>'
+        '<button type="button" class="cmode speed-btn" data-speed="4">4&times;</button>'
+        "</div>"
+    )
     markup = (
         '<div class="traj-wrap">'
         '<canvas id="traj-canvas" class="traj-canvas"></canvas>'
@@ -465,8 +590,11 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
         '<input id="traj-slider" type="range" min="0" max="1000" value="0" '
         'class="traj-slider">'
         '<span id="traj-time" class="traj-time">t = 0 s</span>'
+        + speed
         + toggle
-        + "</div></div>"
+        + "</div>"
+        + panel
+        + "</div>"
     )
     script = "<script>" + _JS.replace("__DATA__", data_json) + "</script>"
     return Card(

--- a/tests/test_trajviz.py
+++ b/tests/test_trajviz.py
@@ -127,3 +127,35 @@ def test_component_shows_smoke_toggle_only_when_smoke_present(monkeypatch):
     monkeypatch.setattr(trajviz, "_payload", lambda *a, **k: _base_payload(smoke=None))
     without_smoke = to_xml(trajviz.trajectory_component(object(), object()))
     assert 'id="traj-smoke"' not in without_smoke
+
+
+def test_component_always_renders_speed_controls(monkeypatch):
+    from fasthtml.common import to_xml
+
+    from pyfds_evac.webapp import trajviz
+
+    monkeypatch.setattr(
+        trajviz, "_payload", lambda *a, **k: _base_payload(hasFed=False)
+    )
+    html = to_xml(trajviz.trajectory_component(object(), object()))
+    assert 'class="cmode speed-btn active" data-speed="1"' in html
+    assert 'data-speed="0.25"' in html and 'data-speed="4"' in html
+
+
+def test_component_shows_fed_panel_only_when_fed_present(monkeypatch):
+    from fasthtml.common import to_xml
+
+    from pyfds_evac.webapp import trajviz
+
+    monkeypatch.setattr(trajviz, "_payload", lambda *a, **k: _base_payload(hasFed=True))
+    with_fed = to_xml(trajviz.trajectory_component(object(), object()))
+    assert 'class="fed-panel"' in with_fed
+    assert 'id="fed-spark"' in with_fed
+    assert 'id="fed-val-max"' in with_fed
+
+    monkeypatch.setattr(
+        trajviz, "_payload", lambda *a, **k: _base_payload(hasFed=False)
+    )
+    without_fed = to_xml(trajviz.trajectory_component(object(), object()))
+    assert 'class="fed-panel"' not in without_fed
+    assert 'id="fed-spark"' not in without_fed

--- a/tests/test_trajviz.py
+++ b/tests/test_trajviz.py
@@ -6,6 +6,7 @@ shipped to the browser. fdsreader is not required here: the tests inject a fake
 """
 
 import base64
+import re
 
 import numpy as np
 import pytest
@@ -138,8 +139,12 @@ def test_component_always_renders_speed_controls(monkeypatch):
         trajviz, "_payload", lambda *a, **k: _base_payload(hasFed=False)
     )
     html = to_xml(trajviz.trajectory_component(object(), object()))
-    assert 'class="cmode speed-btn active" data-speed="1"' in html
     assert 'data-speed="0.25"' in html and 'data-speed="4"' in html
+    # The 1x button is the default-active one. Match on the whole <button> tag
+    # so the check is independent of serialized attribute order.
+    btn_1x = re.search(r"<button[^>]*\bdata-speed=\"1\"[^>]*>", html)
+    assert btn_1x is not None
+    assert "active" in btn_1x.group() and "speed-btn" in btn_1x.group()
 
 
 def test_component_shows_fed_panel_only_when_fed_present(monkeypatch):


### PR DESCRIPTION
## Summary

Second extracted piece of the stalled #29 (`gregory/smokerender`), rebased onto `main` (after the smoke overlay in #36). Two viewer-UX additions to the canvas trajectory animation:

- **Playback speed** — ¼×, ½×, 1×, 2×, 4× buttons scale the `requestAnimationFrame` advance via `speedMult`. Reuses the existing `.cmode` toggle styling.
- **Live FED-dose panel** (rendered only when the run has FED) — current **max/mean** dose (colour-coded by tier), a gradient dose bar, and a **sparkline** of the crowd's FED max (solid) / mean (dashed) over time, with 0.3 / 1.0 threshold guides and a cursor tracking the scrubber.

`fds_dir` threading and the smoke layer are unchanged from #36.

## Adaptation notes

- **Colours mapped to main's palette.** The source branch styled these against its dark re-theme; every colour here uses main's existing tier vars (`--tier-safe #3f8f57`, `--tier-alert #d19a2e`, `--tier-critical #d2722b`, `--tier-severe #c23b2e`) — the *same* palette the agent-dot `STOPS` already use, so the panel stays coherent with the dots. The scrubber cursor is dark (the source's white cursor is invisible on the light canvas).
- **Panel layout via `.fed-*` classes** added to `theme.py`, following the existing `.traj-*` pattern, rather than porting ~20 inline dark-hex styles. `.fed-spark` carries an explicit `height` so `clientHeight` is non-zero and the sparkline actually draws.
- Deliberately **excludes** the dark-theme re-skin, the Smokeview/PRT5 exporter, and the committed FDS binaries from #29.

## Tests

`tests/test_trajviz.py` (8 tests total; render via fasthtml `to_xml`, no jupedsim/FDS deck needed):
- Speed buttons always render; the `1×` button is the default-active one.
- FED panel elements (`fed-panel`, `fed-spark`, `fed-val-max`) render **iff** `hasFed`.
- (plus the existing smoke-overlay payload/packing tests.)

Local checks: 8/8 pass; `ruff format --check` + `ruff check` clean; viewer JS validated with `node --check`; rendered markup **div-balance verified** with an HTML parser for both `hasFed` branches.

**Verification ceiling (honest):** the panel/sparkline are client-side canvas JS with no pure-Python surface — the tests prove the elements render and the markup is well-formed, but *not* that the sparkline draws correctly with real FED data. That needs a live FED run through the web GUI, which isn't runnable in CI/local here (needs `jupedsim`). Worth a manual eyeball before/at merge.