### PR TITLE
docs: validate the Station case against witness statements, not models

### DIFF
--- a/docs/superpowers/specs/2026-08-05-station-validation-design.md
+++ b/docs/superpowers/specs/2026-08-05-station-validation-design.md
@@ -21,10 +21,12 @@ NCSTAR keeps a role: it supplies the dimensioned geometry, the door clear
 widths, and a clear-air cross-check. But the primary target moves to observed
 behaviour.
 
-Source note: the paper's Table 2 (exits used by starting location) did not
-render legibly from the scanned PDF. Every per-location number below is taken
-from the prose on pp. 11–12, which restates the same breakdown. Before building,
-the table should be read directly and any discrepancy resolved in its favour.
+Source note: Table 2 is reproduced in full below. It was transcribed from the
+paper after the scanned PDF failed to render it, and independently reconciled:
+every column total matches the aggregate percentages the paper states on p. 12
+(front 35.8 %, bar 20.0 %, stage 6.5 %, kitchen 5.4 %, windows 27.9 %), and
+355 − 8 unknown = 347, the count of survivors whose exit usage the paper says
+could be determined.
 
 ## What the paper gives us
 
@@ -43,34 +45,42 @@ At least another 62 *attempted* the front door and failed — 34 of those went o
 a window, 25 through another door. So **at least 50 % of survivors tried or
 succeeded in using the front door**, out of four available doors.
 
-### Exit choice by starting location (pp. 11–12)
+### Exit choice by starting location (Table 2)
 
-The row that matters most, because it is the one a nearest-exit model gets
-wrong:
+Rows are location at ignition; columns are the exit actually used. N = 355.
 
-| from | n | front | stage | main bar door | windows | kitchen | unspec. |
-|---|---|---|---|---|---|---|---|
-| **near stage / dance floor** | 75 | 16 | 7 | 4 | 40 | 1 | 7 |
-| behind dance floor / soundboard | 74 | 40 | – | 15 | 14 | 1 | 4 |
-| between the two bars | 29 | 15 | – | 9 | 2 | – | 3 |
-| rear bar / dart room | 28 | 4 | – | 10 | 3 | 10 | 1 |
-| near the stage door | 17 | 3 | 10 | 1 | 1 | 1 | 1 |
-| sunroom | 16 | 4 | 2 | 1 | 6 | – | 3 |
-| along the back wall | 15 | 3 | – | 4 | 7 | 1 | – |
-| back hallway / restrooms | 14 | 3 | – | 3 | 3 | 3 | 2 |
-| main bar area (excl. 6 at its door) | 31 | 8 | – | 18 | 2 | – | 3 |
+| area at ignition | sunroom win | bar door | unspec door | front | kitchen | main bar win | w/d R | w/d L | stage | unspec win | unk | total |
+|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|
+| Unclear | 0 | 0 | 0 | 6 | 0 | 0 | 0 | 0 | 0 | 1 | 1 | 8 |
+| Stage | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 4 | 0 | 0 | 4 |
+| Near stage door | 1 | 0 | 1 | 3 | 1 | 1 | 0 | 0 | 10 | 0 | 0 | 17 |
+| **Near stage or on dance floor** | 12 | 4 | 1 | **16** | 1 | **28** | 1 | 0 | **7** | 5 | 0 | **75** |
+| Back wall platform | 0 | 4 | 0 | 3 | 1 | 7 | 0 | 0 | 0 | 0 | 0 | 15 |
+| Sunroom | 6 | 1 | 0 | 4 | 0 | 0 | 0 | 0 | 2 | 3 | 0 | 16 |
+| Behind dance floor | 3 | 15 | 1 | **40** | 1 | 11 | 0 | 0 | 0 | 3 | 0 | 74 |
+| Back hallway | 2 | 3 | 0 | 3 | 3 | 1 | 0 | 0 | 0 | 1 | 1 | 14 |
+| Between bars | 0 | 9 | 1 | 15 | 0 | 2 | 0 | 1 | 0 | 0 | 1 | 29 |
+| Rear bar / dart room | 0 | 10 | 0 | 4 | 10 | 3 | 0 | 0 | 0 | 1 | 0 | 28 |
+| Entryway | 0 | 0 | 0 | 17 | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 17 |
+| Main bar | 0 | 24 | 2 | 8 | 0 | 2 | 0 | 0 | 0 | 1 | 0 | 37 |
+| Center stage-side | 0 | 1 | 0 | 4 | 1 | 1 | 0 | 0 | 0 | 0 | 0 | 7 |
+| Unknown / not reported | 2 | 0 | 0 | 4 | 1 | 1 | 0 | 0 | 0 | 1 | 5 | 14 |
+| **Total** | **26** | **71** | **6** | **127** | **19** | **57** | **1** | **1** | **23** | **16** | **8** | **355** |
 
 Two findings pull in opposite directions and the model must reproduce both:
 
