### PR TITLE
feat(cognitive-map): familiarity as a probability, plus entrance seeding

### DIFF
--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -19,20 +19,86 @@ class AgentCognitiveMap:
     known_edges: set[tuple[str, str]] = field(default_factory=set)
 
 
+def familiarity_probability(value) -> float:
+    """Normalise a familiarity setting to the probability an exit is known.
+
+    Accepts the historical names as well as a number, so existing scenarios and
+    the scalar form can coexist:
+
+        "full"      -> 1.0     the agent knows the whole building
+        "discovery" -> 0.0     it knows only what it can perceive
+        0.0 .. 1.0  -> itself  the probability each exit is in its map at t=0
+
+    A binary cannot express a real crowd. At The Station 29.2 % of patrons were
+    there for the first time and about two dozen were regulars -- a gradient.
+    """
+    if isinstance(value, str):
+        if value == "full":
+            return 1.0
+        if value == "discovery":
+            return 0.0
+        raise ValueError(
+            f"unknown familiarity {value!r}: expected 'full', 'discovery', "
+            "or a probability in [0, 1]"
+        )
+    probability = float(value)
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError(
+            f"familiarity {probability} is outside [0, 1]; it is the probability "
+            "that an exit is already known"
+        )
+    return probability
+
+
+def _learn_route_to(cmap: AgentCognitiveMap, graph, source: str, target: str) -> bool:
+    """Add the shortest path to *target*, nodes and edges, to the map.
+
+    Knowing an exit has to mean knowing how to reach it.  Routing runs on the
+    subgraph of known nodes *and* known edges, so an exit added on its own would
+    sit in the map unreachable -- present, and useless.
+    """
+    paths = graph.shortest_paths_to_exits(source)
+    entry = paths.get(target)
+    if entry is None:
+        return False
+    _cost, path = entry
+    for node_id in path:
+        cmap.known_nodes.add(node_id)
+    for a, b in zip(path, path[1:]):
+        cmap.known_edges.add((a, b))
+    return True
+
+
 def init_cognitive_map(
     spawn_node: str,
     graph,
-    familiarity: str,
+    familiarity,
     vis_model,
     time_s: float,
+    *,
+    rng=None,
+    entrance: str | None = None,
+    no_visibility: bool = False,
 ) -> AgentCognitiveMap:
     """Initialise a cognitive map for an agent spawning at *spawn_node*.
 
-    'full'      → knows everything immediately.
-    'discovery' → knows spawn node + any adjacent nodes whose sign is
-                  visible from the spawn centroid at t=*time_s*.
+    *familiarity* is the probability that each exit is already known (see
+    :func:`familiarity_probability`); 1.0 is the historical ``full`` tier and
+    0.0 the ``discovery`` one.
+
+    *entrance* names the exit the agent walked in through, which it knows
+    whatever its familiarity.  At The Station every patron entered by the front
+    door, and that one fact is the mechanism behind the crush: the exit everyone
+    knew was the one everyone went back to.
+
+    *rng* makes the draw reproducible; without one no probabilistic knowledge is
+    added, so a caller that forgets it gets the conservative result rather than
+    an irreproducible one.  *no_visibility* skips the perception step, for
+    callers testing the initial draw alone.
     """
-    if familiarity == "full":
+    probability = familiarity_probability(familiarity)
+
+    if probability >= 1.0:
         all_edges = {
             (e.source, e.target) for edges in graph.edges.values() for e in edges
         }
@@ -43,8 +109,17 @@ def init_cognitive_map(
         )
 
     cmap = AgentCognitiveMap(familiarity="discovery", known_nodes={spawn_node})
+
+    if entrance is not None and entrance in graph.nodes:
+        _learn_route_to(cmap, graph, spawn_node, entrance)
+
+    if rng is not None and probability > 0.0:
+        for exit_id in graph.exit_nodes():
+            if exit_id not in cmap.known_nodes and rng.random() < probability:
+                _learn_route_to(cmap, graph, spawn_node, exit_id)
+
     node = graph.nodes.get(spawn_node)
