### PR TITLE
chore: enable ruff's import sorting, and sort

### DIFF
--- a/assets/blind_spawn_discovery/build_geometry.py
+++ b/assets/blind_spawn_discovery/build_geometry.py
@@ -48,9 +48,9 @@ Whether hop 1 also reveals the exits is a genuine open question about
 to record which happens rather than to assume three hops.
 """
 
-from pathlib import Path
 import json
 import math
+from pathlib import Path
 
 from shapely.geometry import box
 from shapely.ops import unary_union

--- a/assets/cognitive_map_memory/build_geometry.py
+++ b/assets/cognitive_map_memory/build_geometry.py
@@ -50,9 +50,9 @@ Familiarity is ``discovery``; at ``full`` the map holds everything from t=0 and
 there is nothing to acquire.
 """
 
-from pathlib import Path
 import json
 import math
+from pathlib import Path
 
 from shapely.geometry import box
 

--- a/assets/exit_visibility_alpha/build_geometry.py
+++ b/assets/exit_visibility_alpha/build_geometry.py
@@ -38,8 +38,8 @@ viewing angle and distance only, never by smoke.  That keeps alpha the single
 independent variable.
 """
 
-from pathlib import Path
 import json
+from pathlib import Path
 
 from shapely.geometry import Point, box
 

--- a/assets/fic_vs_fed_speed/build_geometry.py
+++ b/assets/fic_vs_fed_speed/build_geometry.py
@@ -43,8 +43,8 @@ Expected: the first two are indistinguishable; the third is ~1/0.65 = 1.54x
 slower.
 """
 
-from pathlib import Path
 import json
+from pathlib import Path
 
 from shapely.geometry import box
 

