### PR TITLE
fix(routing): stop double-charging first-segment FED and smoke mid-leg

### DIFF
--- a/docs/rerouting-oscillation-notes.md
+++ b/docs/rerouting-oscillation-notes.md
@@ -196,6 +196,12 @@ actual position:
 - **A route diverging from that heading** → add the *backtrack* from the agent's position to
   the branch node before the graph distance.
 
+Smoke and FED are credited over the same stretch: the first segment contributes only its
+untraversed share `rho = remaining / segment_length` to `K_ave`, `travel_time` and
+`fed_growth`. The dose taken on the part already walked is inside the agent's `current_fed`,
+so charging the full segment would count it twice and inflate `FED_max` for exactly the
+route the agent is committed to.
+
 Verified against agent 35's real trajectory: t=86 becomes B = 11 vs A = 121 → **stays at B**
 (no walking away); t=102 becomes A = 77 vs B = 137 → **stays at A** (no reversal). Without
 `agent_position` it falls back to the geometric node path length (backward compatible).

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -603,6 +603,47 @@ def evaluate_segment(
     )
 
 
+def _position_aware_length(
+    graph: StageGraph,
+    path: list[str],
+    agent_position: tuple[float, float],
+    current_target: str | None,
+    path_length: float,
+    first_length_m: float,
+) -> tuple[float, float]:
+    """Haensel path-integrated distance measured from the agent's position.
+
+    Returns ``(effective_length, first_share)``, where ``first_share`` is the
+    still-untraversed fraction of the first segment. It is 1.0 unless the route
+    continues toward ``current_target``; then the agent has already covered part
+    of that segment, so only the remainder is ahead of it.
+    """
+    first_node = graph.nodes.get(path[0])
+    next_node = graph.nodes.get(path[1])
+    if first_node is None or next_node is None:
+        return path_length, 1.0
+
+    px, py = agent_position
+    if path[1] == current_target:
+        # Continuing toward the current target: charge only the distance
+        # remaining from the agent's position to that node.
+        remaining = math.hypot(px - next_node.centroid_x, py - next_node.centroid_y)
+        if first_length_m <= 1e-9:
+            return path_length - first_length_m + remaining, 1.0
+        # Floored above zero so an impassable first segment (infinite travel
+        # time) stays infinite even for an agent standing on its end node.
+        share = min(1.0, max(1e-9, remaining / first_length_m))
+        return path_length - first_length_m + remaining, share
+
+    if current_target is not None:
+        # Diverging from the current heading: the agent must walk back to the
+        # branch (first) node before taking this route.
+        backtrack = math.hypot(px - first_node.centroid_x, py - first_node.centroid_y)
+        return path_length + backtrack, 1.0
+
+    return path_length, 1.0
+
+
 def evaluate_route(
     graph: StageGraph,
     path: list[str],
@@ -627,6 +668,9 @@ def evaluate_route(
     is charged the backtrack from the agent's position to the branch node. This
     stops an agent 1 m from one exit being priced as if standing at the far
     upstream junction (which made it walk past exits and reverse mid-corridor).
+    The smoke and FED terms are credited over the same stretch as the distance,
+    so exposure already incurred on the traversed part -- and already carried in
+    ``current_fed`` -- is not charged a second time.
     """
     segments: list[SegmentCost] = []
     for i in range(len(path) - 1):
@@ -648,35 +692,33 @@ def evaluate_route(
         segments.append(seg)
 
     path_length = sum(s.length_m for s in segments)
-    total_k_samples = sum(s.k_avg * s.length_m for s in segments)
-    k_ave = total_k_samples / path_length if path_length > 1e-9 else 0.0
-    travel_time = sum(s.travel_time_s for s in segments)
-    fed_growth = sum(s.fed_growth for s in segments)
-    fed_max = current_fed + fed_growth
 
     # Position-aware distance (Haensel path-integrated). Default: the geometric
     # node-to-node path_length (used everywhere agent_position is absent).
     effective_length = path_length
+    first_share = 1.0
     if agent_position is not None and len(path) >= 2:
-        first_node = graph.nodes.get(path[0])
-        next_node = graph.nodes.get(path[1])
-        if first_node is not None and next_node is not None:
-            px, py = agent_position
-            if path[1] == current_target:
-                # Continuing toward the current target: the agent has already
-                # covered part of the first segment, so charge only the distance
-                # remaining from its position to that node.
-                remaining = math.hypot(
-                    px - next_node.centroid_x, py - next_node.centroid_y
-                )
-                effective_length = path_length - segments[0].length_m + remaining
-            elif current_target is not None:
-                # Diverging from the current heading: the agent must walk back to
-                # the branch (first) node before taking this route.
-                backtrack = math.hypot(
-                    px - first_node.centroid_x, py - first_node.centroid_y
-                )
-                effective_length = path_length + backtrack
+        effective_length, first_share = _position_aware_length(
+            graph,
+            path,
+            agent_position,
+            current_target,
+            path_length,
+            segments[0].length_m,
+        )
+
+    # Exposure is accumulated over the same stretch the distance term charges:
+    # the smoke and FED the agent already took on the traversed part of the first
+    # segment are in current_fed, so charging the full segment would count them
+    # twice and inflate the FED and smoke terms of a route it is midway along.
+    shares = [first_share] + [1.0] * (len(segments) - 1)
+    weighted = list(zip(shares, segments))
+    exposure_length = sum(w * s.length_m for w, s in weighted)
+    total_k_samples = sum(w * s.k_avg * s.length_m for w, s in weighted)
+    k_ave = total_k_samples / exposure_length if exposure_length > 1e-9 else 0.0
+    travel_time = sum(w * s.travel_time_s for w, s in weighted)
+    fed_growth = sum(w * s.fed_growth for w, s in weighted)
+    fed_max = current_fed + fed_growth
 
     # Composite cost: effective_length * (1 + w_smoke * K_ave) + w_fed * FED_max
     composite = (

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -851,6 +851,87 @@ class TestPositionAwareRouting:
             g, ["J", "E1"], (2.0, 0.0), "E0"
         )
 
+    def test_continue_does_not_double_charge_first_segment_fed(self):
+        # The FED taken on the walked part of the first segment is already in
+        # current_fed, so a route continuing toward the current target is
+        # charged only the remaining share -- 2 m of the 20 m J->E0 leg here.
+        g = self._graph()
+        at_node = self._fed_cost(g, (20.0, 0.0))
+        mid_leg = self._fed_cost(g, (2.0, 0.0))
+        assert mid_leg == pytest.approx(0.1 * at_node)
+
+    def test_diverging_route_charges_full_fed(self):
+        # A route the agent has not started walking keeps its full FED growth.
+        g = self._graph()
+        rc = evaluate_route(
+            g,
+            ["J", "E0"],
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            ConstantFedRateSampler(0.1),
+            RouteCostConfig(base_speed_m_per_s=1.0),
+            agent_position=(2.0, 0.0),
+            current_target="E1",
+        )
+        assert rc.fed_max_route == pytest.approx(0.1 * 20.0 / 60.0)
+
+    def test_continue_reweights_k_ave_by_remaining_share(self):
+        # Two-leg route with smoke on the first leg only: an agent that has
+        # walked 8 m of that 10 m leg carries only the remaining fifth of it
+        # into the path mean, so its route looks less smoky than at the node.
+        class SmokyFirstLeg:
+            """K = 1 upstream of the midpoint M at x = 10, clear beyond it."""
+
+            def sample_extinction(self, time_s, x, y):
+                del time_s, y
+                return 1.0 if x > 10.0 else 0.0
+
+        direct = {
+            "J": {"polygon": _box(20, 0), "stage_type": "checkpoint"},
+            "M": {"polygon": _box(10, 0), "stage_type": "checkpoint"},
+            "E0": {"polygon": _box(0, 0), "stage_type": "exit"},
+        }
+        graph = StageGraph.from_scenario(
+            direct, [{"from": "J", "to": "M"}, {"from": "M", "to": "E0"}]
+        )
+
+        def _cost(agent_position):
+            return evaluate_route(
+                graph,
+                ["J", "M", "E0"],
+                0.0,
+                0.0,
+                SmokyFirstLeg(),
+                None,
+                RouteCostConfig(base_speed_m_per_s=1.0),
+                agent_position=agent_position,
+                current_target="M",
+            )
+
+        at_node = _cost((20.0, 0.0))
+        mid_leg = _cost((12.0, 0.0))
+        s0, s1 = at_node.segments
+        rho = 2.0 / 10.0
+        expected = (rho * s0.k_avg * s0.length_m + s1.k_avg * s1.length_m) / (
+            rho * s0.length_m + s1.length_m
+        )
+        assert mid_leg.k_ave_route == pytest.approx(expected)
+        assert mid_leg.k_ave_route < at_node.k_ave_route
+
+    def _fed_cost(self, graph, agent_position):
+        return evaluate_route(
+            graph,
+            ["J", "E0"],
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            ConstantFedRateSampler(0.1),
+            RouteCostConfig(base_speed_m_per_s=1.0),
+            agent_position=agent_position,
+            current_target="E0",
+        ).fed_max_route
+
     def test_no_agent_position_uses_node_graph(self):
         # Backward compatible: without a position, cost == node path length.
         g = self._graph()


### PR DESCRIPTION
Closes #42.

## Problem

Position-aware route evaluation credited the traversed part of the first segment in the **distance term only**. `effective_length` dropped to the remaining distance to the current target, while `k_ave`, `travel_time` and `fed_growth` were still summed over the *full* first segment.

The dose already taken on the walked part is inside the agent's `current_fed`, so adding the full-segment `fed_growth` on top counted it twice. That inflated `FED_max` for exactly the route the agent was already committed to, and could trip the FED rejection for a mid-leg agent where a node-aligned one would pass.

Measured before the fix (uniform `k = 0.5`, FED rate 0.1/min, 20 m leg):

| agent position | effective distance | `fed_max_route` |
|---|---|---|
| at branch node | 20 m | 0.03474 |
| 2 m from the exit (18 m walked) | 2 m | 0.03474 |

Distance drops 10x, the FED term does not move.

The path is live, not dormant: `scenario.py` passes `agent_position` + `current_target` into `rank_routes`, and rerouting has been on by default at 1 s intervals since #41.

## Fix

Extract the position block into `_position_aware_length`, which now also returns the untraversed share `rho` of the first segment. That segment's length, extinction, travel time and FED growth are all weighted by `rho`, so exposure is credited over the same stretch the distance term charges.

`rho` is floored just above zero so an impassable first segment (infinite travel time) stays infinite instead of becoming `NaN`. Diverging routes and any call without an `agent_position` keep `rho = 1`, so existing behaviour is unchanged.

## Behavioural notes

- `RouteCost.travel_time_s` and `k_ave_route` now mean *remaining* route values for a mid-leg agent. The only consumers are the diagnostics history in `scenario.py`; nothing computes arrival times from them.
- `_must_flee_rejection` compares `k_ave_route` against `impassable_extinction_threshold`, so an agent that has already walked through the worst smoke on its leg is now marginally *less* likely to flee. That follows from the fix, but it is a live change to the flee gate.
- The backtrack leg of a diverging route is still charged distance but not exposure; it retraces ground whose dose is already in `current_fed`.

## Tests

Three tests added to `TestPositionAwareRouting`. Two of them fail on the old code and pass on the fix (verified by stashing `route_graph.py`):

- `test_continue_does_not_double_charge_first_segment_fed` - mid-leg FED is 0.1x the at-node value
- `test_continue_reweights_k_ave_by_remaining_share` - two-leg route with smoke on leg 1 only; asserts `k_ave_route` equals the hand-computed rho-weighted mean and is strictly below the at-node value. A uniform field cannot detect a wrong denominator, so this one uses a step field.
- `test_diverging_route_charges_full_fed` - diverging routes keep full FED growth

`ruff format --check` and `ruff check` clean. Full suite: 305 passed, 1 failed - `tests/verification/test_fed_verif.py::test_a2_3_o2_gate_finite_just_below_threshold`, which fails identically on clean `main` (FED O2 gate, unrelated to routing).

The paper has been updated to match: `main.tex` now documents the position-aware form as Eq. `eq:leff`/`eq:rho`/`eq:exposure` in the route cost section, which the previous composite-cost equation did not cover.