### PR TITLE
feat(routing): give auto-wired adjacency physical meaning

### DIFF
--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -147,14 +147,36 @@ class StageGraph:
                 for nid, n in graph.nodes.items()
                 if n.stage_type in ("distribution", "checkpoint")
             ]
+            # Connect a node only to those reachable without passing another,
+            # so "neighbour" keeps its physical meaning.  A complete graph would
+            # make it meaningless, and expand_on_arrival reveals every neighbour
+            # unconditionally -- so one arrival would expose the whole building
+            # and flatten the familiarity gradient.
+            # Only crossings can block. An exit is terminal -- you cannot pass
+            # through one -- so an exit lying on the way to a farther exit must
+            # not prune it, or that farther exit becomes unreachable outright.
+            blockers = [
+                nid for nid, n in graph.nodes.items() if n.stage_type == "checkpoint"
+            ]
             for src_id in sources:
-                for tgt_id in targets:
-                    if src_id == tgt_id:
-                        continue
-                    edge = _make_edge(
-                        graph.nodes[src_id], graph.nodes[tgt_id], routing_engine
+                candidates = [
+                    _make_edge(graph.nodes[src_id], graph.nodes[tgt_id], routing_engine)
+                    for tgt_id in targets
+                    if tgt_id != src_id
+                ]
+                kept = [
+                    edge
+                    for edge in candidates
+                    if not _passes_through_another_node(
+                        graph, src_id, edge, blockers, routing_engine
                     )
-                    graph.edges.setdefault(src_id, []).append(edge)
+                ]
+                # Pruning must never strand a node: if everything looked
+                # blocked, keep the nearest target so it still has somewhere
+                # to go and every exit stays reachable in some number of hops.
+                if not kept and candidates:
+                    kept = [min(candidates, key=lambda e: e.weight)]
+                graph.edges.setdefault(src_id, []).extend(kept)
 
         return graph
 
@@ -265,6 +287,51 @@ class StageGraph:
             cur = prev.get(cur)
         path.reverse()
         return path
+
+
+def _passes_through_another_node(
+    graph, src_id: str, edge: StageEdge, blockers, routing_engine
+) -> bool:
+    """Whether some third stage lies on the way from ``src_id`` to the target.
+
+    Betweenness by path length: C is on the way from A to B when going A->C->B
+    costs no more than A->B itself, within a small tolerance.  Distances follow
+    the walkable area when a routing engine is available, so a node around a
+    corner does not count as "in between" merely by being near the straight
+    line.
+
+    Only crossings are blockers.  Walking across a spawn area does not make the
+    target behind it unreachable, and an exit cannot be passed through at all --
+    treating either as a blocker strands whatever lies beyond.
+    """
+    src = graph.nodes[src_id]
+    tgt = graph.nodes[edge.target]
+    direct = edge.weight
+    if direct <= 1e-9:
+        return False
+    for mid_id in blockers:
+        if mid_id in (src_id, edge.target):
+            continue
+        mid = graph.nodes[mid_id]
+        via = _walkable_distance(
+            routing_engine,
+            (src.centroid_x, src.centroid_y),
+            (mid.centroid_x, mid.centroid_y),
+        ) + _walkable_distance(
+            routing_engine,
+            (mid.centroid_x, mid.centroid_y),
+            (tgt.centroid_x, tgt.centroid_y),
+        )
+        if via <= direct * (1.0 + _BETWEENNESS_TOLERANCE):
+            return True
+    return False
+
+
+# A third node counts as 'in between' when the detour through it costs no
+# more than this fraction above the direct path.  Small enough that a real
+# alternative route is not mistaken for one, large enough to absorb the
+# navmesh's polyline discretisation.
+_BETWEENNESS_TOLERANCE = 0.05
 
 
 def _make_edge(src_node: StageNode, tgt_node: StageNode, routing_engine) -> StageEdge:

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2090,14 +2090,21 @@ class TestAutoWiringWithCrossings:
         )
         assert sum(len(e) for e in graph.edges.values()) > 0
 
-    def test_distribution_reaches_every_exit_and_crossing(self):
+    def test_distribution_reaches_what_is_not_behind_something_else(self):
+        """Adjacency is physical, not complete.
+
+        The stages sit on a line: e0 at x=0, d0 at 5, c0 at 15, e1 at 30.  So
+        c0 lies exactly between d0 and e1, and d0 -> e1 is pruned; e1 is still
+        reachable, one hop further on.
+        """
         graph = StageGraph.from_scenario(
             self._stages(),
             [],
             distributions={"d0": {"polygon": _box(5, 0)}},
         )
         targets = {edge.target for edge in graph.edges.get("d0", [])}
-        assert targets == {"e0", "e1", "c0"}
+        assert targets == {"e0", "c0"}
+        assert "e1" in graph.shortest_paths_to_exits("d0")
 
     def test_crossing_reaches_exits_but_exits_are_terminal(self):
         graph = StageGraph.from_scenario(
@@ -2268,3 +2275,80 @@ class TestWalkableRemainingDistance:
         )
         straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
         assert effective == pytest.approx(16.0 - 16.0 + straight)
