### PR TITLE
feat(cli): enable rerouting by default, reroute every 1s

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,8 +44,8 @@ uv run python run.py --scenario <scenario.json|.zip|dir> [options]
 
 | Flag | Purpose |
 |------|---------|
-| `--enable-rerouting` | Let agents re-evaluate exits during the run. |
-| `--reroute-interval S` | Seconds between per-agent reevaluations (default 10). |
+| `--enable-rerouting` / `--no-enable-rerouting` | Let agents re-evaluate exits during the run (on by default). |
+| `--reroute-interval S` | Seconds between per-agent reevaluations (default 1). |
 | `--output-route-history CSV` | Write route switches. |
 | `--output-route-cost-history CSV` | Ranked route cost snapshots. |
 | `--vis-cache PKL` | Vismap pickle cache; gates routes by visibility. Requires `--fds-dir`. |

--- a/run.py
+++ b/run.py
@@ -103,8 +103,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--vis-cache",
         help="Path to vismap .npz cache for visibility-gated route rejection. "
-        "Requires --fds-dir and --enable-rerouting. "
-        "Cache is created if missing, loaded if present.",
+        "Requires --fds-dir and rerouting enabled (on by default; do not pass "
+        "--no-enable-rerouting). Cache is created if missing, loaded if present.",
     )
     parser.add_argument(
         "--disable-tenability",

--- a/run.py
+++ b/run.py
@@ -81,14 +81,16 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--enable-rerouting",
-        action="store_true",
-        help="Enable dynamic smoke-based route reevaluation",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Dynamic smoke/congestion-based route reevaluation "
+        "(default: on; use --no-enable-rerouting to disable)",
     )
     parser.add_argument(
         "--reroute-interval",
         type=float,
-        default=10.0,
-        help="Seconds between route reevaluations per agent (default: 10)",
+        default=1.0,
+        help="Seconds between route reevaluations per agent (default: 1)",
     )
     parser.add_argument(
         "--output-route-history",


### PR DESCRIPTION
## Summary

Flips the rerouting CLI defaults, extracted from the closed #30 (`gregory/familiarity`) and kept **separate** from the familiarity feature (#39) because it changes global behavior for **every** scenario, not just familiarity ones.

- `--enable-rerouting`: `store_true` (default **off**) → `BooleanOptionalAction`, default **on**. Disable with `--no-enable-rerouting`.
- `--reroute-interval`: default **10 s → 1 s**.

## Why separate from #39

The familiarity feature (#39) only re-plans on the rerouting cadence, so `discovery` agents don't explore unless rerouting is enabled. #30 turned it on globally to make that automatic. That's a real behavior + performance change for all scenarios, so it gets its own reviewable PR rather than riding inside a feature.

## Blast radius (be aware)

Every scenario now re-evaluates routes every 1 s by default — **10× more often** than before, and on by default. Without smoke/FED cost differences between routes this is a **no-op** (agents keep their path), but it does more work per step.

## Verification

- Parser: `enable_rerouting` default `True`, `reroute_interval` default `1.0`, `--no-enable-rerouting` → `False`.
- Ran `assets/ISO-table21` end-to-end with the new defaults (rerouting on): completes cleanly, `evacuated=1/1`, no crash.
- `ruff` clean. No stale default references in README/docs.

Pairs with #39 (familiarity frontier exploration) so discovery agents explore out of the box.