-    if node is not None:
+    if node is not None and not no_visibility:
         _expand_visible(
             cmap, spawn_node, graph, vis_model, time_s, node.centroid_x, node.centroid_y
         )

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1170,9 +1170,17 @@ def run_scenario(
                 f"direct_steering={len(direct_steering_info)} "
                 f"wait_info={len(agent_wait_info)}"
             )
-        # Pre-compute familiarity per distribution index.
-        dist_familiarity: list[str] = [
+        # Pre-compute familiarity per distribution index. The value may be
+        # "full", "discovery", or a probability in [0, 1] that each exit is
+        # already known -- a real crowd is a gradient, not two camps.
+        dist_familiarity: list = [
             d.get("parameters", {}).get("familiarity", "full")
+            for d in scenario.raw.get("distributions", {}).values()
+        ]
+        # The exit each spawn area's occupants walked in through, which they
+        # know whatever their familiarity.
+        dist_entrance: list = [
+            d.get("parameters", {}).get("entrance")
             for d in scenario.raw.get("distributions", {}).values()
         ]
         exit_counts: dict[str, int] = {}
@@ -1467,6 +1475,11 @@ def run_scenario(
                                             else "full"
                                         )
                                         path_state["familiarity"] = _fam
+                                        path_state["entrance"] = (
+                                            dist_entrance[_dist_idx]
+                                            if _dist_idx < len(dist_entrance)
+                                            else None
+                                        )
                                         if path_state and stage_graph is not None:
                                             _spawn_exit = _extract_terminal_exit(
                                                 path_state, stage_graph.nodes
@@ -1552,6 +1565,12 @@ def run_scenario(
                                             if flow_dist.get("dist_index", source_id)
                                             < len(dist_familiarity)
                                             else "full",
+                                            "entrance": dist_entrance[
+                                                flow_dist.get("dist_index", source_id)
+                                            ]
+                                            if flow_dist.get("dist_index", source_id)
+                                            < len(dist_entrance)
+                                            else None,
                                         }
                                         if stage_graph is not None:
                                             _spawn_exit = _extract_terminal_exit(
@@ -1863,6 +1882,10 @@ def run_scenario(
                                 familiarity,
                                 vis_model,
                                 current_time,
+                                # Seeded per agent so a probabilistic draw is
+                                # reproducible under a fixed run seed.
+                                rng=random.Random(seed + agent_id * 7919),
+                                entrance=wait_info.get("entrance"),
                             )
                     rs = agent_route_state[agent_id]
                     # Force the very first evaluation to happen immediately (at

--- a/tests/test_scalar_familiarity.py
+++ b/tests/test_scalar_familiarity.py
@@ -1,0 +1,169 @@
+"""Familiarity as a probability, and the entrance an agent walked in through.
+
+The `full`/`discovery` binary cannot express a real crowd. At The Station,
+29.2 % of patrons were there for the first time, just over 60 % had been five
+times or fewer, and about two dozen were regulars -- a gradient, not two camps.
+
+Familiarity is therefore the probability that each exit is already in an agent's
+map at t=0. It is an *initialisation* parameter: once the map exists the agent is
+either omniscient or learning, so everything downstream is unchanged.
+
+Knowing an exit means knowing how to reach it. An exit added without the route
+to it would sit in the map unreachable, since routing runs on the subgraph of
+known nodes *and* known edges, so the whole shortest path is added with it.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+from shapely.geometry import box
+
+from pyfds_evac.core.cognitive_map import cognitive_subgraph, init_cognitive_map
+from pyfds_evac.core.route_graph import StageGraph
+
+
+def _b(cx, cy, half=1.0):
+    return box(cx - half, cy - half, cx + half, cy + half)
+
+
+def _graph():
+    """Spawn, a crossing, and two exits the crossing leads to."""
+    stages = {
+        "cp": {"polygon": _b(10, 0), "stage_type": "checkpoint"},
+        "e_near": {"polygon": _b(20, 0), "stage_type": "exit"},
+        "e_far": {"polygon": _b(10, 20), "stage_type": "exit"},
+    }
+    return StageGraph.from_scenario(
+        stages, [], distributions={"spawn": {"polygon": _b(0, 0)}}
+    )
+
+
+def _known_exits(cmap):
+    return {n for n in cmap.known_nodes if n.startswith("e_")}
+
+
+class TestFamiliarityAsAProbability:
+    def test_one_point_zero_is_the_old_full_tier(self):
+        cmap = init_cognitive_map("spawn", _graph(), 1.0, None, 0.0)
+        assert cmap.familiarity == "full"
+        assert cmap.known_nodes == set(_graph().nodes)
+
+    def test_zero_is_the_old_discovery_tier(self):
+        graph = _graph()
+        by_number = init_cognitive_map("spawn", graph, 0.0, None, 0.0)
+        by_name = init_cognitive_map("spawn", graph, "discovery", None, 0.0)
+        assert by_number.known_nodes == by_name.known_nodes
+
+    def test_the_old_names_still_work(self):
+        graph = _graph()
+        assert init_cognitive_map("spawn", graph, "full", None, 0.0).familiarity == (
+            "full"
+        )
+        assert (
+            init_cognitive_map("spawn", graph, "discovery", None, 0.0).familiarity
+            == "discovery"
+        )
+
+    def test_a_population_lands_near_the_requested_share(self):
+        """Over many agents, the share knowing a given exit approaches p."""
+        graph = _graph()
+        p = 0.3
+        knows = 0
+        trials = 400
+        for i in range(trials):
+            cmap = init_cognitive_map(
+                "spawn", graph, p, None, 0.0, rng=random.Random(i), no_visibility=True
+            )
+            if "e_far" in cmap.known_nodes:
+                knows += 1
+        assert knows / trials == pytest.approx(p, abs=0.06)
+
+    def test_the_draw_is_reproducible_for_a_given_seed(self):
+        graph = _graph()
+        a = init_cognitive_map(
+            "spawn", graph, 0.5, None, 0.0, rng=random.Random(7), no_visibility=True
+        )
+        b = init_cognitive_map(
+            "spawn", graph, 0.5, None, 0.0, rng=random.Random(7), no_visibility=True
+        )
+        assert a.known_nodes == b.known_nodes
+
+    def test_a_value_outside_zero_to_one_is_rejected(self):
+        for bad in (-0.1, 1.5):
+            with pytest.raises(ValueError):
+                init_cognitive_map("spawn", _graph(), bad, None, 0.0)
+
+
+class TestKnowingAnExitMeansKnowingTheRoute:
+    def test_a_known_exit_is_actually_reachable(self):
+        """An exit without its route would sit in the map unusable."""
+        graph = _graph()
+        cmap = init_cognitive_map(
+            "spawn",
+            graph,
+            1.0 - 1e-9,
+            None,
+            0.0,
+            rng=random.Random(1),
+            no_visibility=True,
+        )
+        sub = cognitive_subgraph(cmap, graph)
+        for exit_id in _known_exits(cmap):
+            assert exit_id in sub.shortest_paths_to_exits("spawn"), exit_id
+
+    def test_the_intermediate_crossing_comes_with_the_exit(self):
+        graph = _graph()
+        cmap = init_cognitive_map(
+            "spawn",
+            graph,
+            1.0 - 1e-9,
+            None,
+            0.0,
+            rng=random.Random(1),
+            no_visibility=True,
+        )
+        if "e_near" in cmap.known_nodes:
+            assert "cp" in cmap.known_nodes, "the route to e_near passes cp"
+
+
+class TestEntranceSeeding:
+    """An agent knows the door it walked in through, whatever its familiarity.
+
+    At The Station every patron entered by the front door, and that single fact
+    is the mechanism behind the crush: the exit everyone knew was the one
+    everyone went back to.
+    """
+
+    def test_the_entrance_is_known_even_at_zero_familiarity(self):
+        cmap = init_cognitive_map(
+            "spawn", _graph(), 0.0, None, 0.0, entrance="e_far", no_visibility=True
+        )
+        assert "e_far" in cmap.known_nodes
+
+    def test_the_entrance_is_reachable_not_merely_listed(self):
+        graph = _graph()
+        cmap = init_cognitive_map(
+            "spawn", graph, 0.0, None, 0.0, entrance="e_far", no_visibility=True
+        )
+        assert "e_far" in cognitive_subgraph(cmap, graph).shortest_paths_to_exits(
+            "spawn"
+        )
+
+    def test_no_entrance_leaves_a_zero_familiarity_agent_knowing_no_exit(self):
+        """Control: the entrance is what puts it there, not the default state."""
+        cmap = init_cognitive_map("spawn", _graph(), 0.0, None, 0.0, no_visibility=True)
+        assert _known_exits(cmap) == set()
+
+    def test_an_unknown_entrance_name_is_ignored_not_fatal(self):
+        cmap = init_cognitive_map(
+            "spawn",
+            _graph(),
+            0.0,
+            None,
+            0.0,
+            entrance="not_a_stage",
+            no_visibility=True,
+        )
+        assert _known_exits(cmap) == set()


### PR DESCRIPTION
The remaining two model changes from the Station validation spec (#57), following #58's adjacency prerequisite.

## Familiarity as a probability

The `full`/`discovery` binary cannot express a real crowd. At The Station **29.2 %** of patrons were there for the first time, just over **60 %** had been five times or fewer, and about two dozen were regulars — a gradient, not two camps.

`familiarity` is now the probability that each exit is already in an agent's map at t=0. `"full"` and `"discovery"` are kept as names for 1.0 and 0.0, so every existing scenario is untouched.

**It is an initialisation parameter, not persistent state.** Once the map exists the agent is either omniscient or learning, so every downstream check on the tier works unchanged. That is what keeps the change small — no dataclass surgery, no ripple through `cognitive_subgraph` or the expansion rules.

A Station-like population (29.2 % first-timers, 10.8 % second visit, 40 % occasional at p=0.45, 20 % regulars at p=0.9), 400 agents, four exits:

```
1 exit known : 184 agents (46.0 %)
2 exits      :  84 agents (21.0 %)
3 exits      :  71 agents (17.8 %)
4 exits      :  61 agents (15.2 %)
```

That is the gradient the spec asks for, and the near-half who know only one exit are the population the crush is made of.

## Knowing an exit means knowing the route

Routing runs on the subgraph of known nodes **and** known edges, so an exit added on its own would sit in the map unreachable — present and useless. The whole shortest path is added with it, which is also what "knowing the building" means for a person: you know how to get there, not merely that a door exists.

Two tests pin it: a known exit is actually reachable through `cognitive_subgraph`, and the intermediate crossing arrives with it.

## Entrance seeding

An agent knows the door it walked in through, whatever its familiarity. Every patron entered The Station by the front door, and **that single fact is the mechanism behind the crush**: the exit everyone knew was the one everyone went back to. Empirically grounded rather than tuned.

Verified: at `familiarity = 0.0` with `entrance` set, every agent knows that exit and can route to it; without `entrance`, a zero-familiarity agent knows no exit at all. An unknown entrance name is ignored rather than fatal.

## Reproducibility

The draw needs an explicit `rng`, seeded per agent from the run seed. **Without one, no probabilistic knowledge is added at all** — a caller that forgets it gets the conservative result rather than an irreproducible one. A test asserts the same seed yields the same map.

Out-of-range values raise rather than clamp: `familiarity` is a probability, and 1.5 is a mistake, not an intention.

## Plumbing

Both flow through the scenario loader from distribution parameters, at the flow-spawning and by-number sites. Verified **end to end on a real config** — `familiarity: 0.5`, `entrance: "E_far"` — not only at unit level, since the last two model changes had plumbing gaps that unit tests could not see.

## Verification

12 new tests. Full suite **384 passed**, 0 failed. `ruff format --check` and `ruff check` clean.

## What remains for the Station

All three model changes from the spec are now in. The asset itself is still blocked on the geometry reconstruction, which is 60 m² short in the assembly area where 149 of the 355 survivors stood.
