### PR TITLE
fix(verification): drop stale 60x in the O2 hypoxia reference

### DIFF
--- a/tests/verification/test_fed_verif.py
+++ b/tests/verification/test_fed_verif.py
@@ -87,7 +87,10 @@ def test_a2_3_o2_gate_zero_at_and_above_threshold():
 
 def test_a2_3_o2_gate_finite_just_below_threshold():
     inputs = DefaultFedInputs(o2_volume_fraction_percent=19.4)
-    ref_o2_rate = 1.0 / (60.0 * math.exp(8.13 - 0.54 * (20.9 - 19.4)))
+    # Purser / FDS Tech Ref Eq. 18 gives t_incap directly in MINUTES, so the
+    # per-minute rate is 1 / t_incap with no further conversion. This reference
+    # previously carried a spurious 60x, matching the engine bug fixed in #35.
+    ref_o2_rate = 1.0 / math.exp(8.13 - 0.54 * (20.9 - 19.4))
 
     got = default_fed_rate_per_minute(inputs)
 


### PR DESCRIPTION
`tests/verification/test_fed_verif.py::test_a2_3_o2_gate_finite_just_below_threshold` has been failing on `main`. The bug is in the test's reference value, not the engine.

## The error

```python
ref_o2_rate = 1.0 / (60.0 * math.exp(8.13 - 0.54 * (20.9 - 19.4)))
```

Purser / FDS Tech Ref Eq. 18 gives `t_incap` **directly in minutes**, so the per-minute rate is `1 / t_incap` with no further conversion. The extra 60x is spurious.

| | Rate (1/min) | Implied t_incap at 19.4% O2 |
|---|---|---|
| Test expected | `1.10e-05` | ~63 days |
| Engine returns | `6.62e-04` | ~25 hours |

25 hours is the sensible answer for 19.4% O2, which is only just below the 19.5% hypoxia gate.

## Why it drifted

- [`ca61154`](https://github.com/PedestrianDynamics/pyFDS-Evac/commit/ca61154) (2026-06-11) added the verification suite, carrying this reference.
- [`89d6da7`](https://github.com/PedestrianDynamics/pyFDS-Evac/commit/89d6da7) (2026-07-30, #35) fixed the engine, titled *"correct O2 hypoxia rate (was 60x too slow)"*.

The suite predates the fix by seven weeks and encoded the same misreading, so the test has been red since #35 landed.

## Corroboration

Three independent sources already document the correct form; only the test disagreed.

- `_o2_hypoxia_rate_per_minute` docstring in `pyfds_evac/core/fed.py`: `t_incap [min] = exp(8.13 - 0.54 * (20.9 - C_O2%))`, `rate [1/min] = 1 / t_incap`
- README equation table: $\mathrm{FED}_{O_2} = \int 1/\exp(8.13 - 0.54(20.9 - C_{O_2}))\, dt$
- `docs/testing-homogeneous.md`

The other `/60.0` occurrences in `test_fed_verif.py` and `tests/test_fed.py` are legitimate `dt_s` to minutes conversions and are unchanged.

## Verification

`pytest tests/verification` (slow tests included): **56 passed**, up from 55 passed / 1 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
