### PR TITLE
fix(routing): measure position-aware distance along the walkable area

### DIFF
--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -49,6 +49,9 @@ class StageGraph:
 
     nodes: dict[str, StageNode] = field(default_factory=dict)
     edges: dict[str, list[StageEdge]] = field(default_factory=dict)
+    # Kept so route evaluation can measure distances from an agent's actual
+    # position along the walkable area, the same way edges are measured.
+    routing_engine: object | None = None
 
     @classmethod
     def from_scenario(
@@ -83,6 +86,7 @@ class StageGraph:
             import jupedsim as jps  # lazy import; jupedsim not always required
 
             routing_engine = jps.RoutingEngine(walkable_polygon)
+        graph.routing_engine = routing_engine
 
         # Add distribution nodes (not in direct_steering_info).
         if distributions:
@@ -308,6 +312,23 @@ def _polyline_length(waypoints: list[tuple[float, float]]) -> float:
             waypoints[i + 1][1],
         )
     return total
+
+
+def _walkable_distance(routing_engine, from_xy, to_xy) -> float:
+    """Path length through the walkable area, or straight-line if unavailable.
+
+    A wrong distance only degrades ranking, so a failed or degenerate query
+    falls back rather than ending the run.
+    """
+    if routing_engine is None:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    try:
+        waypoints = list(routing_engine.compute_waypoints(from_xy, to_xy))
+    except Exception:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    if len(waypoints) < 2:
+        return _euclidean(from_xy[0], from_xy[1], to_xy[0], to_xy[1])
+    return _polyline_length(waypoints)
 
 
 # ── Route cost evaluation (Phase 3) ──────────────────────────────────