--- a/assets/iso_table22_coupled/build_geometry.py
+++ b/assets/iso_table22_coupled/build_geometry.py
@@ -40,8 +40,8 @@ What this catches that the stubbed test cannot
     model wants volume fraction, or a mesh whose extent does not cover the agent.
 """
 
-from pathlib import Path
 import json
+from pathlib import Path
 
 from shapely.geometry import box
 

--- a/assets/station/build_geometry.py
+++ b/assets/station/build_geometry.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Reconstruct The Station nightclub floor plan.
+
+Traced from the dimensioned plan of the venue (the version annotated with the
+four exit doors), cross-checked against NIST NCSTAR 2 Vol. I where they overlap.
+
+Coordinate system
+    x runs west-to-east along the front facade, y runs from the front facade
+    (y = 0, FRONT on the plan) toward the REAR.  Origin is the south-west corner
+    of the main building, so the western storage wing has negative x.
+
+Dimension provenance
+    Constants are marked "plan" when read directly off the drawing, "chain" when
+    derived from a dimension chain that closes, and "approx" where the drawing is
+    ambiguous.  Two chains close exactly and anchor everything else:
+
+      * West wall of the main bar room:  3.7 + 0.9 + 3.0 = 7.6, the labelled
+        height.  This fixes the main bar side exit door at 0.9 m wide, 3.7 m
+        north of the front corner.
+      * Overall widths:  32.8 (top) - 26.5 (front) = 6.3 m of western wing.
+
+    The 0.9 m door width independently reproduces NCSTAR Table 7-6's *measured*
+    914 mm clear width for the side doors.  That is a real cross-check between
+    two separate sources, not a restatement of one.
+
+Status
+    First-pass rectilinear reconstruction, NOT yet verified against the drawing
+    by eye.  Run with --preview and compare before trusting it.  The horseshoe
+    bar is squared off, and canted walls at the alcove and the western wing are
+    approximated by rectangles.
+"""
+
+from pathlib import Path
+
+from shapely.geometry import box
+from shapely.ops import unary_union
+
+HERE = Path(__file__).parent
+
+FRONT_WIDTH = 26.5  # plan
+TOP_WIDTH = 32.8  # plan
+DEPTH = 20.9  # plan
+WEST_WING = TOP_WIDTH - FRONT_WIDTH  # chain: 6.3
+
+DOOR_W = 0.9  # plan; matches NCSTAR Table 7-6's 914 mm
+
+# ── Rooms, (x_min, y_min, x_max, y_max) ──────────────────────────────
+ROOMS = {
+    # Front range, west to east
+    "main_bar_room": (0.0, 0.0, 8.5, 7.6),  # 7.6 chain; 8.5 approx
+    "entry_hall": (8.5, 0.0, 11.0, 2.8),  # 2.8 plan
+    "ticket_area": (8.5, 2.8, 11.0, 7.6),  # approx
+    "sunroom": (11.0, 0.0, 22.0, 5.0),  # 5 plan (east side)
+    "dressing_room": (22.0, 0.0, 24.4, 4.9),  # 2.4 x 4.9 plan
+    # Assembly range
+    "main_floor": (11.0, 5.0, 19.0, 12.3),  # circulation
+    "dance_floor": (13.5, 5.0, 19.0, 12.3),  # 7.3 deep, plan
+    "raised_platform": (19.0, 5.0, 22.6, 12.3),  # 3.6 x 7.3 plan
+    "alcove": (22.6, 5.0, 25.0, 8.0),  # 2.4 x 3 plan; lower corner carries the door
+    "raised_dining": (11.0, 12.3, 19.0, 14.4),  # 2.1 deep, plan
+    # Back of house
+    "kitchen": (0.0, 7.6, 7.3, 9.9),  # 7.3 x 2.3 plan
+    "rear_bar_dart": (0.0, 9.9, 11.0, 14.4),  # approx
+    "back_hallway": (7.3, 14.4, 11.0, 16.5),  # approx
+    "restroom_a": (11.0, 14.4, 14.0, 17.4),  # 3 x 3 plan
+    "restroom_b": (11.0, 17.4, 14.0, 20.4),  # 3 x 3 plan
+    "office": (5.0, 16.5, 11.0, 20.9),  # approx, within the 11.9 top block
+    "side_bar": (14.0, 14.4, 17.7, 17.4),  # 3.7 plan
+    "rear_area": (14.0, 14.4, 22.0, 17.0),  # approx
+    "storage_west": (-WEST_WING, 8.0, 0.0, 15.2),  # 6.1 x 7.2 plan
+}
+
+# Horseshoe main bar, squared off. NCSTAR Fig. 7-3 gives 12.7 m2 for it.
+MAIN_BAR_COUNTER = (1.9, 1.5, 6.5, 5.8)  # 4.6 x 4.3 plan
+
+# (wall axis, fixed coordinate, centre along the wall, width, outward normal)
+DOORS = {
+    "main_bar_side": ("x", 0.0, 3.7 + DOOR_W / 2, DOOR_W, -1),  # chain
+    "kitchen_side": ("x", 0.0, 8.75, DOOR_W, -1),  # approx
+    "platform_side": ("x", 25.0, 5.0 + DOOR_W / 2, DOOR_W, +1),  # 5 plan
+    "front_entrance": ("y", 0.0, 9.75, DOOR_W, -1),  # between the 2.0/2.1 dims
+}
+
+
+def _strip(axis, fixed, centre, width, outward, depth=1.6):
+    half = width / 2.0
+    if axis == "y":
+        lo, hi = sorted((fixed, fixed + outward * depth))
+        return box(centre - half, lo, centre + half, hi)
+    lo, hi = sorted((fixed, fixed + outward * depth))
+    return box(lo, centre - half, hi, centre + half)
+
+
+def build_walkable():
+    parts = [box(*bounds) for bounds in ROOMS.values()]
+    parts += [_strip(*spec) for spec in DOORS.values()]
+    walkable = unary_union(parts).difference(box(*MAIN_BAR_COUNTER))
+    if walkable.geom_type != "Polygon":
+        raise SystemExit(
+            f"walkable area is {walkable.geom_type}: some room is disconnected"
+        )
+    return walkable
+
+
+def preview(walkable):
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Polygon as MplPoly
+
+    fig, ax = plt.subplots(figsize=(11, 9))
+    xs, ys = walkable.exterior.xy
+    ax.add_patch(MplPoly(list(zip(xs, ys)), fc="#dfe7f0", ec="#20313f", lw=1.6))
+    for ring in walkable.interiors:
+        ix, iy = ring.xy
+        ax.add_patch(MplPoly(list(zip(ix, iy)), fc="#20313f"))
+    for name, bounds in ROOMS.items():
+        ax.text(
+            (bounds[0] + bounds[2]) / 2,
+            (bounds[1] + bounds[3]) / 2,
+            name.replace("_", "\n"),
+            fontsize=6,
+            ha="center",
+            va="center",
+        )
+    for name, (axis, fixed, centre, _w, _o) in DOORS.items():
+        x, y = (fixed, centre) if axis == "x" else (centre, fixed)
+        ax.plot(x, y, "o", ms=9, mfc="#d62728", mec="k", zorder=5)
+        ax.annotate(name, (x, y), textcoords="offset points", xytext=(8, 6), fontsize=7)
+    ax.set_aspect("equal")
+    ax.set_xlabel("x [m]   west -> east along the front facade")
+    ax.set_ylabel("y [m]   front -> rear")
+    ax.set_title(
+        f"The Station, reconstructed: {walkable.area:.0f} m2 walkable "
+        "(NCSTAR footprint 412 m2)",
+        fontsize=10,
+    )
+    ax.grid(alpha=0.25)
+    fig.tight_layout()
+    out = HERE / "layout_preview.png"
+    fig.savefig(out, dpi=140)
+    print(f"Wrote: {out}")
+
+
+def build(make_preview: bool = False):
+    walkable = build_walkable()
+    (HERE / "geometry.wkt").write_text(walkable.wkt + "\n", encoding="utf-8")
+    print(f"Walkable area : {walkable.area:7.1f} m2   (NCSTAR footprint 412 m2)")
+    print(f"Bounding box  : {tuple(round(v, 1) for v in walkable.bounds)}")
+    print(f"Expected      : x in [{-WEST_WING}, {FRONT_WIDTH}], y in [0.0, {DEPTH}]")
+    if make_preview:
+        preview(walkable)
+    return walkable
+
+
+if __name__ == "__main__":
+    import sys
+
+    build(make_preview="--preview" in sys.argv)

