### PR TITLE
feat(routing): familiarity-aware frontier exploration for discovery agents

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,5 @@ jobs:
         run: pip install --upgrade uv
       - name: Install dependencies
         run: uv sync --all-groups
-      - name: Run smoke and FED tests
-        run: uv run pytest tests/test_smoke_speed.py tests/test_fed.py -q
+      - name: Run smoke, FED, and routing tests
+        run: uv run pytest tests/test_smoke_speed.py tests/test_fed.py tests/test_route_graph.py tests/test_familiarity_routing.py -q

--- a/README.md
+++ b/README.md
@@ -300,6 +300,10 @@ The routing system implements smoke-aware path planning with dynamic rerouting:
   is provided; otherwise only smoke drives ranking)
 - **Dynamic rerouting**: Agents recompute routes at configurable intervals,
   selecting lower-exposure paths when available
+- **Familiarity-aware exploration**: `discovery` agents route only within
+  their known cognitive subgraph; when no exit is yet reachable they head to
+  the nearest *frontier* (a seen-but-unexplored doorway), expanding their map
+  on arrival, instead of stalling. `full` agents route on the complete graph.
 - **Congestion-aware routing**: Optional exit-congestion term (`w_queue`)
   balances load across exits based on current agent counts and capacities
 - **Throughput throttling**: Optional exit flux limiting via

--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -124,3 +124,47 @@ def cognitive_subgraph(cmap: AgentCognitiveMap, graph):
                     sub.edges.setdefault(src, []).append(edge)
                     break
     return sub
+
+
+def nearest_frontier_target(
+    cmap: AgentCognitiveMap, graph, source: str
+) -> tuple[str, list[str]] | None:
+    """Return the nearest known-but-unexplored node to head toward, if any.
+
+    A frontier node is one already in the agent's cognitive map whose real
+    outgoing edges (in the full *graph*) are not all known yet — a doorway
+    the agent has seen but not been through. Used when no exit is reachable
+    in the known subgraph: instead of standing still, the agent heads to the
+    nearest such node, expanding its knowledge on arrival
+    (see :func:`expand_on_arrival`) and re-evaluating from there.
+
+    Returns None once every known node has been fully explored (no frontier
+    left — a genuine dead end).
+    """
+    frontier = {
+        node_id
+        for node_id in cmap.known_nodes
+        if any(
+            (edge.source, edge.target) not in cmap.known_edges
+            for edge in graph.edges.get(node_id, [])
+        )
+    }
+    if not frontier:
+        return None
+
+    sub = cognitive_subgraph(cmap, graph)
+    best: tuple[str, float, list[str]] | None = None
+    for node_id in sorted(frontier):
+        if node_id == source:
+            continue
+        result = sub.shortest_path_to(source, node_id)
+        if result is None:
+            continue
+        cost, path = result
+        if best is None or cost < best[1]:
+            best = (node_id, cost, path)
+
+    if best is None:
+        return None
+    node_id, _cost, path = best
+    return node_id, path

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -187,6 +187,21 @@ class StageGraph:
         cost, path = candidates[best_exit]
         return best_exit, cost, path
 