+
+
+class TestAdjacencyIsMeaningful:
+    """Auto-wiring connects a node only to those reachable without passing another.
+
+    A complete graph makes "neighbour" meaningless, and that matters beyond
+    tidiness: ``expand_on_arrival`` reveals every neighbour unconditionally, so
+    in a complete graph one arrival exposes the whole building and the
+    familiarity gradient collapses.  Adjacency has to mean physical adjacency
+    for that rule to say what it is meant to say.
+    """
+
+    @staticmethod
+    def _collinear_stages():
+        """d0 --- c0 --- e0 on a line, so c0 sits between d0 and e0."""
+        return {
+            "c0": {"polygon": _box(10, 0), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(20, 0), "stage_type": "exit"},
+        }
+
+    def test_a_node_behind_another_is_not_a_neighbour(self):
+        graph = StageGraph.from_scenario(
+            self._collinear_stages(),
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        targets = {edge.target for edge in graph.edges.get("d0", [])}
+        assert targets == {"c0"}, "e0 lies behind c0, so it is not adjacent to d0"
+
+    def test_the_intermediate_still_reaches_the_far_node(self):
+        graph = StageGraph.from_scenario(
+            self._collinear_stages(),
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        assert {edge.target for edge in graph.edges.get("c0", [])} == {"e0"}
+
+    def test_every_exit_stays_reachable(self):
+        """Pruning must not strand an exit: the path is longer, not absent."""
+        graph = StageGraph.from_scenario(
+            self._collinear_stages(),
+            [],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        reachable = graph.shortest_paths_to_exits("d0")
+        assert "e0" in reachable
+
+    def test_nodes_off_the_line_stay_adjacent(self):
+        """Only genuine betweenness prunes: a node to the side blocks nothing."""
+        stages = {
+            "c0": {"polygon": _box(10, 0), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(10, 20), "stage_type": "exit"},
+        }
+        graph = StageGraph.from_scenario(
+            stages, [], distributions={"d0": {"polygon": _box(0, 0)}}
+        )
+        assert {edge.target for edge in graph.edges.get("d0", [])} == {"c0", "e0"}
+
+    def test_a_source_is_never_left_with_no_edges(self):
+        """Guard: whatever the geometry, a spawn area keeps its nearest target."""
+        stages = {
+            "c0": {"polygon": _box(5, 0), "stage_type": "checkpoint"},
+            "c1": {"polygon": _box(10, 0), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(15, 0), "stage_type": "exit"},
+        }
+        graph = StageGraph.from_scenario(
+            stages, [], distributions={"d0": {"polygon": _box(0, 0)}}
+        )
+        assert graph.edges.get("d0"), "a spawn area must always have somewhere to go"
+
+    def test_explicit_transitions_are_untouched_by_pruning(self):
+        graph = StageGraph.from_scenario(
+            self._collinear_stages(),
+            [{"from": "d0", "to": "e0"}],
+            distributions={"d0": {"polygon": _box(0, 0)}},
+        )
+        assert {edge.target for edge in graph.edges.get("d0", [])} == {"e0"}


### PR DESCRIPTION
First of the three model changes the Station validation spec (#57) names. It is the stated **prerequisite**: the other two are pointless until adjacency means something.

## The problem

Auto-wiring connected every node to every other. That made "neighbour" meaningless — and it matters beyond tidiness, because `expand_on_arrival` reveals every neighbour **unconditionally**. In a complete graph, one arrival exposed the whole building and flattened the familiarity gradient the Station case depends on.

## The fix

Connect a node only to those reachable **without passing another**. A third node is "in between" when the detour through it costs no more than 5 % above the direct path, measured along the walkable area where a routing engine is available — so a node around a corner is not mistaken for one on the line.

**Arrival stays unconditional**, as previously decided. That rule now says what it was meant to say, because a junction's neighbours are the stages actually adjacent to it. On a corridor of crossings:

```
edges:  c1 -> [c2, e_near]      c2 -> [c1, c3]      c3 -> [c2, e_far]
        d0 -> [c1, e_near]

after arriving at c1, the agent knows: c1, c2, d0, e_near
exits known: e_near only, of 2
```

Before, that arrival revealed everything. The corridor structure emerges from geometry alone — no adjacency list authored.

## One design error the tests caught

My first attempt let **exits** block as well as crossings. Six tests failed, and the cause was real: an exit is terminal and cannot be passed through, so an exit lying on the way to a farther exit stranded that exit outright. In `cognitive_map_memory` the side exit sits almost exactly on the line from the spawn area to the far exit, which made the far exit unreachable and broke the scenario's premise.

**Only crossings block.** Spawn areas do not either — walking across one does not make the target behind it unreachable.

## Safety

Pruning never leaves a node with nowhere to go: if every candidate looks blocked, the nearest is kept. Every exit stays reachable in some number of hops rather than disappearing, and a test asserts exactly that.

Explicit `transitions` are untouched — this only runs on the auto-wiring path.

## Tests

Six new in `TestAdjacencyIsMeaningful`: a node behind another is not a neighbour; the intermediate still reaches it; every exit stays reachable; a node off the line still blocks nothing; a source always keeps an edge; explicit transitions are unaffected.

`test_distribution_reaches_every_exit_and_crossing` asserted the old complete-graph behaviour and is replaced by one asserting the new contract — including that the pruned exit is still reachable one hop on.

Full suite: **372 passed**, 0 failed. `ruff format --check` and `ruff check` clean.

## Still to come from the spec

- scalar familiarity replacing the `full`/`discovery` binary
- seeding each agent's map with the entrance it came through
