### PR TITLE
style: restore blank lines lost in a conflict resolution

### DIFF
--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2188,6 +2188,8 @@ class TestUnroutableCentroid:
 
         assert "d0" in caplog.text
         assert "e0" in caplog.text
+
+
 class TestWalkableRemainingDistance:
     """Position-aware distance must follow the walkable area, not cut corners.
 


### PR DESCRIPTION
Two test classes ended up adjacent with no separating blank lines when the conflict markers were removed during the rebase of #48 onto #46. `ruff format --check` fails on `main` until this lands; no behaviour change, tests unaffected (115 passed).