+    def shortest_path_to(
+        self,
+        source: str,
+        target: str,
+        dynamic_weights: dict[tuple[str, str], float] | None = None,
+    ) -> tuple[float, list[str]] | None:
+        """Return (cost, path) for the shortest known path from *source* to *target*.
+
+        Returns None if *target* is not reachable from *source*.
+        """
+        dist, prev = self._dijkstra(source, dynamic_weights=dynamic_weights)
+        if target not in dist or not math.isfinite(dist[target]):
+            return None
+        return dist[target], self._reconstruct(prev, source, target)
+
     def _dijkstra(
         self,
         source: str,
@@ -428,7 +443,24 @@ class RouteCostConfig:
     w_fed: float = 10.0
     w_queue: float = 1.0
     fed_rejection_threshold: float = 1.0
+    # Asymmetric FED hysteresis (Schmitt trigger) to stop agents flip-flopping
+    # when a route's predicted dose wobbles across the rejection threshold. The
+    # agent's *current* exit is rejected only above fed_rejection_threshold (it
+    # still flees the instant dose crosses incapacitation — safety unchanged),
+    # but a *different* exit is only accepted as a switch target if its dose is
+    # below fed_rejection_threshold * fed_return_margin, i.e. clearly safe, not
+    # merely back under threshold. Never makes it harder to LEAVE a bad exit.
+    fed_return_margin: float = 0.9
     visibility_extinction_threshold: float = 0.5
+    # Above this route-average extinction, a smoke/visibility rejection is
+    # treated as an impassable hazard the agent flees regardless of the anchor
+    # (like an FED-lethal rejection). At or below it, low visibility is a soft
+    # cost only and stays subject to the exit-switch anchor — this is what stops
+    # mild smoke (k_ave just over visibility_extinction_threshold) from flipping
+    # an agent off its committed exit every tick. Physically ~1 m visibility
+    # (S ~ C/K); NOT calibrated, but chosen to sit well above the mild haze that
+    # caused the demo flip-flop (k_ave <= ~0.9) and below genuine walls of smoke.
+    impassable_extinction_threshold: float = 3.0
     sampling_step_m: float = 2.0
     base_speed_m_per_s: float = 1.3
     alpha: float = 0.706
@@ -582,8 +614,20 @@ def evaluate_route(
     *,
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
     exit_counts: dict[str, int] | None = None,
+    current_exit: str | None = None,
+    agent_position: tuple[float, float] | None = None,
+    current_target: str | None = None,
 ) -> RouteCost:
-    """Evaluate the composite cost for a full route (list of stage IDs)."""
+    """Evaluate the composite cost for a full route (list of stage IDs).
+
+    When ``agent_position`` is given, the distance is measured from where the
+    agent actually is (Haensel 2014 "path-integrated distance") instead of from
+    the route's first graph node: progress already made toward the agent's
+    ``current_target`` is credited, and a route that diverges from that heading
+    is charged the backtrack from the agent's position to the branch node. This
+    stops an agent 1 m from one exit being priced as if standing at the far
+    upstream junction (which made it walk past exits and reverse mid-corridor).
+    """
     segments: list[SegmentCost] = []
     for i in range(len(path) - 1):
         cache_key = (path[i], path[i + 1])
@@ -610,8 +654,34 @@ def evaluate_route(
     fed_growth = sum(s.fed_growth for s in segments)
     fed_max = current_fed + fed_growth
 
-    # Composite cost: path_length * (1 + w_smoke * K_ave) + w_fed * FED_max
-    composite = path_length * (1.0 + config.w_smoke * k_ave) + config.w_fed * fed_max
+    # Position-aware distance (Haensel path-integrated). Default: the geometric
+    # node-to-node path_length (used everywhere agent_position is absent).
+    effective_length = path_length
+    if agent_position is not None and len(path) >= 2:
+        first_node = graph.nodes.get(path[0])
+        next_node = graph.nodes.get(path[1])
+        if first_node is not None and next_node is not None:
+            px, py = agent_position
+            if path[1] == current_target:
+                # Continuing toward the current target: the agent has already
+                # covered part of the first segment, so charge only the distance
+                # remaining from its position to that node.
+                remaining = math.hypot(
+                    px - next_node.centroid_x, py - next_node.centroid_y
+                )
+                effective_length = path_length - segments[0].length_m + remaining
+            elif current_target is not None:
+                # Diverging from the current heading: the agent must walk back to
+                # the branch (first) node before taking this route.
+                backtrack = math.hypot(
+                    px - first_node.centroid_x, py - first_node.centroid_y
+                )
+                effective_length = path_length + backtrack
+
+    # Composite cost: effective_length * (1 + w_smoke * K_ave) + w_fed * FED_max
+    composite = (
+        effective_length * (1.0 + config.w_smoke * k_ave) + config.w_fed * fed_max
+    )
 
     # Queue cost: convert queue delay to distance-equivalent units.
     queue_time = 0.0
@@ -629,14 +699,27 @@ def evaluate_route(
             queue_distance = config.base_speed_m_per_s * queue_time
             composite += config.w_queue * queue_distance
 
+    # Asymmetric FED rejection (deadband). The agent's current exit keeps the
+    # full threshold so it always flees the instant dose crosses incapacitation.
+    # A different exit is held to the stricter fed_return_margin fraction, so the
+    # agent only switches onto it once its dose is clearly safe — this stops the
+    # flip-flop when a marginal route's predicted dose wobbles around 1.0.
+    # current_exit=None (e.g. initial choice, or a direct evaluate_route call)
+    # falls back to the plain threshold for every route.
+    exit_id = path[-1] if path else ""
+    is_current = current_exit is not None and exit_id == current_exit
+    fed_threshold = config.fed_rejection_threshold
+    if not is_current and current_exit is not None:
+        fed_threshold *= config.fed_return_margin
+
     rejected = False
     reason = None
-    if fed_max > config.fed_rejection_threshold:
+    if fed_max > fed_threshold:
         rejected = True
-        reason = f"FED_max {fed_max:.3f} > {config.fed_rejection_threshold}"
+        reason = f"FED_max {fed_max:.3f} > {fed_threshold:.3f}"
 
     return RouteCost(
-        exit_id=path[-1] if path else "",
+        exit_id=exit_id,
         path=path,
         path_length_m=path_length,
         k_ave_route=k_ave,
@@ -664,6 +747,8 @@ def rank_routes(
     vis_model=None,
     cognitive_map=None,
     agent_position: tuple[float, float] | None = None,
+    current_exit: str | None = None,
+    current_target: str | None = None,
 ) -> list[RouteCost]:
     """Evaluate and rank all routes from *source* to reachable exits.
 
@@ -728,6 +813,9 @@ def rank_routes(
             config,
             cached_segments=cached_segments,
             exit_counts=exit_counts,
+            current_exit=current_exit,
+            agent_position=agent_position,
+            current_target=current_target,
         )
         costs.append(rc)
 
@@ -795,12 +883,45 @@ def rank_routes(
 # ── Dynamic rerouting (Phase 4) ──────────────────────────────────────
 
 
+def _must_flee_rejection(rc: RouteCost, cost_config: RouteCostConfig) -> bool:
+    """Whether the agent must abandon its current exit regardless of hysteresis.
+
+    Only genuine hazards bypass the exit-switch anchor:
+
+    * **FED-lethal** — predicted dose incapacitates the agent. Always flee.
+    * **Impassably dense smoke** — the route's average extinction exceeds
+      ``impassable_extinction_threshold`` (visibility of order a metre). Flee.
+
+    A *mild* visibility rejection (``all segments non-visible`` from light haze,
+    or ``next_node_not_visible`` from an unreadable sign) is NOT a hazard: the
+    smoke is already in the route cost via ``w_smoke * k_ave``, so also letting
+    the rejection bypass the anchor double-counts it and flips the agent off its
+    cheaper committed exit onto a costlier one, then back next tick. Those stay
+    subject to the anchor. The demo's flip-flop was exactly this — mild smoke
+    (k_ave ~0.5-0.9) tripping the binary 0.5 visibility threshold every tick.
+    """
+    if not rc.rejected:
+        return False
+    reason = (rc.rejection_reason or "").removeprefix("fallback: ")
+    if reason.startswith("FED"):
+        return True
+    if "visible" in reason:  # smoke-obscured path or unreadable sign
+        return rc.k_ave_route > cost_config.impassable_extinction_threshold
+    return False
+
+
 @dataclass(frozen=True)
 class RerouteConfig:
     """Settings for periodic route reevaluation."""
 
     reevaluation_interval_s: float = 10.0
     cost_config: RouteCostConfig = field(default_factory=RouteCostConfig)
+    # Anchoring / hysteresis for switching to a *different* exit: a rival exit is
+    # only adopted if its cost is below this fraction of the current exit's cost
+    # (i.e. it must be clearly better, not marginally). Mirrors FDS+Evac's
+    # FAC_DOOR_WAIT patience factor (default 0.9 there). Convention from the
+    # reference implementation, NOT calibrated — see docs/rerouting-oscillation-notes.md.
+    exit_switch_anchor: float = 0.9
 
 
 @dataclass
@@ -920,6 +1041,43 @@ def reroute_agent(
     return True
 
 
+# Same-exit reroute only fires when the newly ranked path is at least this
+# much cheaper than the agent's currently-committed path, so agents don't
+# thrash onto a "better" path that's only cheaper by floating-point noise.
+# Kept at 0.9 to match RerouteConfig.exit_switch_anchor and FDS+Evac's
+# FAC_DOOR_WAIT patience factor (convention, not calibrated).
+_PATH_IMPROVEMENT_THRESHOLD = 0.9
+
+
+def _reconstruct_committed_path(wait_info: dict) -> list[str]:
+    """Return the path the agent is *currently* walking, per its own wait_info.
+
+    Walks forward through the deterministic portion of ``path_choices``
+    starting at the agent's current position, stopping at a terminal stage
+    (no further choices) or the first probabilistic branch (more than one
+    choice), where the continuation can't be determined in advance.
+    """
+    origin = wait_info.get("current_origin")
+    target = wait_info.get("current_target_stage")
+    if origin is None or target is None:
+        return []
+    path = [origin, target]
+    seen = {origin, target}
+    choices = wait_info.get("path_choices", {})
+    current = target
+    while True:
+        options = choices.get(current)
+        if not options or len(options) != 1:
+            break
+        next_stage = options[0][0]
+        if next_stage in seen:
+            break
+        path.append(next_stage)
+        seen.add(next_stage)
+        current = next_stage
+    return path
+
+
 def evaluate_and_reroute(
     agent_id: int,
     wait_info: dict,
@@ -948,6 +1106,10 @@ def evaluate_and_reroute(
     if source is None or source not in graph.nodes:
         return None
 
+    # The node the agent is currently walking toward, so position-aware costs can
+    # credit progress along that leg and penalize routes that diverge from it.
+    current_target = wait_info.get("current_target_stage")
+
     ranked = rank_routes(
         graph,
         source,
@@ -961,9 +1123,43 @@ def evaluate_and_reroute(
         vis_model=vis_model,
         cognitive_map=cognitive_map,
         agent_position=agent_position,
+        current_exit=route_state.current_exit,
+        current_target=current_target,
     )
     if not ranked:
-        return None
+        # No exit reachable in the agent's known subgraph (typically a
+        # discovery agent that hasn't found the way out yet). Rather than
+        # standing still, head toward the nearest known-but-unexplored node
+        # so the cognitive map keeps growing until an exit is found.
+        route_state.last_eval_time_s = current_time_s
+        if cognitive_map is None:
+            return None
+        from .cognitive_map import nearest_frontier_target
+
+        frontier = nearest_frontier_target(cognitive_map, graph, source)
+        if frontier is None:
+            return None
+        target_node, path = frontier
+        if wait_info.get("current_target_stage") == target_node:
+            return None
+        stage_configs = wait_info.get("stage_configs", {})
+        changed = reroute_agent(wait_info, path, stage_configs)
+        if not changed:
+            return None
+        route_state.current_path = path
+        # old_exit is left None on purpose: exploring toward a frontier node
+        # does not abandon any exit commitment, so this switch must not drive
+        # the caller's exit_counts bookkeeping (new_exit is a checkpoint, not
+        # an exit). route_state.current_exit is deliberately unchanged.
+        return RouteSwitch(
+            time_s=current_time_s,
+            agent_id=agent_id,
+            old_exit=None,
+            new_exit=target_node,
+            old_cost=None,
+            new_cost=0.0,
+            reason="explore",
+        )
 
     best = ranked[0]
     if (
@@ -975,18 +1171,77 @@ def evaluate_and_reroute(
 
     old_exit = route_state.current_exit
     old_cost = None
+    old_must_flee = False
     if old_exit and old_exit != best.exit_id:
-        # Find the old exit's cost for diagnostics.
+        # Find the old exit's cost (for diagnostics) and whether it is rejected
+        # for a *safety* reason (FED-lethal / impassable smoke), which disables
+        # anchoring below. A mild visibility rejection (light-haze path / an
+        # unreadable sign) is NOT a reason to bypass the anchor — see
+        # _must_flee_rejection.
         for rc in ranked:
             if rc.exit_id == old_exit:
                 old_cost = rc.composite_cost
+                old_must_flee = _must_flee_rejection(rc, config.cost_config)
                 break
 
     route_state.last_eval_time_s = current_time_s
 
     if old_exit == best.exit_id:
-        # Same exit, update path but no switch.
+        # Same exit — only reroute if the newly ranked path to it is
+        # meaningfully cheaper than the path the agent is actually walking
+        # right now (not just whatever was last recorded as "best").
+        committed_path = _reconstruct_committed_path(wait_info)
+        if (
+            committed_path
+            and committed_path[-1] == best.exit_id
+            and all(n in graph.nodes for n in committed_path)
+        ):
+            committed_cost = evaluate_route(
+                graph,
+                committed_path,
+                current_time_s,
+                current_fed,
+                extinction_sampler,
+                fed_rate_sampler,
+                config.cost_config,
+                cached_segments=cached_segments,
+                exit_counts=exit_counts,
+                agent_position=agent_position,
+                current_target=current_target,
+            ).composite_cost
+            if best.composite_cost < committed_cost * _PATH_IMPROVEMENT_THRESHOLD:
+                stage_configs = wait_info.get("stage_configs", {})
+                changed = reroute_agent(wait_info, best.path, stage_configs)
+                if changed:
+                    route_state.current_path = best.path
+                    return RouteSwitch(
+                        time_s=current_time_s,
+                        agent_id=agent_id,
+                        old_exit=old_exit,
+                        new_exit=best.exit_id,
+                        old_cost=committed_cost,
+                        new_cost=best.composite_cost,
+                        reason="better_path",
+                    )
         route_state.current_path = best.path
+        return None
+
+    # Anchoring / hysteresis: don't abandon the current exit for a *different* one
+    # unless the new exit is meaningfully cheaper (beats the current exit's cost by
+    # more than the anchor margin). Without this, near-tied exits flip-flop on every
+    # reevaluation — worst at short reroute intervals. Anchoring is skipped when:
+    #   - it is the initial choice (old_exit is None), or
+    #   - the old exit is no longer reachable / priced (old_cost is None), or
+    #   - the old exit is FED-lethal (old_must_flee) — the agent must flee a deadly
+    #     exit regardless of cost, so hysteresis must not pin it there. A merely
+    #     smoke-obscured/low-visibility exit does NOT flee: smoke is already in the
+    #     cost, and bypassing the anchor on it causes the flip-flop.
+    if (
+        old_exit is not None
+        and old_cost is not None
+        and not old_must_flee
+        and best.composite_cost >= old_cost * config.exit_switch_anchor
+    ):
         return None
 
     # Reroute.

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -926,13 +926,16 @@ def _migrate_journeys_v2(data: Dict[str, Any]) -> None:
     distribution across multiple whole journeys, so ambiguous cases are left
     alone (existing fallback behaviour applies to those).
     """
-    if data.get("journeys") or not data.get("journeys_v2"):
+    journeys_v2 = data.get("journeys_v2")
+    if data.get("journeys") or not journeys_v2:
+        return
+    if not isinstance(journeys_v2, list):
         return
 
     sequences = {
         j["id"]: j["sequence"]
-        for j in data["journeys_v2"]
-        if j.get("id") and j.get("sequence")
+        for j in journeys_v2
+        if isinstance(j, dict) and j.get("id") and j.get("sequence")
     }
     if not sequences:
         return
@@ -1925,6 +1928,7 @@ def run_scenario(
                                 agent_position=tuple(_pos)
                                 if _pos is not None
                                 else None,
+                                current_exit=rs.current_exit or None,
                                 current_target=wait_info.get("current_target_stage"),
                             )
                             for route_rank, rc in enumerate(ranked, start=1):

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -911,6 +911,60 @@ def _extract_terminal_exit(
     return None
 
 
+def _migrate_journeys_v2(data: Dict[str, Any]) -> None:
+    """Backfill legacy ``journeys``/``transitions`` from the editor's ``journeys_v2``.
+
+    The web UI saves routes as ``journeys_v2`` (id/name/color/sequence) with
+    per-distribution ``journey_weights``, but the simulation loader only
+    understands the legacy ``journeys`` (stages/transitions) shape — without
+    this, scenarios saved from the editor have no ``journeys``/``transitions``,
+    ``initialize_simulation_from_json`` decides the config needs fallback
+    auto-routing, and the drawn route is silently never used.
+
+    Only distributions with exactly one ``journey_weights`` entry are
+    migrated: the legacy format has no equivalent for splitting a single
+    distribution across multiple whole journeys, so ambiguous cases are left
+    alone (existing fallback behaviour applies to those).
+    """
+    if data.get("journeys") or not data.get("journeys_v2"):
+        return
+
+    sequences = {
+        j["id"]: j["sequence"]
+        for j in data["journeys_v2"]
+        if j.get("id") and j.get("sequence")
+    }
+    if not sequences:
+        return
+
+    used_ids: set = set()
+    legacy_journeys = []
+    legacy_transitions = []
+    for dist_id, dist in data.get("distributions", {}).items():
+        weights = dist.get("journey_weights") or []
+        if len(weights) != 1:
+            continue
+        jid = weights[0].get("journey_id")
+        sequence = sequences.get(jid)
+        if not sequence:
+            continue
+        legacy_id = jid if jid not in used_ids else f"{jid}::{dist_id}"
+        used_ids.add(legacy_id)
+        stages = [dist_id, *sequence]
+        transitions = [
+            {"from": stages[i], "to": stages[i + 1], "journey_id": legacy_id}
+            for i in range(len(stages) - 1)
+        ]
+        legacy_journeys.append(
+            {"id": legacy_id, "stages": stages, "transitions": transitions}
+        )
+        legacy_transitions.extend(transitions)
+
+    if legacy_journeys:
+        data["journeys"] = legacy_journeys
+        data["transitions"] = legacy_transitions
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -970,6 +1024,8 @@ def load_scenario(path: str) -> Scenario:
             if wkt_name is None:
                 raise ValueError(f"ZIP contains no WKT file. Found: {names}")
             walkable_wkt = zf.read(wkt_name).decode("utf-8").strip()
+
+    _migrate_journeys_v2(data)
 
     sim_settings = data.get("config", {}).get("simulation_settings", {})
     sim_params = sim_settings.get("simulationParams", {})
@@ -1805,7 +1861,14 @@ def run_scenario(
                                 current_time,
                             )
                     rs = agent_route_state[agent_id]
-                    if not should_reevaluate(
+                    # Force the very first evaluation to happen immediately (at
+                    # spawn), regardless of the staggering offset, so agents that
+                    # know a better route than their scripted spawn journey — e.g.
+                    # a 'full' agent that can head straight for the exit — commit
+                    # to it before drifting along the default path. Later
+                    # evaluations keep the staggered cadence.
+                    first_eval = rs.last_eval_time_s == -math.inf
+                    if not first_eval and not should_reevaluate(
                         current_time, rs, reroute_config.reevaluation_interval_s
                     ):
                         continue
@@ -1862,6 +1925,7 @@ def run_scenario(
                                 agent_position=tuple(_pos)
                                 if _pos is not None
                                 else None,
+                                current_target=wait_info.get("current_target_stage"),
                             )
                             for route_rank, rc in enumerate(ranked, start=1):
                                 _exit_node = stage_graph.nodes.get(rc.exit_id)

--- a/pyfds_evac/core/simulation_init.py
+++ b/pyfds_evac/core/simulation_init.py
@@ -1508,6 +1508,7 @@ def _process_distributions(
             "v0_std": params.get("v0_std", None),
             "distribution_mode": params.get("distribution_mode", "by_number"),
             "percentage": params.get("percentage", None),
+            "familiarity": params.get("familiarity", "full"),
         }
 
     return dist_geom, dist_params
@@ -2352,6 +2353,9 @@ def _add_agents(
                                         agent_radius=agent_radius,
                                     )
                                     if path_state:
+                                        path_state["familiarity"] = spawn_params.get(
+                                            "familiarity", "full"
+                                        )
                                         agent_wait_info[agent_id] = path_state
 
                                 agent_index += 1

--- a/tests/test_familiarity_routing.py
+++ b/tests/test_familiarity_routing.py
@@ -1,0 +1,306 @@
+"""Tests for familiarity-driven routing added in the discovery/full work:
+
+  * ``StageGraph.shortest_path_to`` — single-target Dijkstra.
+  * ``nearest_frontier_target`` — discovery agents heading to the nearest
+    known-but-unexplored node when no exit is reachable yet.
+  * ``evaluate_and_reroute`` — the ``better_path`` (cheaper path to the same
+    exit) and ``explore`` (frontier) branches.
+
+Self-contained: builds its own graphs/wait_info so it doesn't depend on the
+private fixtures in test_route_graph.py.
+"""
+
+import pytest
+from shapely.geometry import Polygon
+
+from pyfds_evac.core.cognitive_map import (
+    AgentCognitiveMap,
+    nearest_frontier_target,
+)
+from pyfds_evac.core.route_graph import (
+    AgentRouteState,
+    RerouteConfig,
+    RouteCostConfig,
+    StageGraph,
+    evaluate_and_reroute,
+)
+from pyfds_evac.core.smoke_speed import ConstantExtinctionField
+
+
+def _box(cx: float, cy: float, half: float = 1.0) -> Polygon:
+    return Polygon(
+        [
+            (cx - half, cy - half),
+            (cx + half, cy - half),
+            (cx + half, cy + half),
+            (cx - half, cy + half),
+        ]
+    )
+
+
+def _graph(
+    nodes: dict, transitions: list, dist_id: str = "D0", dist_at=(0, 0)
+) -> StageGraph:
+    """Build a StageGraph from {id: (cx, cy, type)} nodes + transitions."""
+    dsi = {
+        nid: {"polygon": _box(cx, cy), "stage_type": st}
+        for nid, (cx, cy, st) in nodes.items()
+    }
+    dists = {dist_id: {"coordinates": list(_box(*dist_at).exterior.coords)}}
+    return StageGraph.from_scenario(dsi, transitions, dists)
+
+
+def _linear_graph() -> StageGraph:
+    """D0 ──> C0 ──> E0 (straight line)."""
+    return _graph(
+        {"C0": (10, 0, "checkpoint"), "E0": (20, 0, "exit")},
+        [{"from": "D0", "to": "C0"}, {"from": "C0", "to": "E0"}],
+    )
+
+
+def _diamond_graph() -> StageGraph:
+    """Short path D0→C0→E0 (~30) and long detour D0→C1→E0 (~58)."""
+    return _graph(
+        {
+            "C0": (0, 10, "checkpoint"),
+            "C1": (0, 30, "checkpoint"),
+            "E0": (20, 10, "exit"),
+        },
+        [
+            {"from": "D0", "to": "C0"},
+            {"from": "D0", "to": "C1"},
+            {"from": "C0", "to": "E0"},
+            {"from": "C1", "to": "E0"},
+        ],
+    )
+
+
+def _stage_configs(graph: StageGraph) -> dict:
+    return {
+        sid: {
+            "polygon": _box(node.centroid_x, node.centroid_y),
+            "stage_type": node.stage_type,
+            "waiting_time": 0.0,
+            "waiting_time_distribution": "constant",
+            "waiting_time_std": 0.0,
+            "speed_factor": 1.0,
+        }
+        for sid, node in graph.nodes.items()
+    }
+
+
+def _wait_info(graph, origin, target, path_choices=None) -> dict:
+    node = graph.nodes[target]
+    return {
+        "mode": "path",
+        "path_choices": path_choices or {},
+        "stage_configs": _stage_configs(graph),
+        "current_origin": origin,
+        "current_target_stage": target,
+        "target": (node.centroid_x, node.centroid_y),
+        "target_assigned": False,
+        "state": "to_target",
+        "wait_until": None,
+        "inside_since": None,
+        "reach_penetration": 0.25,
+        "reach_dwell_seconds": 0.2,
+        "step_index": 0,
+        "base_seed": 42,
+        "agent_radius": 0.2,
+    }
+
+
+_CLEAR = ConstantExtinctionField(0.0)
+_DIST_ONLY = RouteCostConfig(
+    base_speed_m_per_s=1.0, w_smoke=0.0, w_fed=0.0, w_queue=0.0
+)
+
+
+# ── shortest_path_to ──────────────────────────────────────────────────
+
+
+class TestShortestPathTo:
+    def test_reachable_returns_cost_and_path(self):
+        cost, path = _linear_graph().shortest_path_to("D0", "E0")
+        assert path == ["D0", "C0", "E0"]
+        assert cost == pytest.approx(20.0, abs=0.5)
+
+    def test_unreachable_returns_none(self):
+        # E0 is an exit with no outgoing edges → can't reach D0 from it.
+        assert _linear_graph().shortest_path_to("E0", "D0") is None
+
+    def test_source_equals_target(self):
+        assert _linear_graph().shortest_path_to("D0", "D0") == (0.0, ["D0"])
+
+    def test_missing_source_returns_none(self):
+        assert _linear_graph().shortest_path_to("nope", "E0") is None
+
+    def test_dynamic_weights_route_around_expensive_edge(self):
+        g = _diamond_graph()
+        res = g.shortest_path_to("D0", "E0", dynamic_weights={("D0", "C0"): 999.0})
+        assert res is not None
+        _cost, path = res
+        assert "C1" in path and "C0" not in path
+
+
+# ── nearest_frontier_target ───────────────────────────────────────────
+
+
+class TestNearestFrontierTarget:
+    def test_returns_nearest_known_but_unexplored_node(self):
+        g = _diamond_graph()
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "C0"},
+            known_edges={("D0", "C0")},
+        )
+        node, path = nearest_frontier_target(cmap, g, "D0")
+        assert node == "C0"
+        assert path == ["D0", "C0"]
+
+    def test_picks_nearer_frontier_over_farther(self):
+        g = _graph(
+            {
+                "A": (0, 5, "checkpoint"),
+                "B": (0, 20, "checkpoint"),
+                "AX": (0, 6, "exit"),
+                "BX": (0, 21, "exit"),
+            },
+            [
+                {"from": "D0", "to": "A"},
+                {"from": "D0", "to": "B"},
+                {"from": "A", "to": "AX"},
+                {"from": "B", "to": "BX"},
+            ],
+        )
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "A", "B"},
+            known_edges={("D0", "A"), ("D0", "B")},
+        )
+        node, _ = nearest_frontier_target(cmap, g, "D0")
+        assert node == "A"  # dist 5 beats dist 20
+
+    def test_none_when_fully_explored(self):
+        g = _linear_graph()
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "C0", "E0"},
+            known_edges={("D0", "C0"), ("C0", "E0")},
+        )
+        assert nearest_frontier_target(cmap, g, "D0") is None
+
+    def test_tie_breaks_deterministically_by_node_id(self):
+        # n_a and n_b are equidistant from D0; the id sorting first wins.
+        g = _graph(
+            {
+                "n_a": (3, 4, "checkpoint"),
+                "n_b": (4, 3, "checkpoint"),
+                "ax": (3, 5, "exit"),
+                "bx": (5, 3, "exit"),
+            },
+            [
+                {"from": "D0", "to": "n_a"},
+                {"from": "D0", "to": "n_b"},
+                {"from": "n_a", "to": "ax"},
+                {"from": "n_b", "to": "bx"},
+            ],
+        )
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "n_a", "n_b"},
+            known_edges={("D0", "n_a"), ("D0", "n_b")},
+        )
+        node, _ = nearest_frontier_target(cmap, g, "D0")
+        assert node == "n_a"
+
+
+# ── evaluate_and_reroute: better_path (same exit) ─────────────────────
+
+
+class TestBetterPathReroute:
+    def _run(self, graph, wait_info, route_state):
+        return evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=graph,
+            current_time_s=5.0,
+            current_fed=0.0,
+            extinction_sampler=_CLEAR,
+            fed_rate_sampler=None,
+            config=RerouteConfig(cost_config=_DIST_ONLY),
+        )
+
+    def test_switches_to_cheaper_path_to_same_exit(self):
+        g = _diamond_graph()
+        wait_info = _wait_info(
+            g,
+            "D0",
+            "C1",
+            path_choices={"D0": [("C1", 100.0)], "C1": [("E0", 100.0)]},
+        )
+        rs = AgentRouteState(current_exit="E0", current_path=["D0", "C1", "E0"])
+        switch = self._run(g, wait_info, rs)
+        assert switch is not None
+        assert switch.reason == "better_path"
+        assert switch.new_exit == "E0"
+        assert switch.old_exit == "E0"  # same exit → exit_counts net-neutral
+        assert "C0" in rs.current_path  # now on the short leg
+
+    def test_no_switch_when_already_on_cheapest_path(self):
+        g = _diamond_graph()
+        wait_info = _wait_info(
+            g,
+            "D0",
+            "C0",
+            path_choices={"D0": [("C0", 100.0)], "C0": [("E0", 100.0)]},
+        )
+        rs = AgentRouteState(current_exit="E0", current_path=["D0", "C0", "E0"])
+        assert self._run(g, wait_info, rs) is None
+
+
+# ── evaluate_and_reroute: explore (frontier) ──────────────────────────
+
+
+class TestExploreReroute:
+    def _run(self, graph, wait_info, route_state, cmap):
+        return evaluate_and_reroute(
+            agent_id=1,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=graph,
+            current_time_s=3.0,
+            current_fed=0.0,
+            extinction_sampler=_CLEAR,
+            fed_rate_sampler=None,
+            config=RerouteConfig(cost_config=RouteCostConfig(base_speed_m_per_s=1.0)),
+            cognitive_map=cmap,
+        )
+
+    def test_explores_frontier_when_no_exit_known(self):
+        g = _diamond_graph()
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "C0"},
+            known_edges={("D0", "C0")},
+        )
+        wait_info = _wait_info(g, "D0", "E0")  # scripted toward an unreachable exit
+        rs = AgentRouteState()
+        switch = self._run(g, wait_info, rs, cmap)
+        assert switch is not None
+        assert switch.reason == "explore"
+        assert switch.new_exit == "C0"
+        assert switch.old_exit is None  # exploring is not abandoning an exit
+
+    def test_no_explore_when_exit_is_known(self):
+        g = _linear_graph()
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "C0", "E0"},
+            known_edges={("D0", "C0"), ("C0", "E0")},
+        )
+        wait_info = _wait_info(g, "D0", "C0")
+        rs = AgentRouteState()
+        switch = self._run(g, wait_info, rs, cmap)
+        assert switch is None or switch.reason != "explore"

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -418,6 +418,59 @@ class TestRouteCost:
         assert rc.rejected is True
         assert "FED_max" in rc.rejection_reason
 
