### PR TITLE
fix(routing): route each agent from its own spawn area

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,11 @@ config:
 `alpha` is a compass bearing (degrees from north, clockwise): 90 = sign
 visible from the east, 270 = from the west, 180 = from the south.
 
+Every exit, checkpoint and waypoint gets a sign: nodes without an authored
+`"sign"` get one synthesised at the node's polygon centroid (`c=3`,
+`alpha=None`, i.e. omni-directional). A node is never exempt from
+visibility gating for lack of an authored sign.
+
 At each reevaluation tick the `VisibilityModel` checks whether an agent
 can see the next node's sign using a cached [fdsvismap](https://github.com/FireDynamics/fdsvismap)
 pickle. If the sign is not visible, the route is rejected with

--- a/docs/routing-and-signs-notes.md
+++ b/docs/routing-and-signs-notes.md
@@ -116,7 +116,7 @@ Symbols used below:
 
 ## Part 2 — How exit signs & visibility work
 
-1. **Signs are opt-in, defined per node in `config.json`.**
+1. **Every routable node has a sign; authoring one is optional.**
    Any exit / checkpoint / waypoint may carry a `sign` block (e.g.
    `on/config.json:60`):
    ```json
@@ -125,8 +125,11 @@ Symbols used below:
    - `x, y` — the sign's world position.
    - `alpha` — compass bearing the sign faces (deg from north, clockwise).
    - `c` — contrast/visibility constant (default 3).
-   `extract_sign_descriptors()` (`visibility.py:14`) collects every node that has
-   one. **A node with no `sign` is always treated as visible** (opt-in system).
+   `extract_sign_descriptors()` collects every exit, checkpoint and waypoint.
+   An authored `sign` is kept verbatim; **a node without one gets a sign
+   synthesised at its centroid** with `c = 3` and `alpha = None`
+   (omni-directional), so no routable stage escapes smoke-dependent legibility.
+   A node whose coordinates cannot form a polygon is skipped and stays ungated.
 
 2. **Signs are directional.**
    A sign is only readable from the side it faces (`visibility.py:209`):
@@ -153,7 +156,8 @@ Symbols used below:
 
 4. **The routing query is a single boolean.**
    `node_is_visible(time, x, y, node_id)` (`visibility.py:251`) → True/False.
-   Nodes without a sign always return True.
+   Nodes with no descriptor at all — spawn areas, and nodes whose geometry was
+   unusable — return True.
 
 5. **Signs gate routes (rejection), they don't (yet) change cost.**
    In `rank_routes` (`route_graph.py:750`): a route is **rejected if the agent

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -31,6 +31,18 @@ graph = StageGraph.from_scenario(
 )
 ```
 
+### Graph construction without a journey
+
+When a scenario defines no `transitions`, the stage graph wires itself by
+stage type: spawn areas and crossings reach every crossing and every exit,
+exits are terminal, and nothing points back at a spawn area. Crossings
+therefore participate in cost-driven routing without a hand-authored journey.
+In clear air the direct spawn-to-exit edge is cheapest, so agents take the
+nearest exit and crossings sit inert; smoke can make a route through a
+crossing cheaper.
+
+Explicit `transitions` remain authoritative and skip this path entirely.
+
 ### Edge geometry
 
 Edges carry a polyline that follows the corridor geometry computed

