### PR TITLE
feat(fds): warn on silent slice-height and FED mismatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ See [docs/usage.md](docs/usage.md) for the full catalogue of CLI flags,
 post-processing scripts, and the `scripts/run_and_plot.sh` driver that
 runs a simulation and produces every plot in one go.
 
+**Bringing your own FDS case?** Read
+[docs/fds-case-requirements.md](docs/fds-case-requirements.md) first. pyFDS-Evac
+does not run FDS, it samples the output of a finished run, and your deck has to
+dump specific slices for that to work. That page also covers the `&REAC` yields
+those slices depend on, and two failure modes that stay silent otherwise.
+
 ## Web GUI
 
 A [FastHTML](https://fastht.ml/) web GUI 

--- a/docs/fds-case-requirements.md
+++ b/docs/fds-case-requirements.md
@@ -26,7 +26,9 @@ quantity name `load_slice_sampler` looks up
 | Slice | Feeds | If absent |
 |-------|-------|-----------|
 | Extinction coefficient | smoke-speed, visibility gating, GUI smoke layer | `IndexError` when `--fds-dir` is given without `--constant-extinction` |
-| CO, CO2, O2 | FED toxic dose | Skipped for that species |
+| CO **and** CO2 **and** O2 | FED toxic dose | **FED is switched off and the run continues** (see below) |
+
+It is all three gases or none of them; there is no partial FED.
 
 `EXTINCTION` and `EXTINCTION COEFFICIENT` are two unrelated gas-phase output
 quantities (FDS User Guide Table 22.4) — don't confuse them. `EXTINCTION`
@@ -54,9 +56,38 @@ matter what `&SLCF` lines you add. Fix it at the source:
 That is the `t_junction` reaction. Yields are fuel properties: take them from
 your material's data rather than copying these.
 
+## Two silent failure modes
+
+**FED disabled.** If CO, CO2 or O2 is missing, pyFDS-Evac carries on with
+smoke-speed only and every FED column reads zero. A zero-dose result looks
+exactly like a never-computed one. A warning is logged when this happens, and
+it is the only signal you get:
+
+```
+FED is disabled for <dir>: it has no CO slice, and all three of CO, CO2 and
+O2 are needed. ...
+```
+
+**Wrong slice height.** `--smoke-slice-height` (default 2.0 m) is a
+preference, not a filter: a case with one slice of a quantity uses it whatever
+its height, and a mismatch never fails the run. A case you inherit often
+carries a single slice at whatever height its author chose, so you can end up
+sampling floor-level CO for standing agents. A warning fires past 0.5 m:
+
+```
+Requested a 'SOOT EXTINCTION COEFFICIENT' slice at z=0.50 m but the nearest
+available in <dir> is at z=2.00 m ...
+```
+
+Do not ignore either warning. Nothing else will tell you.
+
 ## Failure modes
 
 | Symptom | Cause |
 |---------|-------|
 | `IndexError: No slice with quantity 'SOOT EXTINCTION COEFFICIENT' found in <dir>` | The deck never declared `&SLCF QUANTITY='EXTINCTION COEFFICIENT'`, or the species was never tracked. |
+| `IndexError: No slice with quantity '...' found in <dir>` | The deck never declared that `&SLCF`, or the species was never tracked. |
+| Warning: FED is disabled for `<dir>` | CO, CO2 or O2 is missing. Check `CO_YIELD` on `&REAC`. |
+| FED is zero everywhere and nobody is incapacitated | Either genuinely survivable, or FED never ran. Check for the warning above before concluding the former. |
 | `ValueError: Point (x, y) is outside the sampled FDS slice domain` | Walkable area extends past the slice extent. |
+| Warning: requested slice at z=A, nearest is z=B | Your case has no slice near the height you asked for. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -30,6 +30,11 @@ uv run python run.py --scenario <scenario.json|.zip|dir> [options]
 
 ### FDS coupling (smoke / FED / visibility)
 
+Your FDS case has to dump specific slices before any of this works. See
+[fds-case-requirements.md](fds-case-requirements.md) for the deck lines to add
+and two failure modes (FED silently disabled, wrong slice height) that stay
+silent unless you check the warning log.
+
 | Flag | Purpose |
 |------|---------|
 | `--fds-dir DIR` | FDS result directory driving smoke-speed and FED. |

--- a/pyfds_evac/core/fds_sampling.py
+++ b/pyfds_evac/core/fds_sampling.py
@@ -7,10 +7,21 @@ FED model (gas concentrations).
 
 from __future__ import annotations
 
+import logging
+
 try:
     from fdsreader import Simulation
 except ModuleNotFoundError:
     Simulation = None
+
+
+_logger = logging.getLogger(__name__)
+
+# How far the selected slice may sit from the requested height before the
+# mismatch is worth reporting.  A slice this far off samples a different part
+# of the smoke layer than the caller asked for, which silently changes every
+# extinction and gas reading downstream.
+_SLICE_HEIGHT_TOLERANCE_M = 0.5
 
 
 class SliceFieldSampler:
@@ -73,6 +84,48 @@ class SliceFieldSampler:
         return float(subslice.data[t_index, i_index, j_index])
 
 
+def _slice_z_mid(slice_obj) -> float:
+    """Return the mid-height of a slice's z-extent."""
+    return (slice_obj.extent.z_start + slice_obj.extent.z_end) / 2
+
+
+def _warn_on_height_mismatch(
+    chosen,
+    requested_height_m: float | None,
+    quantity: str,
+    n_matches: int,
+    fds_dir: str,
+) -> None:
+    """Warn when the selected slice sits far from the requested height.
+
+    Height only ever breaks ties: a case holding a single slice of the
+    requested quantity uses it whatever its z, and a multi-slice case picks
+    the nearest available, which may still be nowhere near.  Either way the
+    caller gets readings from a different part of the smoke layer than it
+    asked for, with no other signal that it happened.
+    """
+
+    if requested_height_m is None:
+        return
+    z_mid = _slice_z_mid(chosen)
+    if abs(z_mid - requested_height_m) <= _SLICE_HEIGHT_TOLERANCE_M:
+        return
+    counted = "1 slice" if n_matches == 1 else f"{n_matches} slices"
+    _logger.warning(
+        "Requested a '%s' slice at z=%.2f m but the nearest available in %s is "
+        "at z=%.2f m (%.2f m away; %s of this quantity in the case). "
+        "Sampling continues at z=%.2f m, so every reading from this quantity "
+        "describes that height, not the one requested.",
+        quantity,
+        requested_height_m,
+        fds_dir,
+        z_mid,
+        abs(z_mid - requested_height_m),
+        counted,
+        z_mid,
+    )
+
+
 def load_slice_sampler(
     fds_dir: str,
     quantity: str | tuple[str, ...] | list[str],
@@ -119,9 +172,8 @@ def load_slice_sampler(
         tried = ", ".join(f"'{c}'" for c in candidates)
         raise IndexError(f"No slice with quantity {tried} found in {fds_dir}")
     if slice_height_m is not None and len(matches) > 1:
-        best = min(
-            matches,
-            key=lambda s: abs((s.extent.z_start + s.extent.z_end) / 2 - slice_height_m),
-        )
-        return SliceFieldSampler(best)
-    return SliceFieldSampler(matches[0])
+        chosen = min(matches, key=lambda s: abs(_slice_z_mid(s) - slice_height_m))
+    else:
+        chosen = matches[0]
+    _warn_on_height_mismatch(chosen, slice_height_m, name, len(matches), fds_dir)
+    return SliceFieldSampler(chosen)

--- a/pyfds_evac/core/run_config.py
+++ b/pyfds_evac/core/run_config.py
@@ -13,6 +13,7 @@ from the GUI. It defaults to a no-op.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Callable, Dict
 
 from .fed import (
@@ -32,6 +33,8 @@ from .smoke_speed import (
 from .visibility import VisibilityModel, extract_sign_descriptors
 
 Logger = Callable[[str], None]
+
+_logger = logging.getLogger(__name__)
 
 
 def _noop(_message: str) -> None:
@@ -68,6 +71,24 @@ def _build_fed_model(opts: Any, log: Logger):
         return None
     inventory = inspect_fds_quantities(opts.fds_dir)
     if not inventory.supports_default_fed():
+        # Not an error: plenty of cases legitimately carry no toxic gas data,
+        # and the run continues with smoke-speed only. But the result then has
+        # no FED in it at all, and every FED column reads zero, which looks
+        # exactly like a survivable fire. Say so rather than letting the user
+        # infer tenability from a model that never ran.
+        present = sorted(inventory.canonical_slice_names())
+        missing = sorted({"co", "co2", "o2"}.difference(present))
+        named = ", ".join(m.upper() for m in missing)
+        _logger.warning(
+            "FED is disabled for %s: it has no %s %s, and all three of CO, CO2 "
+            "and O2 are needed. Results will report zero dose and no "
+            "incapacitation. FDS only writes these species when the &REAC line "
+            "asks for them (CO needs CO_YIELD); see "
+            "docs/fds-case-requirements.md.",
+            opts.fds_dir,
+            named,
+            "slice" if len(missing) == 1 else "slices",
+        )
         return None
     log("Configuring FED calculation.")
     fed_config = DefaultFedConfig(
@@ -121,7 +142,8 @@ def _build_vis_model(scenario: Any, opts: Any, log: Logger):
     if not sign_descriptors:
         log("Warning: --vis-cache set but no sign descriptors found in config.")
         return None
-    log(f"Configuring visibility model ({len(sign_descriptors)} sign(s)).")
+    n_signs = len(sign_descriptors)
+    log(f"Configuring visibility model ({n_signs} sign{'' if n_signs == 1 else 's'}).")
     return VisibilityModel(
         fds_dir=opts.fds_dir,
         sign_descriptors=sign_descriptors,

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -17,7 +17,6 @@ from fasthtml.common import (
     Button,
     Div,
     EventStream,
-    I,
     Link,
     NotStr,
     P,
@@ -56,13 +55,6 @@ app, rt = fast_app(
     pico=False,
 )
 manager = RunManager()
-
-_TIERS = [
-    ("safe", "Safe"),
-    ("alert", "Alert"),
-    ("critical", "Critical"),
-    ("severe", "Severe"),
-]
 
 # ── style tokens ─────────────────────────────────────────────────────────────
 _CARD = "background:#2A262A;border:1px solid rgba(255,255,255,.07);border-radius:1.1rem;padding:20px;box-shadow:0 8px 24px rgba(0,0,0,.45)"
@@ -135,17 +127,6 @@ _LOGO_SVG = NotStr("""
   <circle cx="28.5" cy="11.5" r="2.1" fill="#f4c430"/>
 </svg>
 """)
-
-
-def _legend() -> Div:
-    return Div(
-        Div("Tenability tiers", cls="legend-label"),
-        Div(
-            *[Div(I(cls="sw"), label, cls=f"tier {name}") for name, label in _TIERS],
-            cls="tier-row",
-        ),
-        cls="tier-legend",
-    )
 
 
 def _fed_live_section() -> Div:
@@ -238,23 +219,66 @@ def _sidebar() -> Div:
     )
 
 
+def _warnings_card(messages: list[str]) -> Div:
+    """Show engine warnings above the results, or nothing when the run was clean.
+
+    These describe runs that *succeeded* but sampled something other than what
+    was asked for -- a slice at the wrong height, agents outside the FDS
+    domain. The numbers below look no different either way, so the only signal
+    a GUI user gets is this card.
+    """
+
+    if not messages:
+        return Div()
+    heading = "1 warning" if len(messages) == 1 else f"{len(messages)} warnings"
+    return Div(
+        Div(
+            f"{heading} during this run",
+            style=(
+                f"{_GROTESK};font-weight:600;font-size:15px;color:#F4C430;"
+                "margin-bottom:10px"
+            ),
+        ),
+        *[
+            P(
+                message,
+                style=f"font-size:.82rem;line-height:1.6;{_INK2};margin:0 0 8px",
+            )
+            for message in messages
+        ],
+        P(
+            "The run completed, but these affect what the results describe. "
+            "See docs/fds-case-requirements.md.",
+            style=f"font-size:.78rem;line-height:1.6;{_INK2};margin:10px 0 0;opacity:.8",
+        ),
+        style=(
+            "background:#2A262A;border:1px solid rgba(244,196,48,.35);"
+            "border-radius:1.1rem;padding:20px;box-shadow:0 8px 24px rgba(0,0,0,.45)"
+        ),
+    )
+
+
 def _run_panel_idle() -> Div:
     return Div(
         Div(
             Div(
-                Div(I(cls="dot"), "Standby", cls="standby-label"),
+                Div(
+                    _LOGO_SVG,
+                    style=(
+                        "width:64px;height:64px;border-radius:50%;display:flex;"
+                        "align-items:center;justify-content:center;"
+                        "background:rgba(255,106,26,.07);margin:0 auto 20px;"
+                        "animation:pulse 2.6s ease-in-out infinite"
+                    ),
+                ),
                 Div(
                     Div(
-                        "Configure a scenario, then run.",
-                        style=f"{_GROTESK};font-weight:600;font-size:22px;letter-spacing:-.02em;{_INK};margin-bottom:10px",
+                        "Choose a scenario and ",
+                        B("run", style="color:#FF6A1A"),
+                        style=f"{_GROTESK};font-weight:600;font-size:22px;letter-spacing:-.02em;{_INK}",
                     ),
-                    P(
-                        "Live telemetry streams as the coupled fire–pedestrian model steps. When it settles you'll explore agent trajectories, FED dose, smoke and route cost — all interactive.",
-                        style=f"font-size:.85rem;line-height:1.7;{_INK2};margin:0",
-                    ),
-                    style="max-width:46ch",
+                    style="max-width:46ch;text-align:center",
                 ),
-                _legend(),
                 cls="standby",
             ),
             style=_PANEL,
@@ -852,6 +876,7 @@ def _finished_view() -> Div:
 
     return Div(
         kpi_tiles,
+        _warnings_card(manager.warnings),
         art,
         trajviz.trajectory_component(result, scenario, fds_dir=manager.fds_dir),
         plot_card("Cumulative FED", plots.fed_figure(result), "fig-fed"),

--- a/pyfds_evac/webapp/runner.py
+++ b/pyfds_evac/webapp/runner.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import logging
 import sys
 import threading
 from typing import Any, Callable, Dict, List, Optional
@@ -18,6 +19,32 @@ from typing import Any, Callable, Dict, List, Optional
 from pyfds_evac.core import ProgressEvent, ScenarioResult, run_scenario
 
 _MAX_LOG_LINES = 800
+_MAX_WARNINGS = 50
+
+
+class _WarningCapture(logging.Handler):
+    """Collect WARNING-and-above records from the model into a list.
+
+    The console capture below only sees ``stdout``, so anything the engine
+    reports through ``logging`` never reached the GUI at all.  That hid the
+    warnings that matter most -- a slice sampled at the wrong height, or agents
+    walking outside the FDS domain -- because both produce a run that finishes
+    cleanly and looks entirely normal.
+    """
+
+    def __init__(self, sink: List[str]) -> None:
+        super().__init__(level=logging.WARNING)
+        self._sink = sink
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = record.getMessage()
+        except Exception:  # never let logging break a run
+            return
+        if message not in self._sink:  # warn-once sources still repeat on rerun
+            self._sink.append(message)
+        if len(self._sink) > _MAX_WARNINGS:
+            del self._sink[:-_MAX_WARNINGS]
 
 
 class _ConsoleCapture(io.TextIOBase):
@@ -67,6 +94,7 @@ class RunManager:
         self.last_event: Optional[ProgressEvent] = None
         self.fed_snapshots: List[tuple] = []  # (sim_time, max_fed, mean_fed)
         self.log_lines: List[str] = []
+        self.warnings: List[str] = []
 
     @property
     def running(self) -> bool:
@@ -99,6 +127,7 @@ class RunManager:
         self.last_event = None
         self.fed_snapshots = []
         self.log_lines = []
+        self.warnings = []
 
         def on_progress(ev: ProgressEvent) -> None:
             self.last_event = ev
@@ -111,6 +140,14 @@ class RunManager:
 
         def worker() -> None:
             capture = _ConsoleCapture(self.log_lines, echo=sys.__stdout__)
+            warning_handler = _WarningCapture(self.warnings)
+            model_logger = logging.getLogger("pyfds_evac")
+            model_logger.addHandler(warning_handler)
+            # A logger filters by level before handlers ever see a record, so an
+            # app or root configured above WARNING would drop these silently.
+            previous_level = model_logger.level
+            if model_logger.getEffectiveLevel() > logging.WARNING:
+                model_logger.setLevel(logging.WARNING)
             try:
                 with contextlib.redirect_stdout(capture):
                     result = run_scenario(
@@ -124,6 +161,8 @@ class RunManager:
                 self.error = f"{type(exc).__name__}: {exc}"
                 self.status = "error"
             finally:
+                model_logger.removeHandler(warning_handler)
+                model_logger.setLevel(previous_level)
                 self._lock.release()
 
         self._thread = threading.Thread(target=worker, daemon=True)

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -171,29 +171,6 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   color: hsl(var(--muted-foreground)); margin-top: .25rem;
 }
 
-/* ---- tier legend (run panel) ---- */
-.tier-legend {
-  margin-top: 1.25rem; padding: .9rem 1.25rem; border-radius: .9rem;
-  background: #252127; border: 1px solid rgba(255,255,255,.08);
-  width: 100%; max-width: 28rem;
-}
-.legend-label {
-  font-family: var(--font-mono);
-  font-size: .62rem; font-weight: 500; text-transform: uppercase;
-  letter-spacing: .12em; color: hsl(var(--muted-foreground));
-  text-align: center; margin-bottom: .7rem;
-}
-.tier-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: .5rem; }
-.tier {
-  display: flex; flex-direction: column; align-items: center; gap: .4rem;
-  font-family: var(--font-display); font-size: .72rem; font-weight: 600;
-  color: hsl(var(--foreground));
-}
-.tier .sw { width: 10px; height: 10px; border-radius: 3px; display: inline-block; flex: none; }
-.tier.safe .sw     { background: var(--tier-safe); }
-.tier.alert .sw    { background: var(--tier-alert); }
-.tier.critical .sw { background: var(--tier-critical); }
-.tier.severe .sw   { background: var(--tier-severe); }
 @media (max-width: 420px) { .tier-row { grid-template-columns: repeat(2, 1fr); row-gap: .75rem; } }
 @keyframes pulse {
   0%   { box-shadow: 0 0 0 0   rgba(255,90,31,.5); }
@@ -357,15 +334,6 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 
 /* ---- standby ---- */
 .standby { min-height: 58vh; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1.1rem; text-align: center; }
-.standby-label {
-  display: inline-flex; align-items: center; gap: .5rem;
-  font-family: var(--font-mono);
-  font-size: .68rem; letter-spacing: .04em; text-transform: uppercase;
-  color: hsl(var(--muted-foreground));
-  padding: .45rem 1rem; border: 1px solid rgba(255,255,255,.1);
-  border-radius: 99px; background: rgba(255,255,255,.02);
-}
-.standby-label .dot { width: 7px; height: 7px; border-radius: 99px; background: var(--ember); animation: pulse 2.4s infinite; }
 .standby-hint { font-size: .85rem; line-height: 1.7; color: hsl(var(--muted-foreground)); max-width: 40ch; }
 
 /* ---- utility ---- */
@@ -402,7 +370,7 @@ details[open] summary .chevron { transform: rotate(180deg); }
 }
 @keyframes riseIn { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: none; } }
 .rise { animation: riseIn .35s cubic-bezier(.2,.8,.2,1) both; }
-@media (prefers-reduced-motion: reduce) { .rise, .standby-label .dot { animation: none; } }
+@media (prefers-reduced-motion: reduce) { .rise { animation: none; } }
 
 
 /* =================================================================== */

--- a/tests/test_fds_sampling.py
+++ b/tests/test_fds_sampling.py
@@ -1,14 +1,22 @@
-"""load_slice_sampler candidate-quantity resolution.
+"""`load_slice_sampler`: which quantity resolves, and which slice of it.
 
-`EXTINCTION` and `SOOT EXTINCTION COEFFICIENT` are two unrelated FDS slice
-quantities (FDS User Guide Sec. 22.10.29 vs. Sec. 22.10.5): the former is a
-0/1/-1 combustion-suppression flag, the latter is the K [1/m] smoke
-extinction coefficient. Older code treated `EXTINCTION` as a fallback
-spelling of the soot slice, so a case missing the real slice would silently
-sample the combustion flag instead and feed 0/1/-1 into the smoke-speed
-model as if it were K. These tests pin down that the fallback is gone.
+Two independent concerns, merged here because they exercise the same entry
+point.
+
+**Quantity resolution.** `EXTINCTION` and `SOOT EXTINCTION COEFFICIENT` are
+unrelated FDS quantities (User Guide Sec. 22.10.29 vs. Sec. 22.10.5): the
+former is a 0/1/-1 combustion-suppression flag, the latter the K [1/m] smoke
+extinction coefficient. Older code treated `EXTINCTION` as a fallback spelling
+of the soot slice, so a case missing the real slice silently sampled the
+combustion flag and fed 0/1/-1 into the smoke-speed model as if it were K.
+
+**Slice selection.** Height only ever breaks ties between slices of the *same*
+quantity. A case holding exactly one such slice uses it whatever its z, which
+is the quiet failure the height tests pin down: the run continues with readings
+from the wrong part of the smoke layer unless something says so.
 """
 
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -17,20 +25,20 @@ from pyfds_evac.core.fds_sampling import load_slice_sampler
 
 
 class _FakeExtent:
-    def __init__(self):
+    def __init__(self, z_start=1.9, z_end=2.1):
         self.x_start, self.x_end = 0.0, 10.0
         self.y_start, self.y_end = 0.0, 10.0
-        self.z_start, self.z_end = 1.9, 2.1
+        self.z_start, self.z_end = z_start, z_end
 
 
 class _FakeSlice:
-    def __init__(self):
-        self.extent = _FakeExtent()
+    def __init__(self, z_start=1.9, z_end=2.1):
+        self.extent = _FakeExtent(z_start, z_end)
         self.subslices = []
 
 
-def _sim_with(quantity_to_slices: dict):
-    """Build a stand-in for `fdsreader.Simulation` keyed by quantity name."""
+def _sim_with_quantities(quantity_to_slices: dict):
+    """Stand-in keyed by quantity name, for tests about *which quantity* wins."""
 
     def filter_by_quantity(name):
         return list(quantity_to_slices.get(name, []))
@@ -40,9 +48,18 @@ def _sim_with(quantity_to_slices: dict):
     )
 
 
+def _sim_with(*slices):
+    """Stand-in returning these slices for any name, for tests about *which
+    slice of one quantity* wins -- the quantity is not the variable there."""
+    matched = list(slices)
+    return SimpleNamespace(
+        slices=SimpleNamespace(filter_by_quantity=lambda name: matched)
+    )
+
+
 def test_soot_extinction_coefficient_resolves():
     soot_slice = _FakeSlice()
-    sim = _sim_with({"SOOT EXTINCTION COEFFICIENT": [soot_slice]})
+    sim = _sim_with_quantities({"SOOT EXTINCTION COEFFICIENT": [soot_slice]})
     sampler = load_slice_sampler("case", "SOOT EXTINCTION COEFFICIENT", simulation=sim)
     assert sampler._slice is soot_slice
 
@@ -53,7 +70,7 @@ def test_bare_extinction_slice_is_not_used_as_a_fallback():
     `EXTINCTION` is a distinct FDS quantity, not an alias for the smoke
     extinction coefficient, so it must never be substituted in.
     """
-    sim = _sim_with({"EXTINCTION": [_FakeSlice()]})
+    sim = _sim_with_quantities({"EXTINCTION": [_FakeSlice()]})
     with pytest.raises(IndexError) as excinfo:
         load_slice_sampler("case", "SOOT EXTINCTION COEFFICIENT", simulation=sim)
     assert "SOOT EXTINCTION COEFFICIENT" in str(excinfo.value)
@@ -62,6 +79,74 @@ def test_bare_extinction_slice_is_not_used_as_a_fallback():
 def test_extinction_field_from_fds_does_not_fall_back_to_the_combustion_flag():
     from pyfds_evac.core.smoke_speed import ExtinctionField
 
-    sim = _sim_with({"EXTINCTION": [_FakeSlice()]})
+    sim = _sim_with_quantities({"EXTINCTION": [_FakeSlice()]})
     with pytest.raises(IndexError):
         ExtinctionField.from_fds("case", simulation=sim)
+
+
+def test_single_slice_is_used_whatever_its_height():
+    only = _FakeSlice(0.4, 0.6)
+    sampler = load_slice_sampler(
+        "case",
+        "SOOT EXTINCTION COEFFICIENT",
+        simulation=_sim_with(only),
+        slice_height_m=2.0,
+    )
+    assert sampler._slice is only
+
+
+def test_nearest_slice_wins_when_several_match():
+    low, mid, high = _FakeSlice(0.4, 0.6), _FakeSlice(1.9, 2.1), _FakeSlice(4.9, 5.1)
+    sampler = load_slice_sampler(
+        "case",
+        "SOOT EXTINCTION COEFFICIENT",
+        simulation=_sim_with(low, mid, high),
+        slice_height_m=2.0,
+    )
+    assert sampler._slice is mid
+
+
+def test_height_mismatch_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        load_slice_sampler(
+            "case",
+            "SOOT EXTINCTION COEFFICIENT",
+            simulation=_sim_with(_FakeSlice(0.4, 0.6)),
+            slice_height_m=2.0,
+        )
+    assert "SOOT EXTINCTION COEFFICIENT" in caplog.text
+    # The message must name both heights so the mismatch is actionable.
+    assert "2.00" in caplog.text
+    assert "0.50" in caplog.text
+
+
+def test_no_warning_when_the_slice_is_close_enough(caplog):
+    with caplog.at_level(logging.WARNING):
+        load_slice_sampler(
+            "case",
+            "SOOT EXTINCTION COEFFICIENT",
+            simulation=_sim_with(_FakeSlice(1.9, 2.1)),
+            slice_height_m=2.0,
+        )
+    assert caplog.text == ""
+
+
+def test_no_warning_when_no_height_was_requested(caplog):
+    with caplog.at_level(logging.WARNING):
+        load_slice_sampler(
+            "case",
+            "SOOT EXTINCTION COEFFICIENT",
+            simulation=_sim_with(_FakeSlice(0.4, 0.6)),
+        )
+    assert caplog.text == ""
+
+
+def test_missing_quantity_names_every_candidate_tried():
+    with pytest.raises(IndexError) as excinfo:
+        load_slice_sampler(
+            "case",
+            ("SOOT EXTINCTION COEFFICIENT", "EXTINCTION"),
+            simulation=_sim_with(),
+        )
+    assert "'SOOT EXTINCTION COEFFICIENT'" in str(excinfo.value)
+    assert "'EXTINCTION'" in str(excinfo.value)


### PR DESCRIPTION
feat(fds): warn on silent slice-height and FED mismatches

Two new warnings for cases where the FDS coupling silently gives you
something other than what you asked for:

- Slice height mismatch: sampling always uses the nearest available
  slice to the requested height, even when nothing is close, so you
  could end up reading floor-level CO for standing agents with no
  indication. Now warns past a 0.5 m gap, naming both heights.
- FED silently disabled: when CO, CO2, or O2 is missing from the FDS
  case, FED was already being skipped, but the run continued with every
  FED column at zero, identical to a genuinely safe result. Now warns
  and names the missing species (usually a missing CO_YIELD on &REAC).

GUI: both warnings are now visible in the app, not just the log. The
console capture only redirected stdout, so anything reported via
logging never reached the browser; runs now attach a log handler and
show a warnings card above the results. Also redesigned the idle run
panel: dropped the "Standby" chip and tenability tier legend for a
pulsing logo mark and "Choose a scenario and run".

New docs/fds-case-requirements.md covers the required &SLCF lines and
why a case can lack CO/soot/HCN entirely (missing _YIELD on &REAC).

tests/test_fds_sampling.py covers slice selection and the new warning.