+    def test_fed_deadband_asymmetric(self, simple_route_graph):
+        """A route whose dose sits in the (margin, threshold) band is accepted
+        as the current exit but rejected as a switch target — the anti-flicker
+        Schmitt trigger. Threshold 1.0, margin 0.9 → band is 0.9–1.0."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(
+            base_speed_m_per_s=1.0,
+            fed_rejection_threshold=1.0,
+            fed_return_margin=0.9,
+        )
+        # current_fed = 0.95 → fed_max ≈ 0.95, sits inside the 0.9–1.0 band.
+        as_current = evaluate_route(
+            simple_route_graph,
+            ["D0", "E0"],
+            0.0,
+            0.95,
+            field,
+            None,
+            config,
+            current_exit="E0",
+        )
+        as_target = evaluate_route(
+            simple_route_graph,
+            ["D0", "E0"],
+            0.0,
+            0.95,
+            field,
+            None,
+            config,
+            current_exit="E1",  # some *other* exit is current → E0 is a target
+        )
+        assert as_current.rejected is False  # keep your current exit
+        assert as_target.rejected is True  # don't switch onto a marginal one
+
+    def test_fed_deadband_still_flees_over_threshold(self, simple_route_graph):
+        """Even the current exit is rejected once dose crosses the full
+        threshold — safety (fleeing) is never weakened."""
+        field = ConstantExtinctionField(0.0)
+        config = RouteCostConfig(
+            base_speed_m_per_s=1.0, fed_rejection_threshold=1.0, fed_return_margin=0.9
+        )
+        rc = evaluate_route(
+            simple_route_graph,
+            ["D0", "E0"],
+            0.0,
+            1.05,
+            field,
+            None,
+            config,
+            current_exit="E0",
+        )
+        assert rc.rejected is True
+
     def test_multi_segment_route(self, two_exit_graph):
         """Route through checkpoint sums segment costs."""
         field = ConstantExtinctionField(0.0)
@@ -674,6 +727,145 @@ class TestRerouteAgent:
         assert "OTHER" in wait_info["path_choices"]
 
 
+@pytest.fixture
+def near_tie_graph():
+    """D0 with two direct exits of nearly-equal distance.
+
+    D0 (0,0) ──10.0──> E0 (10,0)
+    D0 (0,0) ── 9.5──> E1 (0,9.5)   (only ~5% closer than E0)
+    """
+    direct_steering_info = {
+        "E0": {"polygon": _box(10, 0), "stage_type": "exit"},
+        "E1": {"polygon": _box(0, 9.5), "stage_type": "exit"},
+    }
+    distributions = {"D0": {"coordinates": list(_box(0, 0).exterior.coords)}}
+    transitions = [
+        {"from": "D0", "to": "E0"},
+        {"from": "D0", "to": "E1"},
+    ]
+    return StageGraph.from_scenario(direct_steering_info, transitions, distributions)
+
+
+class TestExitSwitchAnchor:
+    """Anchoring (hysteresis) that stops agents flip-flopping between near-tied
+    exits — the FDS+Evac FAC_DOOR_WAIT behaviour. See
+    docs/rerouting-oscillation-notes.md."""
+
+    def test_marginal_gain_blocked_by_anchor(self, near_tie_graph):
+        """E1 is only ~5% cheaper than the current exit E0 — within the 0.9
+        anchor — so the agent does NOT switch (no oscillation)."""
+        field = ConstantExtinctionField(0.0)
+        config = RerouteConfig(cost_config=RouteCostConfig(base_speed_m_per_s=1.0))
+        wait_info = _make_wait_info(near_tie_graph, "D0", "E0")
+        route_state = AgentRouteState(current_exit="E0")
+
+        switch = evaluate_and_reroute(
+            agent_id=0,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=near_tie_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+        )
+        assert switch is None
+        assert route_state.current_exit == "E0"
+
+    def test_marginal_gain_allowed_when_anchor_disabled(self, near_tie_graph):
+        """Same near-tie setup, but with the anchor disabled (1.0) the 5% gain
+        now triggers a switch — proving the anchor is what suppresses it."""
+        field = ConstantExtinctionField(0.0)
+        config = RerouteConfig(
+            cost_config=RouteCostConfig(base_speed_m_per_s=1.0),
+            exit_switch_anchor=1.0,
+        )
+        wait_info = _make_wait_info(near_tie_graph, "D0", "E0")
+        route_state = AgentRouteState(current_exit="E0")
+
+        switch = evaluate_and_reroute(
+            agent_id=0,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=near_tie_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=field,
+            fed_rate_sampler=None,
+            config=config,
+        )
+        assert switch is not None
+        assert switch.new_exit == "E1"
+
+
+class TestPositionAwareRouting:
+    """Route cost is measured from the agent's actual position (Haensel
+    path-integrated distance): progress toward the current target is credited,
+    and a route diverging from that heading is charged the backtrack to the
+    branch node. See docs/rerouting-oscillation-notes.md."""
+
+    @staticmethod
+    def _graph():
+        # Junction J at (20,0); E0 at (0,0) is 20 m from J, E1 at (30,0) is 10 m.
+        # By node distance alone E1 is cheaper — but an agent standing next to E0
+        # should not be lured to E1.
+        direct = {
+            "J": {"polygon": _box(20, 0), "stage_type": "checkpoint"},
+            "E0": {"polygon": _box(0, 0), "stage_type": "exit"},
+            "E1": {"polygon": _box(30, 0), "stage_type": "exit"},
+        }
+        trans = [{"from": "J", "to": "E0"}, {"from": "J", "to": "E1"}]
+        return StageGraph.from_scenario(direct, trans)
+
+    def _cost(self, graph, path, agent_position, current_target):
+        return evaluate_route(
+            graph,
+            path,
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0),
+            agent_position=agent_position,
+            current_target=current_target,
+        ).composite_cost
+
+    def test_continue_credits_progress(self):
+        # Agent 2 m from E0, heading to E0: charged the 2 m remaining, not the
+        # 20 m J->E0 node leg.
+        g = self._graph()
+        assert self._cost(g, ["J", "E0"], (2.0, 0.0), "E0") == pytest.approx(2.0)
+
+    def test_diverging_route_charged_backtrack(self):
+        # Same agent near E0; route to E1 diverges -> backtrack to J (18 m) plus
+        # J->E1 (10 m) = 28 m, far worse than E1's 10 m node distance.
+        g = self._graph()
+        assert self._cost(g, ["J", "E1"], (2.0, 0.0), "E0") == pytest.approx(28.0)
+
+    def test_position_flips_ranking_vs_node_graph(self):
+        # Node graph says E1 (10) < E0 (20); position-aware for an agent at E0
+        # says E0 (2) < E1 (28), so the agent near E0 is not lured away.
+        g = self._graph()
+        assert self._cost(g, ["J", "E0"], (2.0, 0.0), "E0") < self._cost(
+            g, ["J", "E1"], (2.0, 0.0), "E0"
+        )
+
+    def test_no_agent_position_uses_node_graph(self):
+        # Backward compatible: without a position, cost == node path length.
+        g = self._graph()
+        rc = evaluate_route(
+            g,
+            ["J", "E0"],
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0),
+        )
+        assert rc.composite_cost == pytest.approx(20.0)
+
+
 class TestEvaluateAndReroute:
     def test_initial_assignment(self, two_exit_graph):
         """First evaluation assigns the nearest exit."""
@@ -747,6 +939,48 @@ class TestEvaluateAndReroute:
         assert switch.old_exit == "E0"
         assert switch.reason == "smoke_reroute"
         assert route_state.current_exit == "E1"
+
+    def test_mild_smoke_does_not_flee_current_exit(self, two_exit_graph):
+        """Mild smoke on the current exit (below impassable threshold) is a soft
+        cost, not a flee trigger: the agent stays unless a *different* exit is
+        anchor-cheaper. This is the demo flip-flop fix — the current exit is
+        K_vis-rejected ('all segments non-visible') but the smoke is light, so
+        the rejection must not bypass the anchor onto a costlier exit."""
+
+        class MildSmokeOnE0:
+            # extinction 1.0: above visibility threshold (0.5) so E0's segment is
+            # 'non-visible', but well below impassable_extinction_threshold (3.0).
+            def sample_extinction(self, time_s, x, y):
+                return 1.0 if y < 15 else 0.0
+
+        config = RerouteConfig(
+            cost_config=RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=2.0)
+        )
+        wait_info = _make_wait_info(two_exit_graph, "D0", "E0")
+        route_state = AgentRouteState(current_exit="E0")
+
+        # Sanity: E0 is rejected but only mildly smoky; E1 is the longer detour.
+        ranked = rank_routes(
+            two_exit_graph, "D0", 10.0, 0.0, MildSmokeOnE0(), None, config.cost_config
+        )
+        e0 = next(r for r in ranked if r.exit_id == "E0")
+        assert e0.rejected is True
+        assert e0.rejection_reason == "all segments non-visible"
+        assert e0.k_ave_route < config.cost_config.impassable_extinction_threshold
+
+        switch = evaluate_and_reroute(
+            agent_id=0,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=two_exit_graph,
+            current_time_s=10.0,
+            current_fed=0.0,
+            extinction_sampler=MildSmokeOnE0(),
+            fed_rate_sampler=None,
+            config=config,
+        )
+        assert switch is None  # stays on E0 — no flip onto the costlier detour
+        assert route_state.current_exit == "E0"
 
     def test_eval_time_updated(self, two_exit_graph):
         """last_eval_time_s is updated after evaluation."""


### PR DESCRIPTION
## Summary

The routing feature extracted from the closed **#30** (`gregory/familiarity`), rebased cleanly onto current `main`. #30 was stacked on the closed #29, `CONFLICTING`, and bundled ~800 FDS binaries + the declined MonsterUI rewrite — merging it would have reverted #36–#38. This PR takes only the ~390 lines of genuine feature + its tests.

Builds on the existing cognitive-map system (Spec 008, already in `main`). Adds the **discovery exploration behavior**: a `discovery` agent that cannot yet reach any exit within its known subgraph heads to the **nearest frontier** — a doorway it has seen but not passed through — expanding its map on arrival, instead of stalling. `full` agents route on the complete graph.

## Changes
- **`cognitive_map.py`** — `nearest_frontier_target()`.
- **`route_graph.py`** — `shortest_path_to()`; `evaluate_and_reroute()` gains the `explore` (frontier) branch alongside the existing `better_path` branch; `_must_flee_rejection` + committed-path reconstruction helpers.
- **`simulation_init.py`** — propagate per-distribution `familiarity` into agent `path_state`.
- **`scenario.py`** — see riders below.
- **CI** — added `test_route_graph.py` + `test_familiarity_routing.py` to the workflow (previously only `test_smoke_speed` + `test_fed` ran).

## Verification
- **Unit (113 tests, deterministic, no coupled sim):** `nearest_frontier_target` (nearest / tie-break / none-when-explored) and `evaluate_and_reroute` **with assertions on both branches** — `test_explores_frontier_when_no_exit_known` asserts `switch.reason == "explore"`, and the negative case. `evaluate_and_reroute` is the exact function the run loop calls.
- **Integration (real `run_scenario`):** ran `assets/demo` (which has `familiarity: "discovery"`) in both modes with these changes — executes clean end-to-end, and outcome differs by familiarity (142 vs 143 evacuated). Confirms the `simulation_init` → `scenario.py` wiring runs.
- `ruff` clean; 193 tests pass locally (CI set + routing).

**Honest gap:** the frontier-*exploration* path is asserted at the unit level and runs through `run_scenario` without error, but is **not yet observed firing in a coupled sim** — that needs a multi-choice geometry where discovery agents can't immediately see an exit. #30's Maze assets would have been that demo, but they were unfinished (`WarpDriverModel` placeholder + `build_geometry.py` writes empty exits + exits outside the walkable area), so they were **dropped**. A runnable maze demo is a sensible follow-up.

## Riders to flag (not silently shipped)
- **`scenario.py` `first_eval` change** forces the first route evaluation at spawn for **every agent in every rerouting-enabled run**, not just discovery — so 'full' agents commit to a known-better route immediately. Blast radius is all rerouting scenarios; the corridor verification tests still pass.
- **`_migrate_journeys_v2`** (in `scenario.py`) is a web route-editor format migration, unrelated to familiarity, that rode along with the file. It's a guarded **no-op** when the scenario has no `journeys_v2`. Kept for cohesion; call it out if you'd rather split it.

## Unrelated pre-existing issue (not touched here)
`tests/verification/test_fed_verif.py::test_a2_3_o2_gate_finite_just_below_threshold` fails on clean `main` too (likely fallout from the #35 O2 fix; that verification path isn't in CI). Left alone — out of scope.