--- a/assets/t_junction/vis.py
+++ b/assets/t_junction/vis.py
@@ -1,6 +1,6 @@
-from jupedsim.internal.notebook_utils import animate, read_sqlite_file
-
 import sys
+
+from jupedsim.internal.notebook_utils import animate, read_sqlite_file
 
 trajectory_file = sys.argv[1]
 traj, walkable_area = read_sqlite_file(trajectory_file)

--- a/docs/smv-repro/build_repro.py
+++ b/docs/smv-repro/build_repro.py
@@ -24,7 +24,6 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
-
 from pyfds_evac.core.smv_export import (
     patch_ini_for_avatars,
     patch_smv_file,

--- a/notebooks/fds-evac.ipynb
+++ b/notebooks/fds-evac.ipynb
@@ -13,22 +13,22 @@
    },
    "outputs": [],
    "source": [
+    "import math\n",
     "import os\n",
-    "import sys\n",
     "import pickle\n",
+    "import sys\n",
     "from pathlib import Path\n",
+    "from typing import Any, List, Tuple\n",
     "\n",
     "import fdsvismap as fv\n",
     "import jupedsim as jps\n",
     "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
     "import pedpy\n",
     "import shapely\n",
-    "from matplotlib.patches import Circle\n",
-    "from shapely import Polygon, from_wkt\n",
-    "import numpy as np\n",
     "from jupedsim.internal.notebook_utils import animate, read_sqlite_file\n",
-    "from typing import Any, List, Tuple\n",
-    "import math"
+    "from matplotlib.patches import Circle\n",
+    "from shapely import Polygon, from_wkt"
    ]
   },
   {

--- a/pyfds_evac/config.py
+++ b/pyfds_evac/config.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+
 from shapely import Polygon
 
 

--- a/pyfds_evac/core/__init__.py
+++ b/pyfds_evac/core/__init__.py
@@ -5,9 +5,10 @@ from .fds_inventory import (
     inspect_fds_quantities,
     list_simulations,
 )
+from .fds_sampling import SliceFieldSampler, load_slice_sampler
 from .fed import (
-    DefaultFedInputs,
     DefaultFedConfig,
+    DefaultFedInputs,
     DefaultFedModel,
     FdsFedField,
     FedComponents,
@@ -18,7 +19,6 @@ from .fed import (
     default_fic,
     time_to_fed_threshold_s,
 )
-from .fds_sampling import SliceFieldSampler, load_slice_sampler
 from .route_graph import (
     RerouteConfig,
     RouteCostConfig,
@@ -32,7 +32,6 @@ from .scenario import (
     load_scenario,
     run_scenario,
 )
-from .visibility import VisibilityModel
 from .smoke_speed import (
     ConstantExtinctionField,
     ExtinctionField,
@@ -41,6 +40,7 @@ from .smoke_speed import (
     extinction_from_soot_density,
     speed_from_soot_density,
 )
+from .visibility import VisibilityModel
 
 __all__ = [
     "ConstantExtinctionField",

--- a/pyfds_evac/core/fds_inventory.py
+++ b/pyfds_evac/core/fds_inventory.py
@@ -1,7 +1,7 @@
 """Inspect which FDS quantities are available for smoke and FED models."""
 
-from dataclasses import dataclass
 import pathlib
+from dataclasses import dataclass
 
 try:
     from fdsreader import Simulation

--- a/pyfds_evac/core/run_config.py
+++ b/pyfds_evac/core/run_config.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 import logging
 from typing import Any, Callable, Dict
 
+from .fds_inventory import inspect_fds_quantities
 from .fed import (
     DefaultFedConfig,
     DefaultFedModel,
     FdsFedField,
     TenabilityConfig,
 )
-from .fds_inventory import inspect_fds_quantities
 from .route_graph import RerouteConfig, RouteCostConfig
 from .smoke_speed import (
     ConstantExtinctionField,

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -35,6 +35,12 @@ import numpy as np
 from shapely import wkt
 from shapely.geometry import Polygon
 
+from .cognitive_map import (
+    AgentCognitiveMap,
+    expand_from_visibility,
+    expand_on_arrival,
+    init_cognitive_map,
+)
 from .direct_steering_runtime import (
     advance_path_target,
     assign_agent_target,
@@ -47,11 +53,10 @@ from .direct_steering_runtime import (
     set_agent_smoke_factor,
     update_checkpoint_speed,
 )
-from .cognitive_map import (
-    AgentCognitiveMap,
-    expand_from_visibility,
-    expand_on_arrival,
-    init_cognitive_map,
+from .fed import (
+    default_fed_components,
+    default_fic,
+    sample_incapacitation_threshold,
 )
 from .route_graph import (
     AgentRouteState,
@@ -61,11 +66,6 @@ from .route_graph import (
     evaluate_and_reroute,
     rank_routes,
     should_reevaluate,
-)
-from .fed import (
-    default_fed_components,
-    default_fic,
-    sample_incapacitation_threshold,
 )
 from .smoke_speed import ConstantExtinctionField
 
@@ -402,8 +402,8 @@ class Scenario:
             _, ax = plt.subplots(figsize=(12, 7), constrained_layout=True)
 
         # Walkable area (exterior + interior holes as walls)
-        from matplotlib.path import Path as MplPath
         from matplotlib.patches import PathPatch
+        from matplotlib.path import Path as MplPath
 
         exterior_coords = list(self.walkable_polygon.exterior.coords)
         codes = (

--- a/pyfds_evac/core/simulation_init.py
+++ b/pyfds_evac/core/simulation_init.py
@@ -1,18 +1,18 @@
+import importlib.util
 import json
 import math
 import random
-import zlib
-import pedpy
-from shapely.geometry import Point, Polygon
-from typing import Any, Dict, List, Tuple
-import jupedsim as jps
-import shapely
-from collections import defaultdict
-import numpy as np
-
-import importlib.util
 import subprocess
 import sys
+import zlib
+from collections import defaultdict
+from typing import Any, Dict, List, Tuple
+
+import jupedsim as jps
+import numpy as np
+import pedpy
+import shapely
+from shapely.geometry import Point, Polygon
 
 from .premovement_distributions import (
     PREMOVEMENT_PRESETS,
@@ -718,9 +718,9 @@ def _initialize_with_fallback(
     global_parameters=None,
 ) -> Tuple[Dict[str, Any], List[Tuple[float, float]], Dict[int, float], Dict[str, Any]]:
     """Fallback initialization logic"""
+    import numpy as np
     from shapely.geometry import Polygon
     from shapely.ops import unary_union
-    import numpy as np
 
     # print("Data:", data)
 

--- a/pyfds_evac/jpstooling.py
+++ b/pyfds_evac/jpstooling.py
@@ -1,13 +1,14 @@
 """jupedsim related functions."""
 
-import numpy as np
-from .utilities import distance
-from typing import List, Tuple, Any
-import jupedsim as jps
+import logging
 from pathlib import Path
+from typing import Any, List, Tuple
+
+import jupedsim as jps
+import numpy as np
 
 from .config import SimulationConfig
-import logging
+from .utilities import distance
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"

--- a/pyfds_evac/webapp/docs.py
+++ b/pyfds_evac/webapp/docs.py
@@ -6,9 +6,10 @@ Equation strings use $$ … $$ / $ … $; KaTeX auto-render handles them.
 """
 
 from __future__ import annotations
-from typing import Any
-from fasthtml.common import Button, Div, H1, NotStr, P, Span
 
+from typing import Any
+
+from fasthtml.common import H1, Button, Div, NotStr, P, Span
 
 # ── style tokens ──────────────────────────────────────────────────────────────
 _MONO = "font-family:'JetBrains Mono',monospace"

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -14,7 +14,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from fasthtml.common import Div, H3, NotStr
+from fasthtml.common import H3, Div, NotStr
 
 from .plots import _PALETTE, _agent_exit_map
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,3 +51,10 @@ dev = [
     "pytest>=9.0.2",
     "ruff>=0.15.7",
 ]
+
+[tool.ruff.lint]
+# Ruff's defaults (E4, E7, E9, F) plus import sorting. The codebase already
+# follows the stdlib / third-party / local grouping everywhere; nothing enforced
+# it, so a misplaced import passed `ruff check` while being wrong -- which is
+# exactly what happened in #74 and was caught by a reviewer rather than by CI.
+extend-select = ["I"]

--- a/run.py
+++ b/run.py
@@ -11,8 +11,8 @@ from pyfds_evac.core import (
     load_scenario,
     run_scenario,
 )
-from pyfds_evac.core.run_config import build_run_kwargs
 from pyfds_evac.core.agent_scalars import write_agent_scalars
+from pyfds_evac.core.run_config import build_run_kwargs
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/generate_fed_guide_plot.py
+++ b/scripts/generate_fed_guide_plot.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
-from src.core.fed import DefaultFedInputs, accumulate_default_fed
+from pyfds_evac.core.fed import DefaultFedInputs, accumulate_default_fed
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/scripts/generate_routing_diagram.py
+++ b/scripts/generate_routing_diagram.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 from pathlib import Path
+
 import matplotlib.pyplot as plt
-from matplotlib.patches import FancyBboxPatch, Circle, Polygon
+from matplotlib.patches import Circle, FancyBboxPatch, Polygon
 
 OUT_PATH = Path("routing_diagram_final_result.png")
 

--- a/scripts/generate_tenability_curves.py
+++ b/scripts/generate_tenability_curves.py
@@ -17,7 +17,6 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 # Frantzich-Nilsson defaults (Ronchi 2013 interpretation A3)
 ALPHA_K = 0.706
 BETA_K = -0.057

--- a/scripts/plot_trajectories.py
+++ b/scripts/plot_trajectories.py
@@ -38,8 +38,8 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Polygon as MplPoly  # noqa: E402
-from shapely.geometry import Point, Polygon  # noqa: E402
 from shapely import wkt as shapely_wkt  # noqa: E402
+from shapely.geometry import Point, Polygon  # noqa: E402
 
 PALETTE = ["#2b7bba", "#d94801", "#31a354", "#756bb1", "#e6ab02"]
 UNFINISHED = "#b0b0b0"

--- a/scripts/vis.py
+++ b/scripts/vis.py
@@ -1,6 +1,6 @@
-from jupedsim.internal.notebook_utils import animate, read_sqlite_file
-
 import sys
+
+from jupedsim.internal.notebook_utils import animate, read_sqlite_file
 
 trajectory_file = sys.argv[1]
 traj, walkable_area = read_sqlite_file(trajectory_file)

--- a/tests/test_agent_path_state.py
+++ b/tests/test_agent_path_state.py
@@ -4,7 +4,6 @@ from shapely.geometry import box
 
 from pyfds_evac.core.simulation_init import build_agent_path_state
 
-
 # A single journey listing every stage, as the scenario loader emits it.  The
 # spurious sequential pairs this creates must not shadow the real transitions.
 _ALL_STAGES = [

--- a/tests/test_fed.py
+++ b/tests/test_fed.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
+from pyfds_evac.core import load_scenario, run_scenario
 from pyfds_evac.core.fed import (
     DefaultFedInputs,
     _cn_fed_rate_per_minute,
@@ -19,8 +20,6 @@ from pyfds_evac.core.fed import (
     default_fed_rate_per_minute,
     time_to_fed_threshold_s,
 )
-from pyfds_evac.core import load_scenario, run_scenario
-
 
 CONSTANT_EXPOSURE_CASES = {
     "co_only": DefaultFedInputs(

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -6,20 +6,20 @@ import pytest
 from shapely.geometry import Polygon
 
 from pyfds_evac.core.route_graph import (
+    AgentRouteState,
+    RerouteConfig,
+    RouteCostConfig,
     StageEdge,
     StageGraph,
     StageNode,
-    RouteCostConfig,
-    RerouteConfig,
-    AgentRouteState,
+    _position_aware_length,
+    compute_eval_offset,
+    evaluate_and_reroute,
     evaluate_route,
     evaluate_segment,
     rank_routes,
-    compute_eval_offset,
-    should_reevaluate,
     reroute_agent,
-    evaluate_and_reroute,
-    _position_aware_length,
+    should_reevaluate,
 )
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField
 
@@ -2252,8 +2252,8 @@ class TestWalkableRemainingDistance:
     @staticmethod
     def _l_corridor():
         """An L: a horizontal leg and a vertical leg meeting at the far end."""
-        from shapely.ops import unary_union
         from shapely.geometry import box as _shp_box
+        from shapely.ops import unary_union
 
         return unary_union([_shp_box(0, 0, 20, 3), _shp_box(17, 0, 20, 20)])
 

--- a/tests/test_visibility.py
+++ b/tests/test_visibility.py
@@ -16,7 +16,6 @@ from pyfds_evac.core.visibility import (
     extract_sign_descriptors,
 )
 
-
 # ── helpers ───────────────────────────────────────────────────────────
 
 SIGNS = {

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -117,9 +117,10 @@ def test_full_run_streams_progress_and_completes(client):
 
 def test_second_run_rejected_while_active(client):
     # Hold the lock by faking an active run, then ensure start() refuses.
+    from argparse import Namespace
+
     from pyfds_evac.core import load_scenario
     from pyfds_evac.core.run_config import build_run_kwargs
-    from argparse import Namespace
 
     scenario = load_scenario("assets/ISO-table21")
     opts = Namespace(

--- a/tests/verification/test_fed_verif.py
+++ b/tests/verification/test_fed_verif.py
@@ -12,9 +12,9 @@ import random
 import pytest
 
 from pyfds_evac.core.fed import (
+    _FIC_COEFFS_PPM,
     DefaultFedInputs,
     TenabilityConfig,
-    _FIC_COEFFS_PPM,
     accumulate_default_fed,
     default_fed_rate_per_minute,
     default_fic,

--- a/tests/verification/test_s1_corridor_fed.py
+++ b/tests/verification/test_s1_corridor_fed.py
@@ -22,10 +22,6 @@ indistinguishable from the control).
 from __future__ import annotations
 
 import pytest
-
-from pyfds_evac.core.fed import TenabilityConfig
-from pyfds_evac.core.scenario import run_scenario
-
 from harness import (
     CorridorSpec,
     corridor_scenario,
@@ -35,6 +31,9 @@ from harness import (
     time_to_incapacitation_s,
     uniform,
 )
+
+from pyfds_evac.core.fed import TenabilityConfig
+from pyfds_evac.core.scenario import run_scenario
 
 # 6 % CO -> t* ~ 23.4 s, comfortably inside the 40 s free-walk egress.
 CO_PPM = 60_000.0

--- a/tests/verification/test_s2_corridor_speed.py
+++ b/tests/verification/test_s2_corridor_speed.py
@@ -23,9 +23,6 @@ cannot pass.
 from __future__ import annotations
 
 import pytest
-
-from pyfds_evac.core.scenario import run_scenario
-
 from harness import (
     CorridorSpec,
     corridor_scenario,
@@ -34,6 +31,8 @@ from harness import (
     make_smoke_model,
     uniform,
 )
+
+from pyfds_evac.core.scenario import run_scenario
 
 # K0 = 2 /m: sub-lethal haze. Lund -> 0.839, Fridolf -> 0.429 (clear divergence).
 K0 = 2.0

--- a/tests/verification/test_s4_tjunction_reroute.py
+++ b/tests/verification/test_s4_tjunction_reroute.py
@@ -26,10 +26,6 @@ route evaluation entirely -- a verified limitation worth its own bug report).
 from __future__ import annotations
 
 import pytest
-
-from pyfds_evac.core.route_graph import RerouteConfig, RouteCostConfig
-from pyfds_evac.core.scenario import run_scenario
-
 from harness import (
     EXIT_LEFT,
     EXIT_RIGHT,
@@ -41,6 +37,9 @@ from harness import (
     t_junction_scenario,
     uniform,
 )
+
+from pyfds_evac.core.route_graph import RerouteConfig, RouteCostConfig
+from pyfds_evac.core.scenario import run_scenario
 
 REEVAL_INTERVAL_S = 5.0
 # Right-arm extinction: enough that the short smoky route costs more than the


### PR DESCRIPTION
Follow-up to the review on #74, which caught a stdlib import placed after a third-party one.

## Why CI missed it

There is no `[tool.ruff]` section in `pyproject.toml` at all — ruff has been running on bare defaults (`E4`, `E7`, `E9`, `F`). Import ordering is a convention this codebase follows everywhere and **nothing enforced it**, so a wrongly-grouped import passes `ruff check` while being wrong. A human reviewer caught what CI should have.

```toml
[tool.ruff.lint]
extend-select = ["I"]
```

`extend-select` rather than `select`, so ruff's defaults stay in force instead of being silently narrowed to whatever is listed.

## The change

33 violations across 31 files, all autofixed. **The diff is pure reordering** — no import added or removed, confirmed line by line in `git diff`.

## The one real risk, checked

Seven files call `matplotlib.use("Agg")` *between* imports, where reordering would move `import matplotlib.pyplot` above the backend selection and break headless plotting. isort treats an intervening statement as a barrier and sorts each block independently, so all seven still have `use("Agg")` first.

Verified functionally rather than by reading the diff:

- `scripts/plot_trajectories.py` runs and writes a PNG
- `generate_cognitive_map_states.py` and `generate_exit_visibility_map.py` import cleanly

453 tests pass. `ruff check .` and `ruff format --check .` both clean.

## Note for whoever runs this locally

Touching `pyproject.toml` invalidates uv's cached build, and on my machine that exposed a pre-existing broken `pathspec` in the uv build cache (`ImportError: cannot import name 're2_error'`). Unrelated to this change, but it will bite anyone whose cache holds the same version — `uv cache clean pathspec` fixes it, or use `.venv/bin/ruff` directly.