@@ -644,7 +665,9 @@ def _position_aware_length(
     if path[1] == current_target:
         # Continuing toward the current target: charge only the distance
         # remaining from the agent's position to that node.
-        remaining = math.hypot(px - next_node.centroid_x, py - next_node.centroid_y)
+        remaining = _walkable_distance(
+            graph.routing_engine, (px, py), (next_node.centroid_x, next_node.centroid_y)
+        )
         if first_length_m <= 1e-9:
             return path_length - first_length_m + remaining, 1.0
         # Floored above zero so an impassable first segment (infinite travel
@@ -655,7 +678,11 @@ def _position_aware_length(
     if current_target is not None:
         # Diverging from the current heading: the agent must walk back to the
         # branch (first) node before taking this route.
-        backtrack = math.hypot(px - first_node.centroid_x, py - first_node.centroid_y)
+        backtrack = _walkable_distance(
+            graph.routing_engine,
+            (px, py),
+            (first_node.centroid_x, first_node.centroid_y),
+        )
         return path_length + backtrack, 1.0
 
     return path_length, 1.0

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -19,6 +19,7 @@ from pyfds_evac.core.route_graph import (
     should_reevaluate,
     reroute_agent,
     evaluate_and_reroute,
+    _position_aware_length,
 )
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField
 
@@ -2187,3 +2188,62 @@ class TestUnroutableCentroid:
 
         assert "d0" in caplog.text
         assert "e0" in caplog.text
+class TestWalkableRemainingDistance:
+    """Position-aware distance must follow the walkable area, not cut corners.
+
+    The graph's own edges already route around walls; measuring the agent's
+    remaining distance with a straight line contradicted that and understated
+    it, most severely in the corridor layouts position-aware routing exists to
+    fix.
+    """
+
+    @staticmethod
+    def _l_corridor():
+        """An L: a horizontal leg and a vertical leg meeting at the far end."""
+        from shapely.ops import unary_union
+        from shapely.geometry import box as _shp_box
+
+        return unary_union([_shp_box(0, 0, 20, 3), _shp_box(17, 0, 20, 20)])
+
+    def _graph(self):
+        stages = {
+            "j": {"polygon": _box(18, 2), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(18, 18), "stage_type": "exit"},
+        }
+        return StageGraph.from_scenario(
+            stages,
+            [{"from": "j", "to": "e0"}],
+            walkable_polygon=self._l_corridor(),
+        )
+
+    def test_routing_engine_is_retained_on_the_graph(self):
+        assert self._graph().routing_engine is not None
+
+    def test_remaining_distance_follows_the_corridor(self):
+        """An agent in the horizontal leg must walk to the corner, not through it."""
+        import math
+
+        graph = self._graph()
+        agent = (5.0, 1.5)
+        effective, share = _position_aware_length(
+            graph, ["j", "e0"], agent, "e0", path_length=16.0, first_length_m=16.0
+        )
+        straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
+        assert effective > straight
+
+    def test_euclidean_fallback_without_a_routing_engine(self):
+        import math
+
+        graph = StageGraph.from_scenario(
+            {
+                "j": {"polygon": _box(18, 2), "stage_type": "checkpoint"},
+                "e0": {"polygon": _box(18, 18), "stage_type": "exit"},
+            },
+            [{"from": "j", "to": "e0"}],
+        )
+        agent = (5.0, 1.5)
+        effective, _ = _position_aware_length(
+            graph, ["j", "e0"], agent, "e0", path_length=16.0, first_length_m=16.0
+        )
+        straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
+        assert effective == pytest.approx(16.0 - 16.0 + straight)


### PR DESCRIPTION
Implements Task 3 of `docs/superpowers/plans/2026-08-05-stage-graph-and-signs.md`, unblocked by #44.

## Problem

Graph edges already get their geometry from JuPedSim's `RoutingEngine`, so an edge's realised path follows the walkable area and turns corners. The **position-aware correction** layered on top did not: it measured the agent's remaining distance and its backtrack with `math.hypot`.

Those straight lines cut corners and can leave the walkable area entirely. Measured on an L-corridor, for an agent mid-leg:

| | |
|---|---|
| Euclidean "remaining" — what the code credited | 18.56 m |
| True walkable remaining | 22.48 m |
| **Understated by** | **17.4 %** |

Both branches understate, so mid-leg agents were systematically under-priced against the node-aligned agents the graph assumes — and the error is largest in the corridor layouts where position-aware routing was introduced to cure rerouting oscillation.

## Change

`StageGraph` retains the `RoutingEngine` built in `from_scenario`; a new `_walkable_distance` helper asks it for the path length, the same source of truth `_make_edge` already uses. Euclidean survives as the fallback on three conditions: no routing engine (unit tests without a walkable polygon), a failed query, or fewer than two waypoints. A wrong distance degrades ranking; an exception would end the run.

## This also fixes first-segment exposure weighting

Worth calling out, because the change is larger than "distances get longer". `first_share` is `remaining / first_length_m`, and `first_length_m` is already a walkable polyline length. The ratio was therefore Euclidean/walkable — a genuine unit mismatch that **understated first-segment smoke and FED exposure in corridors**. It is now walkable/walkable. The formula is untouched; only the numerator's measurement changed.

## Cost

Measured ~1 µs per query on a Station-sized navmesh. One query per candidate route per agent per re-evaluation: 1000 agents x 4 exits at the 1 s default interval is ~4 ms per simulated second. The `RoutingEngine`'s expensive part is building the navmesh, which already happens once at graph construction.

## Tests

Three added to `tests/test_route_graph.py`. Two fail on revert:
- `test_routing_engine_is_retained_on_the_graph` — `AttributeError`
- `test_remaining_distance_follows_the_corridor` — on an L-corridor the credited distance must exceed the straight line; pre-fix it is exactly equal, so the strict inequality is a real regression detector
- `test_euclidean_fallback_without_a_routing_engine` — passes either way by design; it guards the fallback that `TestPositionAwareRouting` depends on

Full suite: 307 passed, 1 failed, 1 skipped. The failure is `test_a2_3_o2_gate_finite_just_below_threshold`, which fails on clean `main`. The skip is `test_fdsreader_stationary_haspel_sampling_drives_positive_fed` — see the note below. `ruff format --check` and `ruff check` clean.

`tests/verification/test_s4_tjunction_reroute.py` is unchanged, so the corridor scenario's behaviour did not shift measurably.

## Known minors, deliberately not addressed here

- The `backtrack` query depends only on `(agent_position, path[0])` and is recomputed for every diverging candidate sharing that branch node — memoisable next to the existing `cached_segments`.
- `_walkable_distance` degrades silently. If agent positions systematically fell outside the routing polygon, every query would revert to exactly the Euclidean behaviour this PR removes, with no signal. A rate-limited debug log would make that visible.
- `_make_edge` calls `compute_waypoints` unguarded on `main`, so the same out-of-area condition crashes at graph-build time while `_walkable_distance` degrades at run time. The guard lands with #46; reconcile the two then.