-- **"The people closest to exit doors almost always used those doors."** The 17
-  in the entranceway used the front door; 4 on stage used the stage door; 6 by
-  the main bar door used it.
+- **"The people closest to exit doors almost always used those doors."** All 17
+  in the entryway used the front door; all 4 on stage used the stage door; 10 of
+  the 17 by the stage door used it; 24 of the 37 in the main bar used its door.
 - **Except where the fire intervened.** Of the 75 by the stage, only 16 reached
-  the front door and 7 the stage door — *their two closest exits*. Forty went
-  out windows and 4 crossed the venue to the main bar exit.
+  the front door and 7 the stage door — *their two closest exits*. Forty-five
+  went out windows, 28 of them crossing the venue to the main bar.
 
-And the front door's pull is visible from far away: 40 of the 74 behind the
-dance floor used it, and 31.5 % of all front-door users started there.
+And the front door's pull reaches far: 40 of the 74 behind the dance floor used
+it, and those 40 are 31.5 % of all front-door users.
+
+The `unk` column is the paper's own: 8 survivors whose exit could not be
+determined, which is why usage is reported for 347 of 355.
 
 ### Familiarity, quantified (pp. 6–7)
 
@@ -156,8 +166,9 @@ at zero and full familiarity.
 **Windows are 27.9 % of egress and we do not model them.** This is the largest
 threat to an honest comparison. Two options, and the choice must be stated in
 the results rather than buried: renormalise over door users only (front 52.9 %,
-main bar 29.5 %, stage 9.6 %, kitchen 8.0 %), or add windows as exits and
-compare directly. Silently ignoring them would inflate apparent agreement,
+main bar 29.6 %, stage 9.6 %, kitchen 7.9 % — from counts 127/71/23/19, the
+6 "unspecified door" cases excluded), or add windows as exits and compare
+directly. Silently ignoring them would inflate apparent agreement,
 because the 40 window users by the stage would be redistributed onto doors the
 model does have.
 