--- a/docs/superpowers/plans/2026-08-05-stage-graph-and-signs.md
+++ b/docs/superpowers/plans/2026-08-05-stage-graph-and-signs.md
@@ -1,0 +1,698 @@
+# Stage Graph, Crossings and Signs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let crossings participate in cost-driven routing without a hand-authored journey, make every routable stage smoke-gated by a sign, and measure position-aware distances along the walkable area instead of straight lines.
+
+**Architecture:** Three independent changes to `pyfds_evac/core`. `StageGraph.from_scenario` gains a stage-type-agnostic auto-wiring path and retains its `jps.RoutingEngine` on the graph object; `visibility.extract_sign_descriptors` synthesises a default sign for every exit and crossing that lacks one; `route_graph._position_aware_length` asks that retained routing engine for walkable distances, falling back to Euclidean when it is absent.
+
+**Tech Stack:** Python 3.12, shapely, jupedsim (`jps.RoutingEngine`), fdsvismap, pytest, ruff.
+
+## Global Constraints
+
+- Repo root: `/Users/chraibi/workspace/PedestrianDynamics/Fire/fds_visibility/fds-evac`. Branch: `fix/per-agent-spawn-origin`.
+- Use the project venv for everything: `.venv/bin/python`, `.venv/bin/pytest`, `.venv/bin/ruff`. Never system Python.
+- TDD: write the failing test, watch it fail, implement minimally, watch it pass, commit.
+- Before every commit: `.venv/bin/ruff format <files>` then `.venv/bin/ruff check <files>` must pass.
+- `tests/verification/test_fed_verif.py::test_a2_3_o2_gate_finite_just_below_threshold` **fails on clean `main`** and is unrelated to this work. A full-suite run is green when that is the only failure.
+- Never use `--no-verify` when committing. No AI-attribution lines or `Claude-Session:` trailers in commit messages.
+- Existing behaviour must not change when `transitions` is non-empty, or when no walkable polygon is supplied.
+- Style: guard clauses over nesting, max two levels of indentation per function, no unrelated refactoring.
+
+---
+
+### Task 1: Auto-wire all stage types when no transitions exist
+
+Today `StageGraph.from_scenario` auto-connects distributions to exits only while **every** node is a distribution or an exit. Adding one crossing makes the guard false and the graph ends up with zero edges, so routing dies silently.
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py:128-143` (the auto-connect block)
+- Test: `tests/test_route_graph.py` (append a new class at end of file)
+
+**Interfaces:**
+- Consumes: `StageGraph.from_scenario(direct_steering_info, transitions, distributions=None, walkable_polygon=None)`, `StageNode.stage_type` (one of `"distribution"`, `"checkpoint"`, `"exit"`), `_make_edge(src_node, tgt_node, routing_engine) -> StageEdge`
+- Produces: no signature change. After this task, a graph built with crossings and `transitions=[]` has edges from every distribution and every crossing to every crossing and every exit.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_route_graph.py`:
+
+```python
+class TestAutoWiringWithCrossings:
+    """A graph with no transitions must wire itself whatever stages exist.
+
+    Auto-wiring previously bailed out as soon as a non-exit, non-distribution
+    node appeared, leaving a graph with nodes and no edges -- routing silently
+    dead for anyone who drew a crossing but no journey.
+    """
+
+    @staticmethod
+    def _stages():
+        return {
+            "e0": {"polygon": _box(0, 0), "stage_type": "exit"},
+            "e1": {"polygon": _box(30, 0), "stage_type": "exit"},
+            "c0": {"polygon": _box(15, 0), "stage_type": "checkpoint"},
+        }
+
+    def test_crossing_does_not_kill_auto_wiring(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert sum(len(e) for e in graph.edges.values()) > 0
+
+    def test_distribution_reaches_every_exit_and_crossing(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        targets = {edge.target for edge in graph.edges.get("d0", [])}
+        assert targets == {"e0", "e1", "c0"}
+
+    def test_crossing_reaches_exits_but_exits_are_terminal(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert {edge.target for edge in graph.edges.get("c0", [])} == {"e0", "e1"}
+        assert graph.edges.get("e0", []) == []
+
+    def test_no_edge_points_back_at_a_distribution(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        all_targets = {e.target for edges in graph.edges.values() for e in edges}
+        assert "d0" not in all_targets
+
+    def test_explicit_transitions_still_win(self):
+        """With transitions given, only those edges exist -- unchanged behaviour."""
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [{"from": "c0", "to": "e0"}],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert sum(len(e) for e in graph.edges.values()) == 1
+        assert graph.edges["c0"][0].target == "e0"
+```
+
+- [ ] **Step 1b: Write the smoke-detour test**
+
+This is the point of the change: a crossing must be inert in clear air and
+attractive once smoke sits on the direct route. Append to the same class:
+
+```python
+    def test_crossing_is_inert_in_clear_air(self):
+        """Direct spawn-to-exit is cheapest with no smoke, so no detour."""
+        graph = StageGraph.from_scenario(
+            {
+                "e0": {"polygon": _box(20, 0), "stage_type": "exit"},
+                "c0": {"polygon": _box(10, 10), "stage_type": "checkpoint"},
+            },
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        ranked = rank_routes(
+            graph,
+            "d0",
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=1.0),
+        )
+        assert ranked[0].path == ["d0", "e0"]
+
+    def test_smoke_on_the_direct_route_pushes_agents_through_the_crossing(self):
+        class SmokeOnTheDirectLine:
+            """Dense smoke in a band along y = 0, clear everywhere else."""
+
+            def sample_extinction(self, time_s, x, y):
+                del time_s
+                return 5.0 if (4.0 < x < 16.0 and abs(y) < 2.0) else 0.0
+
+        graph = StageGraph.from_scenario(
+            {
+                "e0": {"polygon": _box(20, 0), "stage_type": "exit"},
+                "c0": {"polygon": _box(10, 10), "stage_type": "checkpoint"},
+            },
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        ranked = rank_routes(
+            graph,
+            "d0",
+            0.0,
+            0.0,
+            SmokeOnTheDirectLine(),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=1.0),
+        )
+        assert ranked[0].path == ["d0", "c0", "e0"]
+```
+
+Both need `rank_routes`, `RouteCostConfig` and `ConstantExtinctionField`, which
+`tests/test_route_graph.py` already imports.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_route_graph.py::TestAutoWiringWithCrossings -v
+```
+
+Expected: `test_crossing_does_not_kill_auto_wiring`, `test_distribution_reaches_every_exit_and_crossing` and `test_crossing_reaches_exits_but_exits_are_terminal` FAIL (0 edges). `test_no_edge_points_back_at_a_distribution` and `test_explicit_transitions_still_win` already pass — that is expected and correct; they are regression guards.
+
+- [ ] **Step 3: Replace the auto-connect block**
+
+In `pyfds_evac/core/route_graph.py`, replace the whole block that begins with the comment `# When no transitions are defined and the graph contains only` and ends with the inner `graph.edges.setdefault(src_id, []).append(edge)` loop, with:
+
+```python
+        # With no transitions the author has drawn stages but not routes, so
+        # wire the graph by stage type and let cost decide: spawn areas and
+        # crossings reach every crossing and every exit, exits are terminal,
+        # and nothing points back at a spawn area.
+        if not transitions:
+            targets = [
+                nid
+                for nid, n in graph.nodes.items()
+                if n.stage_type in ("checkpoint", "exit")
+            ]
+            sources = [
+                nid
+                for nid, n in graph.nodes.items()
+                if n.stage_type in ("distribution", "checkpoint")
+            ]
+            for src_id in sources:
+                for tgt_id in targets:
+                    if src_id == tgt_id:
+                        continue
+                    edge = _make_edge(
+                        graph.nodes[src_id], graph.nodes[tgt_id], routing_engine
+                    )
+                    graph.edges.setdefault(src_id, []).append(edge)
+```
+
+- [ ] **Step 4: Run the new tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_route_graph.py::TestAutoWiringWithCrossings -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Run the full suite for regressions**
+
+```bash
+.venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+```
+
+Expected: only `test_a2_3_o2_gate_finite_just_below_threshold` fails. If any other test fails, stop and report — most likely a scenario that relied on the old bipartite-only wiring.
+
+- [ ] **Step 6: Lint and commit**
+
+```bash
+.venv/bin/ruff format pyfds_evac/core/route_graph.py tests/test_route_graph.py
+.venv/bin/ruff check pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "feat(routing): auto-wire crossings when no journey is defined
+
+Auto-wiring only fired while every node was a distribution or an exit, so
+adding a single crossing without transitions produced a graph with nodes
+and no edges -- rerouting silently dead for anyone who drew a crossing but
+no journey.
+
+Wire by stage type instead: spawn areas and crossings reach every crossing
+and every exit, exits stay terminal, nothing points back at a spawn area.
+Explicit transitions remain authoritative and skip this path entirely."
+```
+
+---
+
+### Task 2: Synthesise a sign for every exit and crossing
+
+`node_is_visible` returns `True` for any node without a sign, so an unsigned stage is permanently known regardless of smoke — silently exempt from the mechanism the model is about. Give every exit and crossing a default sign at its centroid, omni-directional.
+
+**Files:**
+- Modify: `pyfds_evac/core/visibility.py:14-22` (`extract_sign_descriptors`)
+- Modify: `pyfds_evac/core/visibility.py:36-43` (`_build_vismap`, the `alpha=` argument)
+- Test: `tests/test_visibility.py` (append a new class at end of file)
+
+**Interfaces:**
+- Consumes: `raw_config` dict with optional `"exits"`, `"checkpoints"`, `"waypoints"` sections, each `{node_id: {"coordinates": [[x, y], ...], "sign": {...}?}}`
+- Produces: `extract_sign_descriptors(raw_config) -> dict[str, dict]` now returns an entry for **every** exit and crossing, each `{"x": float, "y": float, "alpha": float | None, "c": float}`. `alpha` may be `None`, and `_build_vismap` passes `None` through to `fdsvismap.VisMap.set_waypoint`, which treats it as omni-directional.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_visibility.py`:
+
+```python
+class TestSignSynthesis:
+    """Every routable stage carries a sign, so nothing opts out of smoke gating.
+
+    A node with no sign descriptor reports visible unconditionally, which made
+    it permanently known however dense the smoke.  Synthesising a default sign
+    at the node centroid closes that hole.
+    """
+
+    @staticmethod
+    def _square(x, y):
+        return [[x, y], [x + 2, y], [x + 2, y + 2], [x, y + 2], [x, y]]
+
+    def _config(self):
+        return {
+            "exits": {
+                "e0": {"coordinates": self._square(0, 0)},
+                "e1": {
+                    "coordinates": self._square(10, 0),
+                    "sign": {"x": 11.0, "y": 0.5, "alpha": 90, "c": 8},
+                },
+            },
+            "checkpoints": {"c0": {"coordinates": self._square(5, 0)}},
+            "distributions": {"d0": {"coordinates": self._square(20, 0)}},
+        }
+
+    def test_every_exit_and_crossing_gets_a_descriptor(self):
+        signs = extract_sign_descriptors(self._config())
+        assert set(signs) == {"e0", "e1", "c0"}
+
+    def test_synthesised_sign_sits_at_the_node_centroid(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["e0"]["x"] == pytest.approx(1.0)
+        assert signs["e0"]["y"] == pytest.approx(1.0)
+
+    def test_synthesised_sign_is_omnidirectional_and_reflective(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["c0"]["alpha"] is None
+        assert signs["c0"]["c"] == 3
+
+    def test_authored_sign_is_left_alone(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["e1"] == {"x": 11.0, "y": 0.5, "alpha": 90, "c": 8}
+
+    def test_distributions_get_no_sign(self):
+        """Spawn areas are sources, never navigation targets."""
+        signs = extract_sign_descriptors(self._config())
+        assert "d0" not in signs
+```
+
+Add `import pytest` to the file's imports if it is not already there.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_visibility.py::TestSignSynthesis -v
+```
+
+Expected: the first three FAIL — `extract_sign_descriptors` currently returns only `{"e1": ...}`. `test_authored_sign_is_left_alone` and `test_distributions_get_no_sign` already pass as regression guards. You will also need `extract_sign_descriptors` in the import line at the top of the test file; add it to the existing `from pyfds_evac.core.visibility import ...`.
+
+- [ ] **Step 3: Implement synthesis**
+
+Replace `extract_sign_descriptors` in `pyfds_evac/core/visibility.py` with:
+
+```python
+def _default_sign(entry: dict) -> dict | None:
+    """A reflective, omni-directional sign at the node's centroid.
+
+    alpha is left None on purpose.  fdsvismap reads alpha as a half-plane of
+    readability, so a guessed bearing silently blanks the sign for every agent
+    on the wrong side however clear the air, whereas None means omni-directional
+    and merely omits the orientation effect.
+    """
+    coords = entry.get("coordinates")
+    if not coords:
+        return None
+    from shapely.geometry import Polygon
+
+    centroid = Polygon(coords).centroid
+    return {"x": float(centroid.x), "y": float(centroid.y), "alpha": None, "c": 3}
+
+
+def extract_sign_descriptors(raw_config: dict) -> dict[str, dict]:
+    """Return {node_id: {x, y, alpha, c}} for every exit, crossing and waypoint.
+
+    Nodes with an authored 'sign' keep it verbatim; the rest get a default so
+    that no routable stage escapes smoke-dependent legibility.
+    """
+    descriptors: dict[str, dict] = {}
+    for section in ("exits", "checkpoints", "waypoints"):
+        for node_id, data in raw_config.get(section, {}).items():
+            sign = data.get("sign") or _default_sign(data)
+            if sign is not None:
+                descriptors[node_id] = sign
+    return descriptors
+```
+
+- [ ] **Step 4: Let `alpha=None` reach fdsvismap**
+
+In `_build_vismap`, replace the `set_waypoint` call with:
+
+```python
+    for wp_id, (node_id, sign) in enumerate(sign_descriptors.items()):
+        alpha = sign.get("alpha")
+        vis.set_waypoint(
+            wp_id,
+            float(sign["x"]),
+            float(sign["y"]),
+            c=float(sign.get("c", 3)),
+            # None is meaningful: fdsvismap reads it as omni-directional.
+            alpha=None if alpha is None else float(alpha),
+        )
+```
+
+- [ ] **Step 4b: Test that `alpha=None` survives the trip to fdsvismap**
+
+Append to `TestSignSynthesis`:
+
+```python
+    def test_none_alpha_is_passed_through_not_coerced(self):
+        """fdsvismap reads alpha=None as omni-directional; float(None) raises."""
+        from unittest.mock import MagicMock, patch
+
+        from pyfds_evac.core.visibility import _build_vismap
+
+        fake = MagicMock()
+        fake.fds_time_points.max.return_value = 10.0
+        with patch("fdsvismap.VisMap", return_value=fake):
+            _build_vismap(
+                "unused",
+                {"c0": {"x": 1.0, "y": 2.0, "alpha": None, "c": 3}},
+                time_step_s=5.0,
+                slice_height_m=2.0,
+            )
+        assert fake.set_waypoint.call_args.kwargs["alpha"] is None
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_visibility.py -v
+```
+
+Expected: all pass, including the pre-existing `TestVisibilityModelCache`.
+
+- [ ] **Step 6: Run the full suite for regressions**
+
+```bash
+.venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+```
+
+Expected: only the known `test_a2_3_o2_gate_finite_just_below_threshold` failure. Watch `tests/test_familiarity_routing.py` and `tests/verification/test_cognitive_map_verif.py` in particular — discovery agents now see gated signs on nodes that were previously unconditionally visible.
+
+- [ ] **Step 7: Lint and commit**
+
+```bash
+.venv/bin/ruff format pyfds_evac/core/visibility.py tests/test_visibility.py
+.venv/bin/ruff check pyfds_evac/core/visibility.py tests/test_visibility.py
+git add pyfds_evac/core/visibility.py tests/test_visibility.py
+git commit -m "feat(visibility): give every exit and crossing a sign
+
+node_is_visible returns True for a node with no sign descriptor, so an
+unsigned stage was permanently known however dense the smoke -- silently
+exempt from the mechanism the model exists to represent.
+
+Synthesise a default sign at the node centroid for every exit, crossing
+and waypoint that lacks one: reflective (c=3) and omni-directional
+(alpha=None), since fdsvismap reads alpha as a half-plane and a guessed
+bearing would blank the sign for every agent on the wrong side."
+```
+
+---
+
+### Task 3: Measure position-aware distance along the walkable area
+
+`_position_aware_length` uses `math.hypot` for the agent's remaining distance and its backtrack, so both cut corners. Measured on an L-corridor, the remaining distance is understated by 17 % and the straight segment leaves the walkable area. The base path already respects walls; only the position correction does not.
+
+**Files:**
+- Modify: `pyfds_evac/core/route_graph.py` — `StageGraph` dataclass fields, `from_scenario` (store the engine), `_position_aware_length`
+- Test: `tests/test_route_graph.py` (append a new class at end of file)
+
+**Interfaces:**
+- Consumes: `_polyline_length(waypoints) -> float`, `jps.RoutingEngine.compute_waypoints(from_xy, to_xy) -> iterable[tuple[float, float]]`
+- Produces: `StageGraph` gains a field `routing_engine: object | None = None`, set by `from_scenario` when a walkable polygon is supplied. New helper `_walkable_distance(routing_engine, from_xy, to_xy) -> float` returning the walkable path length, or the Euclidean distance when the engine is absent or the query is unusable.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_route_graph.py`:
+
+```python
+class TestWalkableRemainingDistance:
+    """Position-aware distance must follow the walkable area, not cut corners.
+
+    The graph's own edges already route around walls; measuring the agent's
+    remaining distance with a straight line contradicted that and understated
+    it, most severely in the corridor layouts position-aware routing exists to
+    fix.
+    """
+
+    @staticmethod
+    def _l_corridor():
+        """An L: a horizontal leg and a vertical leg meeting at the far end."""
+        from shapely.ops import unary_union
+        from shapely.geometry import box as _shp_box
+
+        return unary_union([_shp_box(0, 0, 20, 3), _shp_box(17, 0, 20, 20)])
+
+    def _graph(self):
+        stages = {
+            "j": {"polygon": _box(18, 2), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(18, 18), "stage_type": "exit"},
+        }
+        return StageGraph.from_scenario(
+            stages,
+            [{"from": "j", "to": "e0"}],
+            walkable_polygon=self._l_corridor(),
+        )
+
+    def test_routing_engine_is_retained_on_the_graph(self):
+        assert self._graph().routing_engine is not None
+
+    def test_remaining_distance_follows_the_corridor(self):
+        """An agent in the horizontal leg must walk to the corner, not through it."""
+        import math
+
+        graph = self._graph()
+        agent = (5.0, 1.5)
+        effective, share = _position_aware_length(
+            graph, ["j", "e0"], agent, "e0", path_length=16.0, first_length_m=16.0
+        )
+        straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
+        assert effective > straight
+
+    def test_euclidean_fallback_without_a_routing_engine(self):
+        import math
+
+        graph = StageGraph.from_scenario(
+            {
+                "j": {"polygon": _box(18, 2), "stage_type": "checkpoint"},
+                "e0": {"polygon": _box(18, 18), "stage_type": "exit"},
+            },
+            [{"from": "j", "to": "e0"}],
+        )
+        agent = (5.0, 1.5)
+        effective, _ = _position_aware_length(
+            graph, ["j", "e0"], agent, "e0", path_length=16.0, first_length_m=16.0
+        )
+        straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
+        assert effective == pytest.approx(16.0 - 16.0 + straight)
+```
+
+Add `_position_aware_length` to the existing `from pyfds_evac.core.route_graph import ...` line at the top of the test file.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+.venv/bin/python -m pytest tests/test_route_graph.py::TestWalkableRemainingDistance -v
+```
+
+Expected: `test_routing_engine_is_retained_on_the_graph` FAILS with `AttributeError: 'StageGraph' object has no attribute 'routing_engine'`; `test_remaining_distance_follows_the_corridor` FAILS because the Euclidean value equals `straight` rather than exceeding it. `test_euclidean_fallback_without_a_routing_engine` already passes.
+
+- [ ] **Step 3: Retain the routing engine on the graph**
+
+In the `StageGraph` dataclass, add the field after `edges`:
+
+```python
+    nodes: dict[str, StageNode] = field(default_factory=dict)
+    edges: dict[str, list[StageEdge]] = field(default_factory=dict)
+    # Kept so route evaluation can measure distances from an agent's actual
+    # position along the walkable area, the same way edges are measured.
+    routing_engine: object | None = None
+```
+
+In `from_scenario`, `graph = cls()` is created before the routing engine. Leave
+that line alone and add one line directly after the `if walkable_polygon is not
+None:` block that assigns `routing_engine`, so the block reads:
+
+```python
+        routing_engine = None
+        if walkable_polygon is not None:
+            import jupedsim as jps  # lazy import; jupedsim not always required
+
+            routing_engine = jps.RoutingEngine(walkable_polygon)
+        graph.routing_engine = routing_engine
+```
+
+- [ ] **Step 4: Add the walkable-distance helper**
+
+Add next to `_polyline_length` in `pyfds_evac/core/route_graph.py`:
+
+```python
+def _walkable_distance(routing_engine, from_xy, to_xy) -> float:
+    """Path length through the walkable area, or straight-line if unavailable.
+
+    A wrong distance only degrades ranking, so a failed or degenerate query
+    falls back rather than ending the run.
+    """
+    if routing_engine is None:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    try:
+        waypoints = list(routing_engine.compute_waypoints(from_xy, to_xy))
+    except Exception:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    if len(waypoints) < 2:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    return _polyline_length(waypoints)
+```
+
+- [ ] **Step 5: Use it in `_position_aware_length`**
+
+In `_position_aware_length`, replace the two `math.hypot` calls. The `remaining` line becomes:
+
+```python
+        remaining = _walkable_distance(
+            graph.routing_engine, (px, py), (next_node.centroid_x, next_node.centroid_y)
+        )
+```
+
+and the `backtrack` line becomes:
+
+```python
+        backtrack = _walkable_distance(
+            graph.routing_engine,
+            (px, py),
+            (first_node.centroid_x, first_node.centroid_y),
+        )
+```
+
+Leave the surrounding logic — the `first_length_m <= 1e-9` guard, the `share` clamp, and the returned tuple — exactly as they are.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+.venv/bin/python -m pytest tests/test_route_graph.py::TestWalkableRemainingDistance -v
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 7: Run the full suite for regressions**
+
+```bash
+.venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+```
+
+Expected: only the known `test_a2_3_o2_gate_finite_just_below_threshold` failure. `TestPositionAwareRouting` builds graphs without a walkable polygon, so it takes the Euclidean fallback and must be unchanged. If `tests/verification/test_s4_tjunction_reroute.py` shifts, that is the real behaviour change — mid-leg agents now see truer, longer distances in corridors. Report the new numbers rather than adjusting the test to fit.
+
+- [ ] **Step 8: Lint and commit**
+
+```bash
+.venv/bin/ruff format pyfds_evac/core/route_graph.py tests/test_route_graph.py
+.venv/bin/ruff check pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git add pyfds_evac/core/route_graph.py tests/test_route_graph.py
+git commit -m "fix(routing): measure position-aware distance along the walkable area
+
+The graph's edges route around walls, but the position correction layered
+on top measured the agent's remaining distance and its backtrack with
+math.hypot. On an L-corridor that understated the remaining distance by
+17 percent and the straight segment left the walkable area entirely.
+
+Retain the RoutingEngine on StageGraph and ask it for both distances,
+falling back to Euclidean where no engine exists or the query is
+degenerate. Measured at roughly 1 us per query, so the cost is negligible."
+```
+
+---
+
+### Task 4: Update the docs the changes invalidate
+
+**Files:**
+- Modify: `docs/routing.md`
+- Modify: `docs/rerouting-oscillation-notes.md`
+- Modify: `README.md`
+
+**Interfaces:**
+- Consumes: behaviour established in Tasks 1-3.
+- Produces: no code. Documentation consistent with shipped behaviour.
+
+- [ ] **Step 1: Check what the changes contradict**
+
+```bash
+rg -n "nearest exit|auto-connect|distribution.*exit|no transitions" docs/routing.md README.md
+rg -n "position-aware|remaining distance|backtrack" docs/rerouting-oscillation-notes.md
+```
+
+- [ ] **Step 2: Record the three behaviour changes**
+
+In `docs/routing.md`, in or near the section describing how the stage graph is built, add:
+
+```markdown
+### Graph construction without a journey
+
+When a scenario defines no `transitions`, the stage graph wires itself by
+stage type: spawn areas and crossings reach every crossing and every exit,
+exits are terminal, and nothing points back at a spawn area. Crossings
+therefore participate in cost-driven routing without a hand-authored journey.
+In clear air the direct spawn-to-exit edge is cheapest, so agents take the
+nearest exit and crossings sit inert; smoke can make a route through a
+crossing cheaper.
+
+Explicit `transitions` remain authoritative and skip this path entirely.
+```
+
+In `docs/rerouting-oscillation-notes.md`, append to the position-aware fix section:
+
+```markdown
+Distances from the agent's position are measured along the walkable area via
+JuPedSim's routing engine, not as straight lines. An earlier version used
+`math.hypot`, which cut corners -- on an L-corridor it understated the
+remaining distance by 17 % and the segment left the walkable area. The
+figures quoted above were computed under that approximation and are
+correspondingly optimistic in corridor geometry.
+```
+
+- [ ] **Step 3: Verify no stale claims remain**
+
+```bash
+rg -n "only.*distributions and exits|always visible|no sign" docs/ README.md
+```
+
+Fix anything that now contradicts the code. In particular, any statement that a node without a sign is always visible is no longer true — every exit and crossing now gets a synthesised sign.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/routing.md docs/rerouting-oscillation-notes.md README.md
+git commit -m "docs: record stage-graph auto-wiring, default signs, walkable distances"
+```
+
+---
+
+## Verification
+
+After all four tasks:
+
+```bash
+.venv/bin/ruff format --check pyfds_evac tests
+.venv/bin/ruff check pyfds_evac tests
+.venv/bin/python -m pytest tests/ -q 2>&1 | tail -5
+```
+
+Green means one failure only: `test_a2_3_o2_gate_finite_just_below_threshold`.
+
+## Deliberately not in this plan
+
+- **The Station asset.** `assets/station/build_geometry.py` is untracked and still emits hand-authored journeys, transitions and checkpoints. Rebuilding it on top of these changes — distributions, exits and two documented crossings, no journeys — is separate work with its own validation against NCSTAR Table 6-2.
+- **The Station throughput gap.** 98/420 evacuated against NIST's 420 in 188 s is unexplained. Diagnosing it needs the corrected graph first.
+- **Internal walls in the Station WKT**, which `wkt_to_fds.py` would carry into the FDS deck and hence into fdsvismap's occlusions.

--- a/docs/superpowers/plans/2026-08-05-stage-graph-and-signs.md
+++ b/docs/superpowers/plans/2026-08-05-stage-graph-and-signs.md
@@ -4,6 +4,8 @@
 
 **Goal:** Let crossings participate in cost-driven routing without a hand-authored journey, make every routable stage smoke-gated by a sign, and measure position-aware distances along the walkable area instead of straight lines.
 
+**Status (2026-08-05):** Tasks 1, 2 and 4 land on `fix/per-agent-spawn-origin`. Task 3 is deferred to a follow-up PR — see the note on that task.
+
 **Architecture:** Three independent changes to `pyfds_evac/core`. `StageGraph.from_scenario` gains a stage-type-agnostic auto-wiring path and retains its `jps.RoutingEngine` on the graph object; `visibility.extract_sign_descriptors` synthesises a default sign for every exit and crossing that lacks one; `route_graph._position_aware_length` asks that retained routing engine for walkable distances, falling back to Euclidean when it is absent.
 
 **Tech Stack:** Python 3.12, shapely, jupedsim (`jps.RoutingEngine`), fdsvismap, pytest, ruff.
@@ -424,6 +426,13 @@ bearing would blank the sign for every agent on the wrong side."
 
 ### Task 3: Measure position-aware distance along the walkable area
 
+> **DEFERRED to a follow-up PR (decided 2026-08-05).** This task edits
+> `_position_aware_length`, which exists only on `fix/route-cost-first-segment-exposure`
+> (PR #44, unmerged). On `main` and on this branch the logic is still inline
+> inside `evaluate_route`, with no `first_share` and no `first_length_m`.
+> Run this task on a branch cut from #44 once it merges. Tasks 1, 2 and 4 are
+> independent of it and land on this branch.
+
 `_position_aware_length` uses `math.hypot` for the agent's remaining distance and its backtrack, so both cut corners. Measured on an L-corridor, the remaining distance is understated by 17 % and the straight segment leaves the walkable area. The base path already respects walls; only the position correction does not.
 
 **Files:**
@@ -619,7 +628,6 @@ degenerate. Measured at roughly 1 us per query, so the cost is negligible."
 
 **Files:**
 - Modify: `docs/routing.md`
-- Modify: `docs/rerouting-oscillation-notes.md`
 - Modify: `README.md`
 
 **Interfaces:**
@@ -630,7 +638,7 @@ degenerate. Measured at roughly 1 us per query, so the cost is negligible."
 
 ```bash
 rg -n "nearest exit|auto-connect|distribution.*exit|no transitions" docs/routing.md README.md
-rg -n "position-aware|remaining distance|backtrack" docs/rerouting-oscillation-notes.md
+rg -n "sign|visible|checkpoint" docs/routing.md README.md
 ```
 
 - [ ] **Step 2: Record the three behaviour changes**
@@ -651,16 +659,8 @@ crossing cheaper.
 Explicit `transitions` remain authoritative and skip this path entirely.
 ```
 
-In `docs/rerouting-oscillation-notes.md`, append to the position-aware fix section:
-
-```markdown
-Distances from the agent's position are measured along the walkable area via
-JuPedSim's routing engine, not as straight lines. An earlier version used
-`math.hypot`, which cut corners -- on an L-corridor it understated the
-remaining distance by 17 % and the segment left the walkable area. The
-figures quoted above were computed under that approximation and are
-correspondingly optimistic in corridor geometry.
-```
+`docs/rerouting-oscillation-notes.md` is **not** edited in this task: the
+walkable-distance change it would describe is Task 3, which is deferred.
 
 - [ ] **Step 3: Verify no stale claims remain**
 
@@ -673,8 +673,8 @@ Fix anything that now contradicts the code. In particular, any statement that a 
 - [ ] **Step 4: Commit**
 
 ```bash
-git add docs/routing.md docs/rerouting-oscillation-notes.md README.md
-git commit -m "docs: record stage-graph auto-wiring, default signs, walkable distances"
+git add docs/routing.md README.md
+git commit -m "docs: record stage-graph auto-wiring and default signs"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
+++ b/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
@@ -90,12 +90,6 @@ sampled mean extinction (`integrated_extinction_along_polyline`) are measured
 along that real route. A straight centroid-to-centroid ray is used only when no
 walkable polygon is supplied, which in practice means unit tests.
 
-This guarantee does **not** currently extend to the position-aware correction:
-`_position_aware_length` measures the agent's remaining distance and its
-backtrack with `math.hypot`, so both cut corners. Measured on an L-corridor, a
-mid-leg agent's remaining distance is understated by 17 % and the straight
-segment lies outside the walkable area. Tracked separately; see Out of scope.
-
 Explicit `transitions`, when present, remain authoritative and this path is
 skipped, so existing scenarios are untouched.
 
@@ -135,6 +129,45 @@ gated uniformly.
 Two edits follow. `_build_vismap` does `alpha=float(sign["alpha"])` and must
 accept and pass through `None`. `extract_sign_descriptors` gains the synthesis
 step so it returns a descriptor for every exit and crossing.
+
+## Change 3 — position-aware distance from the router, not a straight line
+
+`_position_aware_length` measures the agent's remaining distance and its
+backtrack with `math.hypot`:
+
+```python
+remaining = math.hypot(px - next_node.centroid_x, py - next_node.centroid_y)
+backtrack = math.hypot(px - first_node.centroid_x, py - first_node.centroid_y)
+```
+
+Both cut corners. On an L-corridor a mid-leg agent's remaining distance is
+understated by 17 % and the straight segment lies outside the walkable area
+entirely. Both branches understate, so mid-leg agents are systematically
+under-priced against the node-aligned agents the graph assumes — and the error
+is largest in the corridor layouts where position-aware routing was introduced
+to cure rerouting oscillation.
+
+Replace both with the routing engine's walkable path length, the same source of
+truth `_make_edge` already uses:
+
+```python
+remaining = _polyline_length(routing_engine.compute_waypoints(agent_pos, next_centroid))
+```
+
+The routing engine is therefore threaded from `StageGraph` into route
+evaluation. Where it is absent — unit tests without a walkable polygon — the
+Euclidean form remains as the fallback, matching `_make_edge`'s own behaviour.
+If a query fails or returns fewer than two waypoints, fall back to Euclidean
+rather than raising: a wrong distance degrades ranking, an exception ends the
+run.
+
+**Cost is not a concern.** Measured at ~1 µs per query on a Station-sized mesh:
+420 agents × 2 endpoints is 0.8 ms of a 1 s tick. The expensive part of
+`RoutingEngine` is building the navigation mesh once, which already happens at
+graph construction. Within a single `rank_routes` call an agent has one current
+target and one source node, so all candidate routes share the same two
+endpoints and the natural memo key is `(position, node_id)` — but even the naive
+per-route call is affordable.
 
 ## Scenario instance — The Station nightclub
 
@@ -188,6 +221,10 @@ a sensitivity case for free.
   visibility.
 - With smoke on the direct route and a clear two-hop alternative, the cheaper
   route runs through the crossing; without smoke it does not.
+- On an L-corridor, a mid-leg agent's credited remaining distance equals the
+  walkable path length, not the straight line, and exceeds the Euclidean value.
+- Without a routing engine, the Euclidean fallback still applies and existing
+  position-aware tests are unchanged.
 
 ## Out of scope
 
@@ -197,11 +234,3 @@ a sensitivity case for free.
   corrected graph first, and is separate work.
 - Directional signs as independent objects pointing at a remote destination.
   Settled: a sign marks its own node.
-- Euclidean corner-cutting in `_position_aware_length`. Real, measured at 17 %
-  understatement on an L-corridor, and unbounded in tighter geometry. It biases
-  mid-leg agents relative to node-aligned ones in exactly the corridor layouts
-  where position-aware routing was introduced. The fix — asking the routing
-  engine for the walkable remaining distance — costs one routing call per
-  candidate route per agent per re-evaluation, which needs a caching strategy
-  before it can be adopted. Negligible for The Station, which is essentially
-  one open hall.

--- a/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
+++ b/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
@@ -1,0 +1,187 @@
+# Stage graph, crossings and signs — design
+
+Date: 2026-08-03
+
+## Problem
+
+pyFDS-Evac wants a routing mode that plain JuPedSim does not have: **crossings in
+the graph, no author-defined journey, agents free to choose by cost.** Today that
+combination cannot be expressed.
+
+Two routing modes exist:
+
+- **No journey** — every agent targets its nearest exit, chosen per agent by
+  straight-line distance to the exit polygon (`find_nearest_exit_journey`).
+  Crossings are irrelevant, exactly as in JuPedSim.
+- **Explicit journey** — the editor stores `journeys_v2` as `{id, name, color,
+  sequence}`, an ordered path per distribution selected through
+  `journey_weights`. `_migrate_journeys_v2` rewrites it into a linear chain.
+
+The stage graph auto-wires itself only in the first mode, and only while every
+node is a distribution or an exit (`route_graph.py:131`). Adding one crossing
+without transitions silences the guard and produces a graph with **zero edges**:
+
+```
+no crossing : 3 nodes, 2 edges
+one crossing: 4 nodes, 0 edges
+```
+
+So an author who draws crossings but no journey gets no routing at all, and a
+scenario needing intermediate nodes must hand-author its transitions — which
+means encoding a guess about the building's circulation and then measuring the
+model against a benchmark it was told the answer to.
+
+This matters because smoke acts on two channels, and one of them needs
+intermediate nodes:
+
+- **Cost** — smoke and FED raise the price of routes through them.
+- **Information** — smoke hides signs, so an agent may not know an alternative
+  exists.
+
+With a bipartite distribution→exit graph the second channel is inert: sign
+gating checks the sign of `path[1]`, which *is* the exit, and discovery has no
+intermediate node to arrive at.
+
+## Element semantics (settled, no change needed)
+
+- **exit** — terminal stage; the agent leaves through it.
+- **crossing / checkpoint** — intermediate stage; somewhere to route through and
+  re-decide.
+- **distribution** — spawn area; a source node only.
+- **sign** — `{x, y, alpha, c}` attached to a node. Marks *its own* node and
+  answers "is that stage legible from here". 1:1 with an fdsvismap waypoint.
+
+`alpha` is a compass bearing (degrees clockwise from north) defining a
+**half-plane** of readability with cosine falloff: head-on gives factor 1, 90°
+to the side gives 0, behind is clipped to 0. `alpha=None` is natively supported
+by fdsvismap and means **omni-directional** (`FDSVisMap.py:353`).
+
+Agents on the `discovery` tier expand their cognitive map by three rules; only
+two are smoke-dependent:
+
+| when | rule | smoke-dependent |
+|---|---|---|
+| at spawn | spawn node + adjacent nodes whose signs are legible from the centroid | yes |
+| on arrival at a node | all its neighbours | **no — unconditional, by decision** |
+| at re-evaluation | adjacent nodes whose signs are legible from the agent's position | yes |
+
+Arrival stays unconditional: standing at a junction means you have read every
+sign there. This keeps discovery monotone — an agent never fails to learn what
+it walked to.
+
+Note that `expand_from_visibility` adds all neighbours when no `VisibilityModel`
+is loaded, so **discovery is only meaningful with visibility data present**;
+without it a discovery agent converges to full familiarity after one tick.
+
+## Change 1 — auto-wire all stage types
+
+When `transitions` is empty, build the graph from stage types instead of bailing
+out:
+
+- **distributions** → outgoing edges to every crossing and every exit
+- **crossings** → outgoing edges to every other crossing and every exit
+- **exits** → terminal, no outgoing edges
+
+Each edge goes through `_make_edge`, so JuPedSim's routing engine computes a real
+walkable polyline: no edge crosses a wall, and every edge's length and sampled
+extinction are physical. Explicit `transitions`, when present, remain
+authoritative and this path is skipped, so existing scenarios are untouched.
+
+Consequence: with no smoke the direct distribution→exit edge is cheapest, agents
+take the nearest exit, and crossings sit inert — matching plain JuPedSim. With
+smoke, a two-hop path through a crossing can undercut the direct one, so agents
+route around the smoke and may end at a different exit.
+
+Cost is O(n²) routing-engine calls once at graph build, cached in
+`route_segment_cache`. A 22-node graph is ~500 edges.
+
+**JuPedSim's constraint does not apply here.** A JuPedSim waypoint stage needs a
+journey, but pyFDS-Evac does not steer through journeys: agents sit on a
+`DirectSteeringStage` and their target coordinate is written every tick from
+`wait_info["current_target_stage"]` (`direct_steering_runtime.py:81`). Routing
+lives entirely in `StageGraph`; the JuPedSim journey is a formality.
+
+## Change 2 — signs mandatory, with an omni default
+
+Every exit and crossing gets a sign. When the author supplies none, synthesise:
+
+| field | default | rationale |
+|---|---|---|
+| `x, y` | node polygon centroid | the sign sits on the exit/crossing |
+| `c` | 3 | reflective; the conservative half of the 3/8 convention |
+| `alpha` | `None` | omni-directional — no orientation guess |
+
+A guessed `alpha` silently blanks half the floor for agents on the wrong side,
+however clear the air; a missing `alpha` merely omits an effect. Declining to
+guess is strictly safer.
+
+This closes a hole: `node_is_visible` currently returns `True` for any node
+without a sign (`visibility.py:254`), making it permanently known regardless of
+smoke and silently exempt from the model. With synthesised signs every node is
+gated uniformly.
+
+Two edits follow. `_build_vismap` does `alpha=float(sign["alpha"])` and must
+accept and pass through `None`. `extract_sign_descriptors` gains the synthesis
+step so it returns a descriptor for every exit and crossing.
+
+## Scenario instance — The Station nightclub
+
+The model changes above stand alone. The Station is one scenario that exercises
+them, and its benchmark value is that NIST NCSTAR 2 Vol. I §6.6 specifies the
+setup completely and publishes results from two independent models.
+
+**Geometry.** `assets/station/geometry.wkt` is the single source of truth.
+Internal walls belong in it; `wkt_to_fds.py` inverts the walkable area to solid
+cells and emits `&MESH` plus greedy-merged `&OBST` boxes, auto-refining `dx` to
+resolve thin walls. The same WKT therefore drives JuPedSim, FDS, and — through
+the generated deck — fdsvismap's occlusions.
+
+**Stages.** 8 distributions at NIST's per-room densities (2.17 / 1.56 / 0.72
+persons/m², 36 scattered, 420 total); 4 exits at the clear widths of Table 7-6
+(all side doors 914 mm; the main entrance limited by its 914 mm interior door);
+and 2 crossings, both documented in Table 6-1 rather than invented:
+
+- `cp_ticket_area` — main floor → ticket area → vestibule → double doors, marked
+  by LSF 13 ("exit sign in the main floor area with an arrow towards the ticket
+  area") and LSF 10. This is where the 914 mm constriction and the crush were.
+- `cp_rear_bar` — LSF 9, "exit sign located near the rear bar; it appears to be
+  pointing toward the kitchen exit door".
+
+**No `journeys`, `transitions`, or `waypoint_routing`.** Change 1 builds the
+graph; cost decides.
+
+**Signs** default per Change 2, except where Table 6-1 documents otherwise.
+LSF 11/12 record that the platform exit sign was not always illuminated, which
+maps onto the `c=3` reflective versus `c=8` light-emitting distinction and gives
+a sensitivity case for free.
+
+**One config serves both paper sections:**
+
+- **§5 validation** — no smoke, `familiarity: full`, all hazard weights zero,
+  rerouting disabled. Crossings inert, nearest exit. NIST's rule unmodified.
+- **§6 parameter study** — FDS fields plus `VisibilityModel`,
+  `familiarity: discovery`. Same geometry and graph; smoke now raises route
+  costs and hides signs.
+
+## Testing
+
+- Auto-wiring with a crossing present yields a connected graph and every exit
+  reachable from every distribution; the current 0-edge behaviour is the
+  regression being fixed.
+- Explicit transitions still take precedence — an existing single-distribution
+  asset produces an unchanged graph.
+- A synthesised sign appears for every exit and crossing lacking one, at the
+  node centroid with `c=3` and `alpha=None`.
+- `alpha=None` reaches fdsvismap unconverted and yields omni-directional
+  visibility.
+- With smoke on the direct route and a clear two-hop alternative, the cheaper
+  route runs through the crossing; without smoke it does not.
+
+## Out of scope
+
+- Discovery and familiarity behaviour beyond what Change 2 requires; the
+  arrival rule is settled and unchanged.
+- The Station throughput gap against NIST's 188 s. Diagnosing that needs the
+  corrected graph first, and is separate work.
+- Directional signs as independent objects pointing at a remote destination.
+  Settled: a sign marks its own node.

--- a/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
+++ b/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
@@ -132,6 +132,12 @@ step so it returns a descriptor for every exit and crossing.
 
 ## Change 3 — position-aware distance from the router, not a straight line
 
+> **DEFERRED to a follow-up PR (decided 2026-08-05).** This change edits
+> `_position_aware_length`, which exists only on
+> `fix/route-cost-first-segment-exposure` (PR #44, unmerged). It is **not** part
+> of `fix/per-agent-spawn-origin`; on that branch and on `main` the logic is
+> still inline inside `evaluate_route`. Changes 1 and 2 shipped without it.
+
 `_position_aware_length` measures the agent's remaining distance and its
 backtrack with `math.hypot`:
 

--- a/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
+++ b/docs/superpowers/specs/2026-08-03-stage-graph-and-signs-design.md
@@ -82,10 +82,22 @@ out:
 - **crossings** → outgoing edges to every other crossing and every exit
 - **exits** → terminal, no outgoing edges
 
-Each edge goes through `_make_edge`, so JuPedSim's routing engine computes a real
-walkable polyline: no edge crosses a wall, and every edge's length and sampled
-extinction are physical. Explicit `transitions`, when present, remain
-authoritative and this path is skipped, so existing scenarios are untouched.
+An edge is a directed pair of nodes and carries no geometry of its own. Its
+realised path comes from `_make_edge`, which asks JuPedSim's routing engine for
+a polyline through the walkable area — so the path turns corners rather than
+cutting through walls, and both the edge weight (`_polyline_length`) and the
+sampled mean extinction (`integrated_extinction_along_polyline`) are measured
+along that real route. A straight centroid-to-centroid ray is used only when no
+walkable polygon is supplied, which in practice means unit tests.
+
+This guarantee does **not** currently extend to the position-aware correction:
+`_position_aware_length` measures the agent's remaining distance and its
+backtrack with `math.hypot`, so both cut corners. Measured on an L-corridor, a
+mid-leg agent's remaining distance is understated by 17 % and the straight
+segment lies outside the walkable area. Tracked separately; see Out of scope.
+
+Explicit `transitions`, when present, remain authoritative and this path is
+skipped, so existing scenarios are untouched.
 
 Consequence: with no smoke the direct distribution→exit edge is cheapest, agents
 take the nearest exit, and crossings sit inert — matching plain JuPedSim. With
@@ -185,3 +197,11 @@ a sensitivity case for free.
   corrected graph first, and is separate work.
 - Directional signs as independent objects pointing at a remote destination.
   Settled: a sign marks its own node.
+- Euclidean corner-cutting in `_position_aware_length`. Real, measured at 17 %
+  understatement on an L-corridor, and unbounded in tighter geometry. It biases
+  mid-leg agents relative to node-aligned ones in exactly the corridor layouts
+  where position-aware routing was introduced. The fix — asking the routing
+  engine for the walkable remaining distance — costs one routing call per
+  candidate route per agent per re-evaluation, which needs a caching strategy
+  before it can be adopted. Negligible for The Station, which is essentially
+  one open hall.

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import heapq
+import logging
 import math
 from dataclasses import dataclass, field, replace
 from typing import Protocol
@@ -10,6 +11,8 @@ from typing import Protocol
 from shapely.geometry import Polygon
 
 from .smoke_speed import speed_factor_from_extinction
+
+_logger = logging.getLogger(__name__)
 
 _SECONDS_PER_MINUTE = 60.0
 
@@ -262,18 +265,25 @@ class StageGraph:
 
 def _make_edge(src_node: StageNode, tgt_node: StageNode, routing_engine) -> StageEdge:
     """Build a StageEdge between two nodes using polyline or straight-line geometry."""
+    straight = [
+        (src_node.centroid_x, src_node.centroid_y),
+        (tgt_node.centroid_x, tgt_node.centroid_y),
+    ]
+    waypoints = straight
     if routing_engine is not None:
-        waypoints = list(
-            routing_engine.compute_waypoints(
-                (src_node.centroid_x, src_node.centroid_y),
-                (tgt_node.centroid_x, tgt_node.centroid_y),
+        # A centroid outside the navmesh makes the routing engine raise.  The
+        # edge is still wanted -- a straight ray is a coarse but usable cost --
+        # so fall back rather than lose the connection or abort the run.
+        try:
+            waypoints = list(routing_engine.compute_waypoints(*straight))
+        except Exception as exc:
+            _logger.warning(
+                "Routing %s -> %s failed (%s); using a straight centroid ray",
+                src_node.stage_id,
+                tgt_node.stage_id,
+                exc,
             )
-        )
-    else:
-        waypoints = [
-            (src_node.centroid_x, src_node.centroid_y),
-            (tgt_node.centroid_x, tgt_node.centroid_y),
-        ]
+            waypoints = straight
     return StageEdge(
         source=src_node.stage_id,
         target=tgt_node.stage_id,

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -125,18 +125,25 @@ class StageGraph:
             edge = _make_edge(src_node, tgt_node, routing_engine)
             graph.edges.setdefault(src, []).append(edge)
 
-        # When no transitions are defined and the graph contains only
-        # distributions and exits, auto-connect every distribution to every
-        # exit so that smoke/FED-based rerouting works in minimal configs.
-        if not transitions and all(
-            n.stage_type in ("distribution", "exit") for n in graph.nodes.values()
-        ):
-            dist_ids = [
-                nid for nid, n in graph.nodes.items() if n.stage_type == "distribution"
+        # With no transitions the author has drawn stages but not routes, so
+        # wire the graph by stage type and let cost decide: spawn areas and
+        # crossings reach every crossing and every exit, exits are terminal,
+        # and nothing points back at a spawn area.
+        if not transitions:
+            targets = [
+                nid
+                for nid, n in graph.nodes.items()
+                if n.stage_type in ("checkpoint", "exit")
             ]
-            exit_ids = [nid for nid, n in graph.nodes.items() if n.stage_type == "exit"]
-            for src_id in dist_ids:
-                for tgt_id in exit_ids:
+            sources = [
+                nid
+                for nid, n in graph.nodes.items()
+                if n.stage_type in ("distribution", "checkpoint")
+            ]
+            for src_id in sources:
+                for tgt_id in targets:
+                    if src_id == tgt_id:
+                        continue
                     edge = _make_edge(
                         graph.nodes[src_id], graph.nodes[tgt_id], routing_engine
                     )

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1454,6 +1454,7 @@ def run_scenario(
                                         agent_radius=float(
                                             flow_params.get("radius", 0.2)
                                         ),
+                                        spawn_origin=flow_dist.get("dist_key"),
                                     )
                                     if path_state:
                                         agent_wait_info[agent_id] = path_state

--- a/pyfds_evac/core/simulation_init.py
+++ b/pyfds_evac/core/simulation_init.py
@@ -438,18 +438,22 @@ def build_agent_path_state(
     full_stages = variant_data.get("stages", []) or variant_data.get(
         "actual_stages", []
     )
+    # A resolved variant lists its stages in path order, but a journey that was
+    # never split lists every stage flat.  Consecutive entries are therefore
+    # only an edge when the journey also declares that transition; otherwise
+    # they invent edges that shadow the real transitions below.
+    declared_pairs = {
+        (transition.get("from"), transition.get("to"))
+        for transition in transitions
+        if not journey_key or transition.get("journey_id") == journey_key
+    }
     variant_edges: set = set()
     for idx in range(len(full_stages) - 1):
         from_stage = full_stages[idx]
         to_stage = full_stages[idx + 1]
         if not (isinstance(from_stage, str) and isinstance(to_stage, str)):
             continue
-        # A journey lists every stage, so consecutive pairs are not a path.
-        # For a spawn area that ordering is actively wrong -- it would make one
-        # distribution lead into the next and shadow the explicit transition
-        # that says where its agents actually go -- so leave those to the
-        # transitions below.
-        if from_stage.startswith("jps-distributions_"):
+        if (from_stage, to_stage) not in declared_pairs:
             continue
         _append_edge(from_stage, to_stage)
         variant_edges.add(from_stage)

--- a/pyfds_evac/core/simulation_init.py
+++ b/pyfds_evac/core/simulation_init.py
@@ -416,8 +416,14 @@ def build_agent_path_state(
     agent_id: int,
     initial_position: Tuple[float, float] | None = None,
     agent_radius: float = 0.2,
+    spawn_origin: str | None = None,
 ) -> Dict[str, Any] | None:
-    """Build DS routing state as origin->weighted-next mapping."""
+    """Build DS routing state as origin->weighted-next mapping.
+
+    ``spawn_origin`` is the distribution the agent was actually placed in.
+    Without it the first distribution of the journey is used for every agent,
+    which routes the whole population from one spawn area.
+    """
     if not direct_steering_info:
         return None
 
@@ -436,9 +442,17 @@ def build_agent_path_state(
     for idx in range(len(full_stages) - 1):
         from_stage = full_stages[idx]
         to_stage = full_stages[idx + 1]
-        if isinstance(from_stage, str) and isinstance(to_stage, str):
-            _append_edge(from_stage, to_stage)
-            variant_edges.add(from_stage)
+        if not (isinstance(from_stage, str) and isinstance(to_stage, str)):
+            continue
+        # A journey lists every stage, so consecutive pairs are not a path.
+        # For a spawn area that ordering is actively wrong -- it would make one
+        # distribution lead into the next and shadow the explicit transition
+        # that says where its agents actually go -- so leave those to the
+        # transitions below.
+        if from_stage.startswith("jps-distributions_"):
+            continue
+        _append_edge(from_stage, to_stage)
+        variant_edges.add(from_stage)
 
     # Add journey transitions only for stages NOT already covered by the variant.
     # This preserves cyclic edges and continuity while preventing re-randomization
@@ -500,9 +514,14 @@ def build_agent_path_state(
         for stage in full_stages
         if isinstance(stage, str) and stage.startswith("jps-distributions_")
     ]
-    start_origin = next(
-        (stage for stage in distribution_stages if stage in path_choices), None
-    )
+    # Prefer the spawn area this agent was placed in; fall back to the first
+    # distribution of the journey only when the caller cannot name one, which
+    # is correct for the single-distribution scenarios that predate this.
+    start_origin = spawn_origin if spawn_origin in path_choices else None
+    if start_origin is None:
+        start_origin = next(
+            (stage for stage in distribution_stages if stage in path_choices), None
+        )
     if start_origin is None:
         start_origin = next(
             (
@@ -2351,6 +2370,7 @@ def _add_agents(
                                         agent_id=agent_index,
                                         initial_position=(float(pos[0]), float(pos[1])),
                                         agent_radius=agent_radius,
+                                        spawn_origin=dist_key,
                                     )
                                     if path_state:
                                         path_state["familiarity"] = spawn_params.get(

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -11,14 +11,36 @@ import numpy as np
 _logger = logging.getLogger(__name__)
 
 
+def _default_sign(entry: dict) -> dict | None:
+    """A reflective, omni-directional sign at the node's centroid.
+
+    alpha is left None on purpose.  fdsvismap reads alpha as a half-plane of
+    readability, so a guessed bearing silently blanks the sign for every agent
+    on the wrong side however clear the air, whereas None means omni-directional
+    and merely omits the orientation effect.
+    """
+    coords = entry.get("coordinates")
+    if not coords:
+        return None
+    from shapely.geometry import Polygon
+
+    centroid = Polygon(coords).centroid
+    return {"x": float(centroid.x), "y": float(centroid.y), "alpha": None, "c": 3}
+
+
 def extract_sign_descriptors(raw_config: dict) -> dict[str, dict]:
-    """Return {node_id: {x, y, alpha, c}} for all nodes with a 'sign' field."""
-    return {
-        node_id: data["sign"]
-        for section in ("exits", "checkpoints", "waypoints")
-        for node_id, data in raw_config.get(section, {}).items()
-        if data.get("sign")
-    }
+    """Return {node_id: {x, y, alpha, c}} for every exit, crossing and waypoint.
+
+    Nodes with an authored 'sign' keep it verbatim; the rest get a default so
+    that no routable stage escapes smoke-dependent legibility.
+    """
+    descriptors: dict[str, dict] = {}
+    for section in ("exits", "checkpoints", "waypoints"):
+        for node_id, data in raw_config.get(section, {}).items():
+            sign = data.get("sign") or _default_sign(data)
+            if sign is not None:
+                descriptors[node_id] = sign
+    return descriptors
 
 
 def _build_vismap(
@@ -34,12 +56,14 @@ def _build_vismap(
     t_max = vis.fds_time_points.max()
     vis.set_time_points(list(np.arange(0, t_max + time_step_s, time_step_s)))
     for wp_id, (node_id, sign) in enumerate(sign_descriptors.items()):
+        alpha = sign.get("alpha")
         vis.set_waypoint(
             wp_id,
             float(sign["x"]),
             float(sign["y"]),
             c=float(sign.get("c", 3)),
-            alpha=float(sign["alpha"]),
+            # None is meaningful: fdsvismap reads it as omni-directional.
+            alpha=None if alpha is None else float(alpha),
         )
     vis.compute_all(view_angle=True, obstructions=True, aa=True)
     return vis

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
+from shapely.geometry import Polygon
 
 _logger = logging.getLogger(__name__)
 
@@ -20,11 +21,16 @@ def _default_sign(entry: dict) -> dict | None:
     and merely omits the orientation effect.
     """
     coords = entry.get("coordinates")
-    if not coords:
+    if not coords or len(coords) < 3:
         return None
-    from shapely.geometry import Polygon
-
-    centroid = Polygon(coords).centroid
+    # Configs with unusable polygons simulate fine -- the stage setup skips
+    # them -- so a node that cannot yield a centroid gets no sign rather than
+    # aborting the run the moment visibility is switched on.
+    try:
+        centroid = Polygon(coords).centroid
+    except Exception as exc:
+        _logger.warning("Cannot synthesise a sign from %r: %s", coords, exc)
+        return None
     return {"x": float(centroid.x), "y": float(centroid.y), "alpha": None, "c": 3}
 
 

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -241,8 +241,9 @@ class VisibilityModel:
       270 = visible from west  (sign on east wall, seen by agents to its left)
       180 = visible from south (sign at junction top, seen by agents below)
 
-    If a node has no 'sign' descriptor it is always considered visible
-    (fallback to current behaviour).
+    Every exit, crossing and waypoint carries a descriptor -- authored or
+    synthesised at the node centroid -- so only nodes outside that set (spawn
+    areas, and nodes whose geometry was unusable) are unconditionally visible.
 
     Cache format: numpy npz containing the visibility arrays and metadata.
     The cache is safe to load (no pickle / no arbitrary code execution).
@@ -281,7 +282,9 @@ class VisibilityModel:
     def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
         """Return True if the sign at *node_id* is visible from (x, y) at *time*.
 
-        Nodes without a sign descriptor always return True.
+        Only nodes outside the descriptor set -- spawn areas, and nodes whose
+        geometry could not be turned into a centroid -- return True regardless
+        of the smoke.
         """
         wp_id = self._wp_ids.get(node_id)
         if wp_id is None:

--- a/tests/test_agent_path_state.py
+++ b/tests/test_agent_path_state.py
@@ -87,3 +87,51 @@ class TestSpawnOriginIsPerAgent:
         )
 
         assert state["current_origin"] == "jps-distributions_0"
+
+
+class TestFlatStageListingWithCrossings:
+    """A flat stage listing must not invent edges between unrelated crossings.
+
+    Consecutive entries of a journey's stage listing are only a path when the
+    same pair is also a declared transition.  Two crossings listed side by side
+    are not, and treating them as one used to shadow the real transition out of
+    the first crossing.
+    """
+
+    _STAGES = ["jps-distributions_0", "c0", "c1", "e0"]
+
+    def _state(self):
+        return build_agent_path_state(
+            variant_data={"actual_stages": self._STAGES},
+            journey_key="journey_0",
+            transitions=[
+                {"from": "jps-distributions_0", "to": "c0", "journey_id": "journey_0"},
+                {"from": "c0", "to": "e0", "journey_id": "journey_0"},
+                {"from": "c1", "to": "e0", "journey_id": "journey_0"},
+            ],
+            direct_steering_info={
+                "c0": {"polygon": box(0, 0, 2, 2), "stage_type": "checkpoint"},
+                "c1": {"polygon": box(4, 0, 6, 2), "stage_type": "checkpoint"},
+                "e0": {"polygon": box(8, 0, 10, 2), "stage_type": "exit"},
+            },
+            waypoint_routing={},
+            seed=1,
+            agent_id=1,
+            initial_position=(1.0, 1.0),
+            spawn_origin="jps-distributions_0",
+        )
+
+    def test_real_transition_out_of_first_crossing_survives(self):
+        choices = self._state()["path_choices"]
+
+        assert choices["c0"] == [("e0", 100.0)]
+
+    def test_no_edge_between_the_two_crossings(self):
+        choices = self._state()["path_choices"]
+
+        assert "c1" not in [target for target, _ in choices["c0"]]
+
+    def test_spawn_area_keeps_its_declared_transition(self):
+        choices = self._state()["path_choices"]
+
+        assert choices["jps-distributions_0"] == [("c0", 100.0)]

--- a/tests/test_agent_path_state.py
+++ b/tests/test_agent_path_state.py
@@ -1,0 +1,89 @@
+"""Per-agent routing state built at spawn (``build_agent_path_state``)."""
+
+from shapely.geometry import box
+
+from pyfds_evac.core.simulation_init import build_agent_path_state
+
+
+# A single journey listing every stage, as the scenario loader emits it.  The
+# spurious sequential pairs this creates must not shadow the real transitions.
+_ALL_STAGES = [
+    "jps-distributions_0",
+    "jps-distributions_1",
+    "cp_west",
+    "cp_east",
+]
+
+
+def _direct_steering_info():
+    """Two checkpoints, each reachable from one of two spawn areas."""
+    return {
+        "cp_west": {"polygon": box(0, 0, 2, 2), "stage_type": "checkpoint"},
+        "cp_east": {"polygon": box(20, 0, 22, 2), "stage_type": "checkpoint"},
+    }
+
+
+def _transitions():
+    return [
+        {"from": "jps-distributions_0", "to": "cp_west", "journey_id": "journey_0"},
+        {"from": "jps-distributions_1", "to": "cp_east", "journey_id": "journey_0"},
+    ]
+
+
+def _state_for(spawn_origin, agent_id, position):
+    return build_agent_path_state(
+        variant_data={"actual_stages": _ALL_STAGES},
+        journey_key="journey_0",
+        transitions=_transitions(),
+        direct_steering_info=_direct_steering_info(),
+        waypoint_routing={},
+        seed=1,
+        agent_id=agent_id,
+        initial_position=position,
+        spawn_origin=spawn_origin,
+    )
+
+
+class TestSpawnOriginIsPerAgent:
+    """An agent must be routed from the spawn area it was actually placed in.
+
+    Every bundled scenario before The Station had a single distribution, where
+    "the first distribution in the journey" and "this agent's distribution"
+    coincide.  With several spawn areas they do not, and routing every agent
+    from one of them sends the whole population to whichever exit is nearest
+    that single area.
+    """
+
+    def test_each_spawn_area_keeps_its_own_origin(self):
+        west = _state_for("jps-distributions_0", 1, (1.0, 1.0))
+        east = _state_for("jps-distributions_1", 2, (21.0, 1.0))
+
+        assert west["current_origin"] == "jps-distributions_0"
+        assert east["current_origin"] == "jps-distributions_1"
+
+    def test_agents_from_different_areas_head_to_different_stages(self):
+        west = _state_for("jps-distributions_0", 1, (1.0, 1.0))
+        east = _state_for("jps-distributions_1", 2, (21.0, 1.0))
+
+        assert west["current_target_stage"] == "cp_west"
+        assert east["current_target_stage"] == "cp_east"
+
+    def test_unknown_spawn_origin_falls_back_to_first_distribution(self):
+        """A caller that cannot name the spawn area keeps the old behaviour."""
+        state = _state_for("jps-distributions_missing", 3, (1.0, 1.0))
+
+        assert state["current_origin"] == "jps-distributions_0"
+
+    def test_omitted_spawn_origin_falls_back_to_first_distribution(self):
+        state = build_agent_path_state(
+            variant_data={"actual_stages": _ALL_STAGES},
+            journey_key="journey_0",
+            transitions=_transitions(),
+            direct_steering_info=_direct_steering_info(),
+            waypoint_routing={},
+            seed=1,
+            agent_id=4,
+            initial_position=(1.0, 1.0),
+        )
+
+        assert state["current_origin"] == "jps-distributions_0"

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1,11 +1,14 @@
 """Tests for StageGraph construction and Dijkstra shortest-path routing."""
 
+import logging
+
 import pytest
 from shapely.geometry import Polygon
 
 from pyfds_evac.core.route_graph import (
     StageEdge,
     StageGraph,
+    StageNode,
     RouteCostConfig,
     RerouteConfig,
     AgentRouteState,
@@ -2070,3 +2073,36 @@ class TestAutoWiringWithCrossings:
             RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=1.0),
         )
         assert ranked[0].path == ["d0", "c0", "e0"]
+
+
+class TestUnroutableCentroid:
+    """A stage centroid outside the navmesh must not abort graph construction.
+
+    ``compute_waypoints`` raises for a point JuPedSim considers unreachable.
+    Auto-wiring queries every source/target pair, so one badly placed crossing
+    would otherwise take the whole simulation down at start-up.
+    """
+
+    class _RefusingEngine:
+        def compute_waypoints(self, source, target):
+            raise RuntimeError(f"Point {source} is outside of accessible area")
+
+    def _edge(self):
+        from pyfds_evac.core.route_graph import _make_edge
+
+        src = StageNode("d0", 0.0, 0.0, "distribution")
+        tgt = StageNode("e0", 3.0, 4.0, "exit")
+        return _make_edge(src, tgt, self._RefusingEngine())
+
+    def test_edge_falls_back_to_the_straight_centroid_ray(self):
+        edge = self._edge()
+
+        assert edge.waypoints == [(0.0, 0.0), (3.0, 4.0)]
+        assert edge.weight == pytest.approx(5.0)
+
+    def test_failure_is_logged_with_both_stage_ids(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="pyfds_evac.core.route_graph"):
+            self._edge()
+
+        assert "d0" in caplog.text
+        assert "e0" in caplog.text

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1960,3 +1960,113 @@ class TestAutoEdgeGeneration:
         assert flow_dist_without_key.get("dist_key", exit_id) == exit_id, (
             "without dist_key the fallback is exit_id — this documents the regression"
         )
+
+
+class TestAutoWiringWithCrossings:
+    """A graph with no transitions must wire itself whatever stages exist.
+
+    Auto-wiring previously bailed out as soon as a non-exit, non-distribution
+    node appeared, leaving a graph with nodes and no edges -- routing silently
+    dead for anyone who drew a crossing but no journey.
+    """
+
+    @staticmethod
+    def _stages():
+        return {
+            "e0": {"polygon": _box(0, 0), "stage_type": "exit"},
+            "e1": {"polygon": _box(30, 0), "stage_type": "exit"},
+            "c0": {"polygon": _box(15, 0), "stage_type": "checkpoint"},
+        }
+
+    def test_crossing_does_not_kill_auto_wiring(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert sum(len(e) for e in graph.edges.values()) > 0
+
+    def test_distribution_reaches_every_exit_and_crossing(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        targets = {edge.target for edge in graph.edges.get("d0", [])}
+        assert targets == {"e0", "e1", "c0"}
+
+    def test_crossing_reaches_exits_but_exits_are_terminal(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert {edge.target for edge in graph.edges.get("c0", [])} == {"e0", "e1"}
+        assert graph.edges.get("e0", []) == []
+
+    def test_no_edge_points_back_at_a_distribution(self):
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        all_targets = {e.target for edges in graph.edges.values() for e in edges}
+        assert "d0" not in all_targets
+
+    def test_explicit_transitions_still_win(self):
+        """With transitions given, only those edges exist -- unchanged behaviour."""
+        graph = StageGraph.from_scenario(
+            self._stages(),
+            [{"from": "c0", "to": "e0"}],
+            distributions={"d0": {"polygon": _box(5, 0)}},
+        )
+        assert sum(len(e) for e in graph.edges.values()) == 1
+        assert graph.edges["c0"][0].target == "e0"
+
+    def test_crossing_is_inert_in_clear_air(self):
+        """Direct spawn-to-exit is cheapest with no smoke, so no detour."""
+        graph = StageGraph.from_scenario(
+            {
+                "e0": {"polygon": _box(20, 0), "stage_type": "exit"},
+                "c0": {"polygon": _box(10, 10), "stage_type": "checkpoint"},
+            },
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        ranked = rank_routes(
+            graph,
+            "d0",
+            0.0,
+            0.0,
+            ConstantExtinctionField(0.0),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=1.0),
+        )
+        assert ranked[0].path == ["d0", "e0"]
+
+    def test_smoke_on_the_direct_route_pushes_agents_through_the_crossing(self):
+        class SmokeOnTheDirectLine:
+            """Dense smoke in a band along y = 0, clear everywhere else."""
+
+            def sample_extinction(self, time_s, x, y):
+                del time_s
+                return 5.0 if (4.0 < x < 16.0 and abs(y) < 2.0) else 0.0
+
+        graph = StageGraph.from_scenario(
+            {
+                "e0": {"polygon": _box(20, 0), "stage_type": "exit"},
+                "c0": {"polygon": _box(10, 10), "stage_type": "checkpoint"},
+            },
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        ranked = rank_routes(
+            graph,
+            "d0",
+            0.0,
+            0.0,
+            SmokeOnTheDirectLine(),
+            None,
+            RouteCostConfig(base_speed_m_per_s=1.0, w_smoke=1.0),
+        )
+        assert ranked[0].path == ["d0", "c0", "e0"]

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -231,3 +231,34 @@ class TestSignSynthesis:
                 slice_height_m=2.0,
             )
         assert fake.set_waypoint.call_args.kwargs["alpha"] is None
+
+    def test_synthesised_sign_is_genuinely_gated_end_to_end(self):
+        """A previously-unsigned node must now be visibility-gated, not just present.
+
+        Exercises VisibilityModel.node_is_visible on a synthesised sign (no
+        authored 'sign' in the config) through the real lookup path, using a
+        fake VisMap in place of FDS data. Asserts both directions: visible
+        where the underlying data says visible, not visible where it says
+        invisible. A descriptor merely existing is not enough -- before this
+        change such a node was hard-coded True regardless of the data.
+        """
+        config = {"exits": {"e0": {"coordinates": self._square(0, 0)}}}
+        signs = extract_sign_descriptors(config)
+        assert signs["e0"]["alpha"] is None  # confirm synthesised, not authored
+
+        class _GatedFakeVis:
+            vismap_time_points = np.array([0.0])
+            all_x_coords = np.array([0.0, 1.0])
+            all_y_coords = np.array([0.0])
+            all_time_all_wp_vismap_array_list = [
+                [np.array([[True, False]])],
+            ]
+
+        with patch(
+            "pyfds_evac.core.visibility._build_vismap",
+            return_value=_GatedFakeVis(),
+        ):
+            model = VisibilityModel("unused", signs)
+
+        assert model.node_is_visible(time=0.0, x=0.0, y=0.0, node_id="e0") is True
+        assert model.node_is_visible(time=0.0, x=1.0, y=0.0, node_id="e0") is False

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -8,8 +8,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
+import pytest
 
-from pyfds_evac.core.visibility import VisibilityModel, _make_meta
+from pyfds_evac.core.visibility import (
+    VisibilityModel,
+    _make_meta,
+    extract_sign_descriptors,
+)
 
 
 # ── helpers ───────────────────────────────────────────────────────────
@@ -160,3 +165,69 @@ class TestVisibilityModelCache:
             with np.load(cache, allow_pickle=False) as data:
                 saved_meta = json.loads(str(data["meta"]))
             assert saved_meta["fds_dir"] == str(Path(FDS_DIR).resolve())
+
+
+class TestSignSynthesis:
+    """Every routable stage carries a sign, so nothing opts out of smoke gating.
+
+    A node with no sign descriptor reports visible unconditionally, which made
+    it permanently known however dense the smoke.  Synthesising a default sign
+    at the node centroid closes that hole.
+    """
+
+    @staticmethod
+    def _square(x, y):
+        return [[x, y], [x + 2, y], [x + 2, y + 2], [x, y + 2], [x, y]]
+
+    def _config(self):
+        return {
+            "exits": {
+                "e0": {"coordinates": self._square(0, 0)},
+                "e1": {
+                    "coordinates": self._square(10, 0),
+                    "sign": {"x": 11.0, "y": 0.5, "alpha": 90, "c": 8},
+                },
+            },
+            "checkpoints": {"c0": {"coordinates": self._square(5, 0)}},
+            "distributions": {"d0": {"coordinates": self._square(20, 0)}},
+        }
+
+    def test_every_exit_and_crossing_gets_a_descriptor(self):
+        signs = extract_sign_descriptors(self._config())
+        assert set(signs) == {"e0", "e1", "c0"}
+
+    def test_synthesised_sign_sits_at_the_node_centroid(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["e0"]["x"] == pytest.approx(1.0)
+        assert signs["e0"]["y"] == pytest.approx(1.0)
+
+    def test_synthesised_sign_is_omnidirectional_and_reflective(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["c0"]["alpha"] is None
+        assert signs["c0"]["c"] == 3
+
+    def test_authored_sign_is_left_alone(self):
+        signs = extract_sign_descriptors(self._config())
+        assert signs["e1"] == {"x": 11.0, "y": 0.5, "alpha": 90, "c": 8}
+
+    def test_distributions_get_no_sign(self):
+        """Spawn areas are sources, never navigation targets."""
+        signs = extract_sign_descriptors(self._config())
+        assert "d0" not in signs
+
+    def test_none_alpha_is_passed_through_not_coerced(self):
+        """fdsvismap reads alpha=None as omni-directional; float(None) raises."""
+        from unittest.mock import MagicMock, patch
+
+        from pyfds_evac.core.visibility import _build_vismap
+
+        fake = MagicMock()
+        fake.fds_time_points.max.return_value = 10.0
+        with patch("fdsvismap.VisMap", return_value=fake):
+            _build_vismap(
+                "unused",
+                {"c0": {"x": 1.0, "y": 2.0, "alpha": None, "c": 3}},
+                time_step_s=5.0,
+                slice_height_m=2.0,
+            )
+        assert fake.set_waypoint.call_args.kwargs["alpha"] is None

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -210,6 +210,18 @@ class TestSignSynthesis:
         signs = extract_sign_descriptors(self._config())
         assert signs["e1"] == {"x": 11.0, "y": 0.5, "alpha": 90, "c": 8}
 
+    def test_degenerate_coordinates_are_skipped_not_fatal(self):
+        """simulation_init tolerates unusable polygons, so sign synthesis must too.
+
+        A two-point ring cannot make a Polygon; the node simply gets no
+        synthesised sign instead of aborting the run.
+        """
+        config = {"exits": {"bad": {"coordinates": [[0, 0], [1, 1]]}}}
+
+        signs = extract_sign_descriptors(config)
+
+        assert "bad" not in signs
+
     def test_distributions_get_no_sign(self):
         """Spawn areas are sources, never navigation targets."""
         signs = extract_sign_descriptors(self._config())


### PR DESCRIPTION
Closes #45.

## Problem

`build_agent_path_state()` is called once per agent, but the origin it assigned did not depend on the agent — it took the first distribution stage of the journey and gave that same `current_origin` to everyone. In a multi-distribution scenario every agent was routed as if it stood in one particular spawn area.

Measured on an 8-distribution scenario (420 occupants, per-room placement): all 420 agents reported `origin=jps-distributions_7`, produced the identical route cost `9.3022`, and switched to the same exit in one synchronised decision at t=0.

## Two causes, both fixed

**1. The caller never named the spawn area.** `spawn_origin` is now threaded through from both spawn paths — `dist_key` for by-number placement (`simulation_init.py`) and `flow_dist["dist_key"]` for flow spawning (`scenario.py`).

**2. The journey stage listing was treated as a path.** `journeys[].stages` lists every stage, so the consecutive-pair scan turned it into a chain where one distribution led into the next. Those chain edges landed in `variant_edges`, and journey transitions are skipped for stages already covered — so the explicit `distribution -> checkpoint` transitions were shadowed for every distribution except the last. Spawn areas no longer get chain edges; their transitions are authoritative.

The fallback to the first distribution is kept for callers that cannot name a spawn area, which preserves behaviour for the single-distribution scenarios that predate this.

## Verification

After the fix, agents from the same run report their own origin and diverge immediately:

```
agent=1 origin=jps-distributions_0 target=front_entrance
agent=2 origin=jps-distributions_0 target=bar_side
agent=3 origin=jps-distributions_0 target=platform_side
```

New `tests/test_agent_path_state.py` — 4 tests, all failing before the fix and passing after:

- each spawn area keeps its own origin
- agents from different areas head to different stages
- unknown `spawn_origin` falls back to the first distribution
- omitted `spawn_origin` falls back to the first distribution

`ruff format --check` and `ruff check` clean. Full suite: **309 passed, 1 failed** — `tests/verification/test_fed_verif.py::test_a2_3_o2_gate_finite_just_below_threshold`, which fails identically on clean `main` (FED O2 gate, unrelated).

## Note

This branches from `main`, so it does not include #44. The two are independent.