### PR TITLE
refactor(routing): let the cognitive map be the only visibility gate

### DIFF
--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -830,7 +830,6 @@ def rank_routes(
     *,
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
     exit_counts: dict[str, int] | None = None,
-    vis_model=None,
     cognitive_map=None,
     agent_position: tuple[float, float] | None = None,
     current_exit: str | None = None,
@@ -905,47 +904,29 @@ def rank_routes(
         )
         costs.append(rc)
 
-    # Check visibility rejection.
-    if vis_model is not None:
-        # Reject any route whose first hop node sign is not visible from the
-        # agent's current position.  Prefer the actual agent position over the
-        # source node centroid so that large polygons don't introduce bias.
-        # Falls back to always-visible for nodes without a sign descriptor.
-        if agent_position is not None:
-            ax, ay = agent_position
-        else:
-            src_node = graph.nodes.get(source)
-            ax = src_node.centroid_x if src_node is not None else 0.0
-            ay = src_node.centroid_y if src_node is not None else 0.0
-        updated: list[RouteCost] = []
+    # Sign legibility is not consulted here.  It decides what enters the
+    # agent's cognitive map (see cognitive_map.expand_from_visibility), and the
+    # map decides what Dijkstra can see -- so an unknown exit is absent from
+    # the graph rather than present-and-vetoed.  Checking it again here
+    # double-gated the same criterion, blocked agents who already knew the
+    # building, and forbade an agent from using an exit it had legitimately
+    # learned once the sign went out of view.
+    # K_vis fallback: reject routes where all segments are non-visible,
+    # but only if at least one other route has visibility.
+    any_visible = any(
+        any(s.visible for s in rc.segments) for rc in costs if not rc.rejected
+    )
+    if any_visible:
+        updated = []
         for rc in costs:
-            if not rc.rejected:
-                next_node = rc.path[1] if len(rc.path) > 1 else rc.exit_id
-                if not vis_model.node_is_visible(time_s, ax, ay, next_node):
-                    rc = replace(
-                        rc,
-                        rejected=True,
-                        rejection_reason="next_node_not_visible",
-                    )
+            if not rc.rejected and not any(s.visible for s in rc.segments):
+                rc = replace(
+                    rc,
+                    rejected=True,
+                    rejection_reason="all segments non-visible",
+                )
             updated.append(rc)
         costs = updated
-    else:
-        # K_vis fallback: reject routes where all segments are non-visible,
-        # but only if at least one other route has visibility.
-        any_visible = any(
-            any(s.visible for s in rc.segments) for rc in costs if not rc.rejected
-        )
-        if any_visible:
-            updated = []
-            for rc in costs:
-                if not rc.rejected and not any(s.visible for s in rc.segments):
-                    rc = replace(
-                        rc,
-                        rejected=True,
-                        rejection_reason="all segments non-visible",
-                    )
-                updated.append(rc)
-            costs = updated
 
     # Sort: non-rejected first by cost, then rejected by cost.
     # Break ties by fewer intermediate stages.
@@ -1177,7 +1158,6 @@ def evaluate_and_reroute(
     cached_segments: dict[tuple[str, str], SegmentCost] | None = None,
     *,
     exit_counts: dict[str, int] | None = None,
-    vis_model=None,
     cognitive_map=None,
     agent_position: tuple[float, float] | None = None,
 ) -> RouteSwitch | None:
@@ -1206,7 +1186,6 @@ def evaluate_and_reroute(
         config.cost_config,
         cached_segments=cached_segments,
         exit_counts=exit_counts,
-        vis_model=vis_model,
         cognitive_map=cognitive_map,
         agent_position=agent_position,
         current_exit=route_state.current_exit,

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1924,7 +1924,6 @@ def run_scenario(
                                 reroute_config.cost_config,
                                 cached_segments=route_segment_cache,
                                 exit_counts=exit_counts,
-                                vis_model=vis_model,
                                 cognitive_map=_cmap,
                                 agent_position=tuple(_pos)
                                 if _pos is not None
@@ -1974,7 +1973,6 @@ def run_scenario(
                         config=reroute_config,
                         cached_segments=route_segment_cache,
                         exit_counts=exit_counts,
-                        vis_model=vis_model,
                         cognitive_map=_cmap,
                         agent_position=tuple(_pos) if _pos is not None else None,
                     )

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1879,80 +1879,99 @@ class TestCognitiveMapRouting:
         assert "E1" in exit_ids
 
 
-class TestVisibilityRejection:
-    """rank_routes applies next_node_not_visible rejection unconditionally."""
+class TestSignsDoNotGateRouting:
+    """Routing consults the cognitive map, never sign legibility directly.
 
-    def _make_vis_model(self, visible_nodes: set[str]):
-        """Return a mock vis_model where only *visible_nodes* are visible."""
+    Sign visibility used to veto a route whose first hop was illegible, which
+    duplicated the job the cognitive map already does -- legibility decides
+    map *membership*, and membership decides what Dijkstra can see.  Worse, the
+    veto applied regardless of familiarity, so an agent that knew the building
+    was still blocked by an unreadable sign, and an agent that had legitimately
+    learned an exit was forbidden from using it once the sign went out of view.
+    """
 
-        class _MockVis:
-            def node_is_visible(self, time, x, y, node_id):
-                return node_id in visible_nodes
+    def test_routing_takes_no_visibility_model_at_all(self):
+        """The parameter is gone, not merely ignored.
 
-        return _MockVis()
+        Leaving a vis_model argument that callers pass in good faith and the
+        router silently discards is worse than removing it: it reads as though
+        legibility still gates routing.
+        """
+        import inspect
 
-    def test_invisible_route_rejected(self, multi_exit_graph):
-        """E0 route rejected when E0 sign is not visible."""
-        field = ConstantExtinctionField(0.0)
-        vis = self._make_vis_model(visible_nodes={"E1"})  # E0 not visible
-        ranked = rank_routes(
+        assert "vis_model" not in inspect.signature(rank_routes).parameters
+        assert "vis_model" not in inspect.signature(evaluate_and_reroute).parameters
+
+    def test_membership_is_the_only_gate(self, multi_exit_graph):
+        """An exit outside the agent's map is unreachable; one inside is not."""
+        from pyfds_evac.core.cognitive_map import AgentCognitiveMap
+
+        knows_both = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "E0", "E1"},
+            known_edges={("D0", "E0"), ("D0", "E1")},
+        )
+        knows_far_only = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "E1"},
+            known_edges={("D0", "E1")},
+        )
+
+        def exits_for(cmap):
+            ranked = rank_routes(
+                multi_exit_graph,
+                "D0",
+                0.0,
+                0.0,
+                ConstantExtinctionField(0.0),
+                None,
+                RouteCostConfig(),
+                cognitive_map=cmap,
+            )
+            return {rc.exit_id for rc in ranked}
+
+        assert exits_for(knows_both) == {"E0", "E1"}
+        # E0 is not rejected -- it is absent, because Dijkstra never saw it.
+        assert exits_for(knows_far_only) == {"E1"}
+
+    def test_smoke_still_prices_routes_for_a_fully_familiar_agent(
+        self, multi_exit_graph
+    ):
+        """Removing the veto must not remove the cost channel.
+
+        Smoke influences exit choice through w_smoke * K_ave, which is
+        independent of signs and of familiarity.
+        """
+
+        # D0 -> E0 -> E1 are collinear, so E1's path contains E0's.  Put the
+        # smoke beyond E0 to load the far route only.
+        class SmokeBeyondE0:
+            def sample_extinction(self, time_s, x, y):
+                del time_s, y
+                return 5.0 if 12.0 < x < 18.0 else 0.0
+
+        clear = rank_routes(
             multi_exit_graph,
             "D0",
             0.0,
             0.0,
-            field,
+            ConstantExtinctionField(0.0),
             None,
-            RouteCostConfig(),
-            vis_model=vis,
+            RouteCostConfig(w_smoke=1.0),
         )
