### PR TITLE
feat(webapp): warm dark theme for the web GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ runs a simulation and produces every plot in one go.
 ## Web GUI
 
 A [FastHTML](https://fastht.ml/) + [MonsterUI](https://monsterui.answer.ai/)
-web GUI exposes the same model behind a form: pick a scenario, set any
+web GUI (warm dark instrument-panel theme) exposes the same model behind a
+form: pick a scenario, set any
 `run.py` flag (the `fds dir` field has a folder browser), run it, watch
 live progress, and explore the results as interactive
 [Plotly](https://plotly.com/python/) charts (trajectories coloured by

--- a/pyfds_evac/webapp/plots.py
+++ b/pyfds_evac/webapp/plots.py
@@ -28,20 +28,20 @@ _PALETTE = [
 ]
 
 
-_GRID = "rgba(20,20,19,0.06)"
-_ZERO = "rgba(20,20,19,0.14)"
-_FG = "#4a473f"
+_GRID = "rgba(235,232,225,0.08)"
+_ZERO = "rgba(235,232,225,0.18)"
+_FG = "#c9c3b8"
 
 
 def figure_html(fig: go.Figure, div_id: str) -> Any:
     """Embed a Plotly figure as an HTML fragment (no bundled Plotly.js).
 
-    Applies the Warm Paper Lab light template so charts match the GUI's cream
-    ground (transparent background, warm ink, hue-shifted grid).
+    Applies the Warm Dark Lab template so charts match the GUI's dark ground
+    (transparent background, warm off-white ink, faint light grid).
     """
     fig.update_layout(
         margin=dict(l=52, r=22, t=30, b=46),
-        template="plotly_white",
+        template="plotly_dark",
         paper_bgcolor="rgba(0,0,0,0)",
         plot_bgcolor="rgba(0,0,0,0)",
         font=dict(family="IBM Plex Mono, ui-monospace, monospace", color=_FG, size=12),

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -53,6 +53,7 @@ _CSS = """
   --input: 40 5% 22%;
   --ring: 16 55% 58%;
   --radius: .5rem;
+  color-scheme: dark !important;  /* beats franken/daisyui's light default from CDN */
 
   --font-display: 'Archivo', system-ui, sans-serif;
   --font-sans: 'IBM Plex Sans', system-ui, sans-serif;
@@ -67,8 +68,6 @@ _CSS = """
   /* warm, hue-shifted shadow (not pure black) */
   --shadow-warm: 20 14% 3%;
 }
-html.uk-theme-blue { color-scheme: dark; }
-
 html, body { background: hsl(var(--background)); }
 body {
   font-family: var(--font-sans);
@@ -320,7 +319,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   width: 100%; height: 440px; display: block;
   border: 1px solid hsl(var(--border)); border-radius: .4rem;
   background:
-    radial-gradient(120% 120% at 50% 0%, hsl(40 5% 15%), hsl(40 6% 11%));
+    radial-gradient(120% 120% at 50% 0%, hsl(var(--card)), hsl(var(--background)));
 }
 .traj-controls {
   display: flex; align-items: center; gap: .8rem; margin-top: .6rem;

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -111,7 +111,11 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   color: hsl(var(--muted-foreground));
 }
 .uk-input, .uk-select, input { font-family: var(--font-mono); }
-.uk-input { font-size: .82rem; background: hsl(var(--input)); }
+.uk-input {
+  font-size: .82rem; background: hsl(var(--input));
+  border: 1px solid hsl(var(--border));
+}
+.uk-input:focus { border-color: hsl(var(--primary) / .7); }
 
 /* inline help badge next to a field label */
 .lbl-help { display: inline-flex; align-items: center; }
@@ -201,7 +205,11 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   transition: border-color .2s, background .2s;
 }
 .uk-accordion-title:hover { background: hsl(var(--accent) / .6) !important; }
-.uk-open > .uk-accordion-title { border-left-color: var(--clay); }
+.uk-open > .uk-accordion-title {
+  border-left: 2px solid var(--clay);
+  background: hsl(var(--accent) / .5) !important;
+  box-shadow: inset 2px 0 0 0 var(--clay), 0 0 14px -8px hsl(16 55% 58% / .55);
+}
 
 /* ---- buttons ---- */
 .uk-btn {

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -1,15 +1,14 @@
-"""Visual theme for the pyFDS-Evac GUI: "Warm Paper Lab".
+"""Visual theme for the pyFDS-Evac GUI: "Warm Dark Lab".
 
-A warm cream instrument panel in the spirit of anthropic.com: ivory paper
-(#FAF9F5) ground, warm near-black ink, and a single clay/terracotta accent
-(#CC785C). The FED tenability tiers (Safe/Alert/Critical/Severe) remain the
-semantic colour system, harmonised to sit on cream and always paired with a
-text label (colour is never the sole cue).
+A warm dark instrument panel: near-black warm ground, warm off-white ink, and
+a single clay/terracotta accent (#CC785C). The FED tenability tiers
+(Safe/Alert/Critical/Severe) remain the semantic colour system and are always
+paired with a text label (colour is never the sole cue).
 
 Retheming is done by overriding franken-ui's shadcn-style CSS variables on
 <html>, so every component inherits the palette; the rest adds typography
-(Archivo display, IBM Plex Mono labels, IBM Plex Sans body), chrome, a soft
-paper texture, warm shadows, and load motion.
+(Archivo display, IBM Plex Mono labels, IBM Plex Sans body), chrome, a faint
+engineering grid, warm shadows, and load motion.
 """
 
 from __future__ import annotations
@@ -28,31 +27,31 @@ _FONTS = Link(
     ),
 )
 
-# Palette (sRGB hex, for reference):
-#   ground   ivory   #FAF9F5   surface  cloud  #F4F2EA   ink   #141413
-#   accent   clay    #CC785C   muted-ink       #75726A   line  #E4DECF
+# Palette (HSL tokens; warm dark):
+#   ground   40 6% 10%   surface/card  40 5% 14%   ink  45 20% 91%
+#   accent   clay #CC785C   muted-ink  43 8% 62%   line  40 5% 26%
 #   tiers  safe #3F8F57  alert #D19A2E  critical #D2722B  severe #C23B2E
 _CSS = """
 :root, html.uk-theme-blue {
-  --background: 48 33% 97%;
-  --foreground: 60 4% 9%;
-  --card: 48 29% 95%;
-  --card-foreground: 60 4% 9%;
-  --popover: 48 33% 98%;
-  --popover-foreground: 60 4% 9%;
-  --primary: 16 52% 58%;
-  --primary-foreground: 30 30% 12%;
-  --secondary: 47 28% 90%;
-  --secondary-foreground: 40 6% 16%;
-  --muted: 47 28% 91%;
-  --muted-foreground: 40 5% 42%;
-  --accent: 22 48% 90%;
-  --accent-foreground: 16 48% 34%;
-  --destructive: 5 58% 49%;
-  --destructive-foreground: 48 33% 97%;
-  --border: 46 24% 84%;
-  --input: 45 22% 80%;
-  --ring: 16 52% 56%;
+  --background: 40 6% 10%;
+  --foreground: 45 20% 91%;
+  --card: 40 5% 14%;
+  --card-foreground: 45 20% 91%;
+  --popover: 40 5% 13%;
+  --popover-foreground: 45 20% 91%;
+  --primary: 16 55% 60%;
+  --primary-foreground: 30 30% 10%;
+  --secondary: 40 4% 20%;
+  --secondary-foreground: 45 15% 85%;
+  --muted: 40 4% 20%;
+  --muted-foreground: 43 8% 62%;
+  --accent: 20 30% 24%;
+  --accent-foreground: 22 55% 72%;
+  --destructive: 5 62% 55%;
+  --destructive-foreground: 45 20% 95%;
+  --border: 40 5% 26%;
+  --input: 40 5% 22%;
+  --ring: 16 55% 58%;
   --radius: .5rem;
 
   --font-display: 'Archivo', system-ui, sans-serif;
@@ -66,9 +65,9 @@ _CSS = """
   --tier-severe: #c23b2e;
 
   /* warm, hue-shifted shadow (not pure black) */
-  --shadow-warm: 30 25% 22%;
+  --shadow-warm: 20 14% 3%;
 }
-html.uk-theme-blue { color-scheme: light; }
+html.uk-theme-blue { color-scheme: dark; }
 
 html, body { background: hsl(var(--background)); }
 body {
@@ -85,8 +84,8 @@ body {
 body::before {
   content: ""; position: fixed; inset: 0; z-index: 0; pointer-events: none;
   background-image:
-    linear-gradient(hsl(60 4% 9% / .035) 1px, transparent 1px),
-    linear-gradient(90deg, hsl(60 4% 9% / .035) 1px, transparent 1px);
+    linear-gradient(hsl(45 20% 90% / .04) 1px, transparent 1px),
+    linear-gradient(90deg, hsl(45 20% 90% / .04) 1px, transparent 1px);
   background-size: 46px 46px;
   mask-image: radial-gradient(120% 90% at 50% 0%, #000 30%, transparent 100%);
 }
@@ -112,7 +111,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   color: hsl(var(--muted-foreground));
 }
 .uk-input, .uk-select, input { font-family: var(--font-mono); }
-.uk-input { font-size: .82rem; background: hsl(48 36% 98%); }
+.uk-input { font-size: .82rem; background: hsl(var(--input)); }
 
 /* inline help badge next to a field label */
 .lbl-help { display: inline-flex; align-items: center; }
@@ -184,7 +183,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   border-radius: var(--radius);
   backdrop-filter: blur(6px) saturate(1.05);
   box-shadow:
-    0 1px 0 hsl(0 0% 100% / .6) inset,
+    0 1px 0 hsl(0 0% 100% / .06) inset,
     0 18px 48px -34px hsl(var(--shadow-warm) / .5);
 }
 .uk-card-title, .uk-card h3 {
@@ -223,11 +222,11 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
               0 0 0 1px hsl(16 52% 50% / .4), 0 12px 26px -10px hsl(16 52% 40% / .55);
 }
 .uk-btn-secondary {
-  background: hsl(48 30% 96%); color: hsl(var(--secondary-foreground));
+  background: hsl(var(--secondary)); color: hsl(var(--secondary-foreground));
   border: 1px solid hsl(var(--border));
 }
 .uk-btn-secondary:hover { border-color: hsl(var(--primary) / .6); color: var(--clay); }
-.uk-btn-ghost:hover { background: hsl(var(--accent) / .7); color: hsl(16 48% 34%); }
+.uk-btn-ghost:hover { background: hsl(var(--accent) / .7); color: var(--clay); }
 
 /* ---- run panel: telemetry ---- */
 .telemetry { font-family: var(--font-mono); letter-spacing: .02em; }
@@ -278,7 +277,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .doc-card p { line-height: 1.75; max-width: 74ch; }
 .eq {
   margin: .75rem 0; padding: .65rem 1rem; overflow-x: auto;
-  background: hsl(48 30% 97%); border: 1px solid hsl(var(--border));
+  background: hsl(var(--card)); border: 1px solid hsl(var(--border));
   border-left: 2px solid var(--clay); border-radius: .4rem;
 }
 .eq .katex { font-size: 1.05em; }
@@ -309,7 +308,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   width: 100%; height: 440px; display: block;
   border: 1px solid hsl(var(--border)); border-radius: .4rem;
   background:
-    radial-gradient(120% 120% at 50% 0%, hsl(48 30% 99%), hsl(48 24% 96%));
+    radial-gradient(120% 120% at 50% 0%, hsl(40 5% 15%), hsl(40 6% 11%));
 }
 .traj-controls {
   display: flex; align-items: center; gap: .8rem; margin-top: .6rem;

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -226,6 +226,10 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   border: 1px solid hsl(var(--border));
 }
 .uk-btn-secondary:hover { border-color: hsl(var(--primary) / .6); color: var(--clay); }
+/* base ghost: transparent on the theme surface (overrides pico's blue button) */
+.uk-btn-ghost {
+  background: transparent; color: hsl(var(--foreground)); border-color: transparent;
+}
 .uk-btn-ghost:hover { background: hsl(var(--accent) / .7); color: var(--clay); }
 
 /* ---- run panel: telemetry ---- */

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -271,8 +271,8 @@ _JS = """
         var a = 1 - Math.exp(-K * 0.6);      // Beer-Lambert-ish opacity
         if (a > 0.9) a = 0.9;                 // keep agents visible through it
         var pi = ((H - 1 - iy) * W + ix) * 4; // flip y: world +y is screen up
-        // Neutral gray smoke, dark enough to read on the light canvas theme.
-        d[pi] = 74; d[pi + 1] = 72; d[pi + 2] = 78; d[pi + 3] = Math.round(a * 255);
+        // Light gray smoke, bright enough to read on the dark canvas theme.
+        d[pi] = 205; d[pi + 1] = 203; d[pi + 2] = 214; d[pi + 3] = Math.round(a * 255);
       }
     }
     smCtx.putImageData(id, 0, 0);
@@ -438,14 +438,14 @@ _JS = """
     var curFrac = T.length > 1 ? (simT - T[0]) / (T[T.length - 1] - T[0]) : 0;
     var cx = Math.max(0, Math.min(sw, curFrac * sw));
     sctx.beginPath(); sctx.moveTo(cx, 0); sctx.lineTo(cx, sh);
-    sctx.strokeStyle = 'rgba(20,20,19,.45)'; sctx.lineWidth = 1.5; sctx.stroke();
+    sctx.strokeStyle = 'rgba(255,255,255,.5)'; sctx.lineWidth = 1.5; sctx.stroke();
     sctx.beginPath(); sctx.arc(cx, py(curMax), 3.5, 0, 6.2832);
     sctx.fillStyle = fc(curMax); sctx.fill();
   }
   function draw() {
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
     ctx.clearRect(0, 0, w, h);
-    poly(D.walk, p, 'rgba(20,20,19,0.035)', 'rgba(20,20,19,0.18)', 1);
+    poly(D.walk, p, 'rgba(255,255,255,0.035)', 'rgba(255,255,255,0.16)', 1);
     var b = bracket(simT), a = S[b[0]], c = S[b[1]], f = b[2];
     drawSmoke(b[0], p);
     D.exits.forEach(function (e) {
@@ -468,7 +468,7 @@ _JS = """
       var q = p(X, Y);
       ctx.beginPath(); ctx.arc(q[0], q[1], 4.5, 0, 6.2832);
       ctx.fillStyle = col; ctx.fill();
-      ctx.lineWidth = 0.5; ctx.strokeStyle = 'rgba(20,20,19,0.35)'; ctx.stroke();
+      ctx.lineWidth = 0.5; ctx.strokeStyle = 'rgba(0,0,0,0.45)'; ctx.stroke();
     }
     tlabel.textContent = 't = ' + (simT - t0).toFixed(0) + ' s';
     slider.value = String(((simT - t0) / span) * 1000);

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -445,7 +445,7 @@ _JS = """
   function draw() {
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
     ctx.clearRect(0, 0, w, h);
-    poly(D.walk, p, 'rgba(255,255,255,0.035)', 'rgba(255,255,255,0.16)', 1);
+    poly(D.walk, p, 'rgba(255,255,255,0.04)', 'rgba(255,255,255,0.28)', 1.5);
     var b = bracket(simT), a = S[b[0]], c = S[b[1]], f = b[2];
     drawSmoke(b[0], p);
     D.exits.forEach(function (e) {


### PR DESCRIPTION
## Summary

Re-skins the web GUI from the warm cream "paper lab" palette to a **warm dark** one, keeping the clay accent identity, fonts, radius, and FED tenability tier colours unchanged. **MonsterUI is kept** — no dependency drop.

This is the dark-theme piece of the stalled #29 (`gregory/smokerender`). #29's files are stale relative to `main` (the smoke/speed/FED work from #36/#37 landed since), so this was **re-skinned onto current `main`** rather than porting #29's files, and it takes the smaller path #29 didn't: swap the shadcn-style design tokens instead of dropping MonsterUI.

## Changes

- **`theme.py`** — swap the `:root` design tokens (`background`, `foreground`, `card`, `popover`, `secondary`, `muted`, `accent`, `destructive`, `border`, `input`, `ring`) to dark values + `color-scheme: dark`. MonsterUI inherits the palette via `html.uk-theme-blue`, so franken-ui components follow automatically. Then flip the remaining hardcoded light literals that don't come from tokens: engineering-grid lines, `.uk-input` / `.uk-btn-secondary` / `.eq` (equation box) backgrounds, `.traj-canvas` gradient, card inset highlight, ghost-hover colour.
- **`plots.py`** — `plotly_dark` template with light font/grid (background was already transparent, so charts sit on the dark card).
- **`trajviz.py`** — canvas colours that assumed a light ground (walkable-area fill/stroke, smoke tint, FED scrubber cursor, agent-dot stroke) flipped to read on dark.

## Verification (ran the real app)

Installed the GUI deps locally and drove the running app with a headless browser (`jupedsim` + `pedpy` + `fasthtml` + `monsterui` + `plotly`), so **real MonsterUI CSS** was exercised — the actual risk of "keep MonsterUI + swap tokens". Confirmed on the dark theme:

- Index/form: cards, accordions, inputs, toggles, primary (clay) + secondary buttons, tier badges — all correct contrast.
- Results view after a demo run: dark trajectory canvas (walkable outline + clay exits visible), metric cards, console.
- A **populated Plotly chart** (constant-extinction run): transparent bg, light axis labels/ticks, faint grid, palette lines.
- MODEL/docs tab: KaTeX equation boxes now dark (were bright light boxes — fixed).
- Two light-leak bugs caught and fixed via screenshots: `.uk-btn-secondary` (light-on-light browse buttons) and `.eq` equation boxes.

`tests/test_trajviz.py` + `tests/test_webapp.py`: **17 pass**. `ruff format --check` + `ruff check`: clean.

**Unverified surface (honest):** the FED live sparkline panel needs an FDS field to populate FED data, which isn't available locally — same ceiling as #37. Its colours are token/tier/clay-based, verified to read on dark elsewhere in the UI.

Screenshots shared with the maintainer in the working session.