--- a/docs/superpowers/specs/2026-08-05-station-validation-design.md
+++ b/docs/superpowers/specs/2026-08-05-station-validation-design.md
@@ -1,0 +1,197 @@
+# The Station nightclub: validation against witness statements
+
+Date: 2026-08-05
+
+## Why this replaces the earlier plan
+
+The first Station plan validated against NIST NCSTAR 2 Vol. I §6.6 Table 6-2 —
+evacuation times and per-exit counts from Simulex and buildingEXODUS. That is a
+**model-to-model** comparison, and it tests the parts of pyFDS-Evac that are
+least interesting: geometry and congestion. Neither reference model has
+familiarity or sign visibility, so the two mechanisms this project exists to
+model could not appear in the comparison at all.
+
+`materials/rita.pdf` — Fahy, Proulx & Flynn, *"The Station Nightclub Fire — An
+analysis of witness statements"*, Fire Safety Science 10:197–209 (2011),
+doi:10.3801/IAFSS.FSS.10-197 — is an analysis of statements from 355 survivors.
+It gives **empirical human data on exactly the two mechanisms**: who knew which
+exits, and which exit each person actually used from where they were standing.
+
+NCSTAR keeps a role: it supplies the dimensioned geometry, the door clear
+widths, and a clear-air cross-check. But the primary target moves to observed
+behaviour.
+
+Source note: the paper's Table 2 (exits used by starting location) did not
+render legibly from the scanned PDF. Every per-location number below is taken
+from the prose on pp. 11–12, which restates the same breakdown. Before building,
+the table should be read directly and any discrepancy resolved in its favour.
+
+## What the paper gives us
+
+### Aggregate exit usage (share of survivors, p. 12)
+
+| exit | share |
+|---|---|
+| front (main) door | 35.8 % |
+| main bar door | 20.0 % |
+| stage door | 6.5 % |
+| kitchen door | 5.4 % |
+| **windows** | **27.9 %** (16.1 main bar, 7.3 sunroom, 4.5 unspecified) |
+
+Exit usage was determined for 347 of 355 survivors; 127 left by the front door.
+At least another 62 *attempted* the front door and failed — 34 of those went out
+a window, 25 through another door. So **at least 50 % of survivors tried or
+succeeded in using the front door**, out of four available doors.
+
+### Exit choice by starting location (pp. 11–12)
+
+The row that matters most, because it is the one a nearest-exit model gets
+wrong:
+
+| from | n | front | stage | main bar door | windows | kitchen | unspec. |
+|---|---|---|---|---|---|---|---|
+| **near stage / dance floor** | 75 | 16 | 7 | 4 | 40 | 1 | 7 |
+| behind dance floor / soundboard | 74 | 40 | – | 15 | 14 | 1 | 4 |
+| between the two bars | 29 | 15 | – | 9 | 2 | – | 3 |
+| rear bar / dart room | 28 | 4 | – | 10 | 3 | 10 | 1 |
+| near the stage door | 17 | 3 | 10 | 1 | 1 | 1 | 1 |
+| sunroom | 16 | 4 | 2 | 1 | 6 | – | 3 |
+| along the back wall | 15 | 3 | – | 4 | 7 | 1 | – |
+| back hallway / restrooms | 14 | 3 | – | 3 | 3 | 3 | 2 |
+| main bar area (excl. 6 at its door) | 31 | 8 | – | 18 | 2 | – | 3 |
+
+Two findings pull in opposite directions and the model must reproduce both:
+
+- **"The people closest to exit doors almost always used those doors."** The 17
+  in the entranceway used the front door; 4 on stage used the stage door; 6 by
+  the main bar door used it.
+- **Except where the fire intervened.** Of the 75 by the stage, only 16 reached
+  the front door and 7 the stage door — *their two closest exits*. Forty went
+  out windows and 4 crossed the venue to the main bar exit.
+
+And the front door's pull is visible from far away: 40 of the 74 behind the
+dance floor used it, and 31.5 % of all front-door users started there.
+
+### Familiarity, quantified (pp. 6–7)
+
+Visit frequency, for 288 of the surviving patrons:
+
+| | count | share |
+|---|---|---|
+| first visit | 84 | 29.2 % |
+| second visit | 31 | 10.8 % |
+| 3–5 visits | 62 | — |
+| *subtotal ≤5 visits* | *177* | *just over 60 %* |
+| regulars | ≥24 | — |
+
+Exit awareness, for the 82 patrons where it was recorded:
+
+- 32 aware of all or most alternate exits
+- **24 not aware of the location of the alternate exits**
+- 14 aware of the exit near the stage; 10 of the main bar exit; **2 of the
+  kitchen exit**
+- Of first-time visitors: 8 unaware of any alternate, 3 aware of the stage door
+  (two of them because they were standing next to it)
+
+**All patrons entered through the front door** — tickets collected, hands
+stamped. And of the 56 who arrived after 22:30, **none reported awareness of any
+alternative exit**.
+
+### Signs (p. 7)
+
+- 25 survivors explicitly did not notice any exit sign
+- the stage-door sign was **unlit**: six noticed it unlit, one said there was no
+  sign there at all
+- lit signs were noticed in the main bar (2) and near the rear bar (3)
+
+### Timing and victims
+
+Untenable on the dance floor in **under 90 s**, and in the dart room and sunroom
+ten seconds later. Of the 96 who died at the scene, **31 were in the entranceway
+pile-up** and 18 in the sunroom along the wall adjoining it.
+
+## Scenario definition
+
+**Geometry** from NCSTAR Fig. 1-5 as before: 412 m² footprint, four doors, clear
+widths from Table 7-6 (all side doors 914 mm; the front entrance limited by its
+914 mm interior door). Internal walls belong in the WKT so `wkt_to_fds` carries
+them into the FDS deck and hence into fdsvismap's occlusions.
+
+**Initial positions** from Fahy Fig. 4 rather than NCSTAR's uniform densities —
+the named areas with the counts in the table above. This is observed data
+replacing an assumption.
+
+**Familiarity** drawn to match the visit-frequency distribution, using the
+scalar parameterisation (probability an exit is in the agent's map at t=0)
+rather than the `full`/`discovery` binary:
+
+- ~29 % first-time → knows only the front door
+- ~11 % second visit → front door, plus a small chance of one alternate
+- ~40 % occasional (3–5 visits) → front door plus roughly one alternate
+- ~20 % regulars → most or all exits
+
+**Every agent starts knowing the front door**, because every patron walked in
+through it. That single rule is the mechanism behind the crush, and it is
+empirically grounded rather than tuned.
+
+**Signs**: stage door `c = 3` (unlit), main bar and rear bar `c = 8` (lit),
+front door `c = 8`.
+
+## Validation targets
+
+Primary, in order of how much they discriminate between models:
+
+1. **Origin→exit matrix**, compared row by row against the table above. A
+   nearest-exit model reproduces the entranceway and stage rows and fails the
+   dance-floor row.
+2. **Front-door share** ≥ 50 % of agents attempting it.
+3. **Aggregate per-exit split**, renormalised over door users (see below).
+
+Secondary, as a sanity band rather than a target: NCSTAR Table 6-2's clear-air
+times, 188 s (Simulex) and 202 s (buildingEXODUS), run with all hazard weights
+at zero and full familiarity.
+
+## Four things that bound what this can prove
+
+**Windows are 27.9 % of egress and we do not model them.** This is the largest
+threat to an honest comparison. Two options, and the choice must be stated in
+the results rather than buried: renormalise over door users only (front 52.9 %,
+main bar 29.5 %, stage 9.6 %, kitchen 8.0 %), or add windows as exits and
+compare directly. Silently ignoring them would inflate apparent agreement,
+because the 40 window users by the stage would be redistributed onto doors the
+model does have.
+
+**Survivor bias.** The matrix covers 355 survivors, not the ~455 present. The 96
+who died are absent, and they were concentrated exactly where the model is most
+stressed — 31 in the entranceway pile-up. Every row is conditioned on survival,
+so the model should not be expected to reproduce it as an unconditional
+distribution.
+
+**A bouncer blocked the stage door.** Thirteen survivors mention it; some
+diverted to the main door. We model no such intervention, so the stage-door row
+carries an unmodelled suppression.
+
+**The data is retrospective and self-reported.** The authors state it plainly:
+statements were collected by police for a different purpose, with no consistent
+question set, and the locations "cannot validly be used to calculate crowd
+density." Treat counts as approximate and do not fit parameters to them.
+
+## Model work this implies
+
+- **Scalar familiarity** replacing the `full`/`discovery` binary, as the
+  probability that each exit is in an agent's initial map.
+- **Seed the map with the spawn area's entrance**, so an agent knows the door it
+  came through. Empirically grounded here.
+- The **auto-wiring/discovery degeneracy** must be resolved first: in an
+  auto-wired graph, arrival at any crossing reveals every crossing and exit at
+  once, which would erase the familiarity gradient this scenario depends on.
+
+## Out of scope
+
+- Windows as an egress route, unless the renormalisation proves inadequate.
+- Group behaviour, though the paper documents it (124 of 275 who came with
+  others were already with their party; 16 did not try to find them).
+- Re-entry, altruistic behaviour, and injury outcomes.
+- Fitting any parameter to the witness data. It is a validation target, not a
+  calibration set — the distinction matters more here than usual, because the
+  data is rich enough to fit and too uncertain to fit to.


### PR DESCRIPTION
Replaces the earlier Station plan's validation target.

## Why

The previous plan targeted NCSTAR Table 6-2 — evacuation times and per-exit counts from Simulex and buildingEXODUS. That is **model-to-model**, and it tests geometry and congestion: the parts of pyFDS-Evac that matter least. Neither reference model has familiarity or sign visibility, so the two mechanisms this project exists to model could not appear in the comparison at all.

`materials/rita.pdf` — Fahy, Proulx & Flynn, *"The Station Nightclub Fire — An analysis of witness statements"*, Fire Safety Science 10:197–209 (2011) — analyses statements from 355 survivors and gives empirical data on exactly those mechanisms.

## What it gives us

**Familiarity, quantified.** 29.2 % first visit, 10.8 % second, just over 60 % had been ≤5 times. Of the 82 patrons whose exit awareness was recorded, **24 did not know where the alternate exits were**, and only 2 knew the kitchen exit. Of the 56 who arrived after 22:30, **none** knew of any alternative. **All** patrons entered through the front door.

**The behaviour to reproduce.** At least **50 % of survivors tried or succeeded in using the front door**, out of four available.

**An origin→exit matrix** that discriminates sharply between models. Two findings pull opposite ways and both must be reproduced:

- *"The people closest to exit doors almost always used those doors"* — the entranceway, on-stage and main-bar-door rows.
- **Except where the fire intervened**: of the 75 by the stage, only 16 reached the front door and 7 the stage door — their two closest — while 40 went out windows.

**Signs**, with an empirical anchor: the stage-door sign was **unlit**, and 25 survivors noticed no exit sign at all. That is the `c = 3` vs `c = 8` distinction.

## Four bounds, stated rather than buried

**Windows carried 27.9 % of egress and we do not model them.** The largest threat to an honest comparison: the 40 window users by the stage would otherwise be silently redistributed onto doors the model does have, inflating agreement. Either renormalise over door users (front 52.9 %, main bar 29.5 %, stage 9.6 %, kitchen 8.0 %) or add windows as exits — and say which in the results.

**Survivor bias.** 355 of ~455. The 96 who died are absent and were concentrated where the model is most stressed — 31 in the entranceway pile-up. Every row is conditioned on survival.

**A bouncer blocked the stage door**, mentioned by 13 survivors. An unmodelled suppression on that row.

**Retrospective self-report.** The authors state the statements were collected by police for another purpose with no consistent question set, and that the locations "cannot validly be used to calculate crowd density."

## Model work it implies

- scalar familiarity replacing the `full`/`discovery` binary
- seeding each agent's map with the entrance it came through — empirically grounded here, and the mechanism behind the crush
- resolving the auto-wiring/discovery degeneracy first, since arrival at any crossing currently reveals everything at once and would erase the familiarity gradient this scenario depends on

## Notes

Explicit that this is a **validation target, not a calibration set** — the data is rich enough to fit and too uncertain to fit to.

Source caveat recorded in the spec: the paper's Table 2 did not render legibly from the scanned PDF, so the per-location numbers come from the prose on pp. 11–12 that restates the same breakdown. The table should be read directly before building, and any discrepancy resolved in its favour. All nine location rows were checked to sum to their stated totals.

Docs only — no code, no test changes.