### PR TITLE
test, docs: address review findings on merged PRs

### DIFF
--- a/assets/exit_visibility_alpha/README.md
+++ b/assets/exit_visibility_alpha/README.md
@@ -240,9 +240,16 @@ experiment is about.
 This writes `geometry.wkt`, both configs, and `exit_visibility_alpha.fds`. The
 FDS deck is generated from the WKT via `pyfds_evac.core.wkt_to_fds`, with the
 generator's burner stripped and its analysis slices kept — fdsvismap needs an
-`EXTINCTION COEFFICIENT` slice to answer any legibility query at all, so
-`--geometry-only` would not do, since it drops the slices along with the fire.
-The builder asserts both conditions and fails loudly if either is violated.
+extinction slice to answer any legibility query at all, so `--geometry-only`
+would not do, since it drops the slices along with the fire. The builder asserts
+both conditions and fails loudly if either is violated.
+
+The two names for that slice are not a typo. The deck **asks** for
+`QUANTITY='EXTINCTION COEFFICIENT'`, because FDS 6.10.1 rejects
+`'SOOT EXTINCTION COEFFICIENT'` as an input quantity (ERROR 1042) — but it
+**records** the result under `SOOT EXTINCTION COEFFICIENT`, which is the name
+fdsvismap filters slices by. Input name and output name differ, so matching one
+against the other is what goes wrong.
 
 The deck must then be run once to produce the slice files that `--fds-dir`
 points at:

--- a/docs/superpowers/specs/2026-08-06-blind-spawn-discovery-design.md
+++ b/docs/superpowers/specs/2026-08-06-blind-spawn-discovery-design.md
@@ -87,6 +87,12 @@ else. Ties are resolved by `nearest_frontier_target`'s deterministic
 arbitrary — a test asserts it is *not* 30/0, which would mean the frontier
 choice ignores position.
 
+> **Outcome.** It was 30/0. `nearest_frontier_target` measured from the graph
+> node and never from the agent, so the tie broke identically for everyone. The
+> asset first shipped documenting that limitation; issue #68 fixed it and the
+> split is now 18/12. This paragraph was the prediction, and it was right for a
+> reason the spec did not anticipate.
+
 ## The expected sequence
 
 For a `discovery` agent, clear air:

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2288,19 +2288,40 @@ class TestWalkableRemainingDistance:
 
         Removing that rule must not make an exit around a corner look close.
         The routing engine handles it: the walkable distance goes to the corner
-        and turns, so it exceeds the straight line through the wall -- without
-        any special-casing of what the agent is currently heading toward.
+        and turns, so it exceeds the straight line through the wall.
+
+        The comparison is against the *same* graph without a routing engine,
+        which is the only way to show the geodesic is doing the work. An earlier
+        version of this test looped over three headings, left over from when
+        ``_position_aware_length`` took one; the loop variable was unused, so it
+        asserted one thing three times and would have passed had the routing
+        engine been ignored entirely.
         """
         import math
 
-        graph = self._graph()
         agent = (5.0, 1.5)
-        for heading in ("e0", "j", None):
-            effective, _ = _position_aware_length(
-                graph, ["j", "e0"], agent, path_length=16.0, first_length_m=16.0
-            )
-            straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
-            assert effective > straight, f"heading={heading}"
+        stages = {
+            "j": {"polygon": _box(18, 2), "stage_type": "checkpoint"},
+            "e0": {"polygon": _box(18, 18), "stage_type": "exit"},
+        }
+        transitions = [{"from": "j", "to": "e0"}]
+
+        with_engine, _ = _position_aware_length(
+            self._graph(), ["j", "e0"], agent, path_length=16.0, first_length_m=16.0
+        )
+        without_engine, _ = _position_aware_length(
+            StageGraph.from_scenario(stages, transitions),
+            ["j", "e0"],
+            agent,
+            path_length=16.0,
+            first_length_m=16.0,
+        )
+        straight = math.hypot(agent[0] - 18.0, agent[1] - 18.0)
+
+        assert without_engine == pytest.approx(straight), (
+            "no engine: the fallback is the straight line through the wall"
+        )
+        assert with_engine > straight, "engine: the walk turns at the corner"
 
     def test_euclidean_fallback_without_a_routing_engine(self):
         import math


### PR DESCRIPTION
Copilot review findings on #63, #65 and #66, which merged before I read them.

## Fixed

**#65 — a test that asserted one thing three times.** `test_a_route_around_the_corner_is_not_priced_as_the_crow_flies` looped over three `heading` values, left over from when `_position_aware_length` still took one. The loop variable was unused in the call. Worse than redundant: it would have passed even if the routing engine were ignored entirely, which is the one thing the test exists to check.

Now compares the same graph with and without an engine — the fallback must equal the straight line through the wall, the geodesic must exceed it.

**#63 — one name for a slice that has two.** The deck asks for `QUANTITY='EXTINCTION COEFFICIENT'` because FDS 6.10.1 rejects `'SOOT EXTINCTION COEFFICIENT'` as an *input* (ERROR 1042); FDS then *records* the result under `SOOT EXTINCTION COEFFICIENT`, which is what fdsvismap filters by. Input name ≠ output name, and matching one against the other is exactly what goes wrong. The README now says so.

**#66 — the spec predicted a split the code could not produce.** It said a test would assert the outcome is *not* 30/0. It was 30/0, because `nearest_frontier_target` measured from the graph node and never from the agent. Added an outcome note rather than leaving the spec reading as though the asset had shipped meeting its own prediction. (Fixed for real in #68 / PR #70; the split is now 18/12.)

## Needed no change

**#63, `route_cost_rows=0`.** The reviewer is right that `route_cost_history` is only populated when `--output-route-cost-history` is set, so `0` means "not collected", not "nothing ranked". That narrative was already rewritten when the #61 fix was documented — the sentence no longer exists.

**#64, `__walkable_area__` as a routing source.** Exactly right, and it landed in `5538f35` on that same PR; the comment sits on the pre-fix line. The guard rejects any `dist_key` not present in `data["distributions"]` and keeps the old exit-as-origin behaviour on that branch.

424 tests pass.