-        e0 = next(rc for rc in ranked if rc.exit_id == "E0")
-        e1 = next(rc for rc in ranked if rc.exit_id == "E1")
-        assert e0.rejected
-        assert e0.rejection_reason == "next_node_not_visible"
-        assert not e1.rejected
-
-    def test_all_invisible_fallback_unrejects_least_bad(self, multi_exit_graph):
-        """When all routes are rejected, the fallback un-rejects the cheapest."""
-        field = ConstantExtinctionField(0.0)
-        vis = self._make_vis_model(visible_nodes=set())  # nothing visible
-        ranked = rank_routes(
+        smoky = rank_routes(
             multi_exit_graph,
             "D0",
             0.0,
             0.0,
-            field,
+            SmokeBeyondE0(),
             None,
-            RouteCostConfig(),
-            vis_model=vis,
+            RouteCostConfig(w_smoke=1.0),
         )
-        assert ranked, "should still return routes via fallback"
-        assert not ranked[0].rejected, "fallback must un-reject the best route"
-        assert ranked[0].rejection_reason is not None
-        assert ranked[0].rejection_reason.startswith("fallback")
-
-    def test_agent_position_used_over_centroid(self, multi_exit_graph):
-        """agent_position is forwarded to vis_model instead of node centroid."""
-        received: list[tuple] = []
-
-        class _RecordingVis:
-            def node_is_visible(self, time, x, y, node_id):
-                received.append((x, y))
-                return True
-
-        field = ConstantExtinctionField(0.0)
-        rank_routes(
-            multi_exit_graph,
-            "D0",
-            0.0,
-            0.0,
-            field,
-            None,
-            RouteCostConfig(),
-            vis_model=_RecordingVis(),
-            agent_position=(7.5, 3.0),
-        )
-        assert received, "vis_model.node_is_visible should have been called"
-        assert all(x == 7.5 and y == 3.0 for x, y in received)
+        cost = {rc.exit_id: rc.composite_cost for rc in clear}
+        cost_smoky = {rc.exit_id: rc.composite_cost for rc in smoky}
+        assert cost_smoky["E1"] > cost["E1"], "smoke must raise the smoky route"
+        assert cost_smoky["E0"] == pytest.approx(cost["E0"]), "clear route unchanged"
 
 
 # ── VisibilityModel cache tests are in test_visibility.py ─────────────


### PR DESCRIPTION
Sign legibility acted **twice, independently**:

| where | what it did |
|---|---|
| `cognitive_map.expand_from_visibility` | added a node to the agent's map when its sign was legible |
| `rank_routes` | vetoed any route whose first hop had an illegible sign — **regardless of familiarity** |

Two things were wrong with the second channel.

**A `full`-familiarity agent was blocked by an unreadable sign.** By definition it knows every exit; it does not need to read a sign to find a door it already knows. Signs are wayfinding information — they bind when knowledge is incomplete.

**An agent could not act on knowledge it had legitimately acquired.** Walk past a side exit, read its sign, add it to the map — then walk on until the sign leaves your viewing half-plane, and the veto forbids the route to an exit you demonstrably know about. That contradiction makes acquisition-then-persistence scenarios impossible to express.

## Change

Legibility now feeds **map membership only**, and membership decides what Dijkstra sees. An unknown exit is *absent from the graph* rather than present-and-rejected — it is never ranked, never vetoed, never reinstated by the fallback.

The extinction-based filter that was the veto's `else` branch becomes unconditional. That is deliberate and I think correct: a route whose every segment is impassably smoky is *physically* blocked whoever you are, which is a different claim from "you cannot read the sign". Full-familiarity agents therefore **gain** a rejection they did not have.

`vis_model` is removed from `rank_routes` and `evaluate_and_reroute` rather than left accepted-and-ignored — a discarded argument that callers pass in good faith reads as though legibility still gates routing.

## What is deliberately unchanged

The cost channel. `composite = L_eff·(1 + w_smoke·K̄) + w_fed·D_max + w_queue·…` is untouched, so smoke and toxic dose still price every route for every agent at every familiarity. `test_smoke_still_prices_routes_for_a_fully_familiar_agent` pins that, since it is the obvious thing to break while removing a visibility mechanism.

## Tests

`TestVisibilityRejection` is replaced by `TestSignsDoNotGateRouting`:

- the visibility parameter is **gone**, asserted by signature inspection rather than by behaviour, so it cannot quietly return
- membership is the only gate — an exit outside the map yields no route at all, and the assertion is on *absence*, not on a rejection flag
- smoke still prices routes for a fully familiar agent

Full suite: 331 passed, 1 failed, 1 skipped — the failure is `test_a2_3_o2_gate_finite_just_below_threshold`, which fails on clean `main`. `ruff format --check` and `ruff check` clean.

## Consequence for #50

PR #50's scenario asserts that a **full**-familiarity agent abandons its nearest exit because the sign faces away. Under this change that behaviour is wrong by definition, so #50's premise dies and the scenario must be rebuilt with `discovery` agents — where the flip comes from map membership instead, which I have verified it does:

```
config_visible  known exits at t=0: ['E_far', 'E_near']
config_hidden   known exits at t=0: ['E_far']
```

**Merge this before #50**, and #50 will need its test rewritten on top.