### PR TITLE
fix: calibrate w_queue against Fahy Table 2 (0.03, was 1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,8 +350,13 @@ The routing system implements smoke-aware path planning with dynamic rerouting:
   is provided; otherwise only smoke drives ranking)
 - **Dynamic rerouting**: Agents recompute routes at configurable intervals,
   selecting lower-exposure paths when available
-- **Congestion-aware routing**: Optional exit-congestion term (`w_queue`)
-  balances load across exits based on current agent counts and capacities
+- **Congestion-aware routing**: Optional exit-congestion term (`w_queue`,
+  default 0.03) balances load across exits based on current agent counts and
+  capacities. The default is calibrated against Fahy Table 2 on
+  `assets/station_fahy` — see
+  [Provenance of the queue weight](docs/routing.md#provenance-of-the-queue-weight)
+  and
+  `scripts/sweep_queue_weight.py`
 - **Throughput throttling**: Optional exit flux limiting via
   `enable_throughput_throttling` and `max_throughput` in scenario config
 

--- a/docs/routing-and-signs-notes.md
+++ b/docs/routing-and-signs-notes.md
@@ -67,8 +67,12 @@ Symbols used below:
    queue_time     = n_at_exit / exit_capacity
    queue_distance = base_speed · queue_time
    ```
-   **The three hand-picked weights live here:** `w_smoke = 1.0`, `w_fed = 10.0`,
-   `w_queue = 1.0`. These are NOT calibrated (the main open problem).
+   **The three routing weights live here:** `w_smoke = 1.0`, `w_fed = 10.0`,
+   `w_queue = 0.03`. `w_smoke` and `w_fed` are still hand-picked and NOT
+   calibrated. `w_queue` is calibrated against Fahy Table 2 on
+   `assets/station_fahy` (`scripts/sweep_queue_weight.py`), but at that deck's
+   crowd of 333 only — the term scales with a global `N`, so the weight that
+   expresses a given preference depends on the population size.
 
 5. **Pathfinding uses live edge weights, not raw geometry.**
    `rank_routes()` (`route_graph.py:668`) runs in three phases:
@@ -248,8 +252,9 @@ for picking weights. Key tensions:
 ---
 
 ### One-line takeaways
-- The three routing weights (`w_smoke`, `w_fed`, `w_queue`) are uncalibrated — the
-  core issue.
+- `w_smoke` and `w_fed` are uncalibrated — the core issue. `w_queue` now is
+  calibrated (Fahy Table 2), but only at one crowd size, because it scales with
+  a global agent tally.
 - `w_smoke` is redundant: smoke's real effect (slowdown) is already the calibrated
   Lund speed law → route on travel-time instead.
 - Toxicity is a threshold, not a preference → keep it as the reject, drop `w_fed`.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -151,7 +151,7 @@ from pyfds_evac.core.route_graph import RouteCostConfig
 config = RouteCostConfig(
     w_smoke=1.0,                          # smoke cost weight
     w_fed=10.0,                           # FED cost weight
-    w_queue=1.0,                          # queueing cost weight (0 disables)
+    w_queue=0.03,                         # queueing cost weight (0 disables)
     fed_rejection_threshold=1.0,          # reject if FED_max exceeds
     visibility_extinction_threshold=0.5,  # K threshold for visibility
     sampling_step_m=2.0,                  # ray sample spacing
@@ -189,6 +189,38 @@ that cannot change which path is selected to a given exit.
 
 Setting `w_queue = 0` disables congestion-aware routing entirely
 (backward compatible with existing behaviour).
+
+#### Provenance of the queue weight
+
+Calibrated, not conventional. `scripts/sweep_queue_weight.py` sweeps the
+weight on `assets/station_fahy` with rerouting on, three seeds per
+point, and scores each run with that asset's own `validate.py`. The
+front-door share falls monotonically with `w_queue`:
+
+| `w_queue` | front-door share | mean row deviation |
+|---|---|---|
+| 0 | 65.9 % | 18.2 % |
+| **0.03** | **53.3 %** | **17.9 %** |
+| 0.05 | 48.4 % | 18.0 % |
+| 0.1 | 44.9 % | 18.9 % |
+| 1.0 | 22.9 % | 21.8 % |
+
+Fahy, Proulx & Flynn measured 52.9 % of door users at the front door,
+so `w_queue = 0.03` reproduces the Station's aggregate exit split and
+the previous default of `1.0` did not. The mean per-row deviation is
+also lower, but it is nearly flat across 0.02–0.05 (17.1–18.0 %) while
+the front-door share swings 58.1 % → 48.4 %, so the row structure
+confirms that low weights beat 1.0 without discriminating 0.03 within
+that band. The value is fixed by the aggregate target alone.
+
+**This calibration holds at one crowd size.** The term is
+`w_queue * v0 * N / c` with `N` a global tally, so its magnitude
+relative to the path-length differences it competes with grows linearly
+with the population — 0.03 was fitted at the Station's 333 agents, and
+a scenario an order of magnitude smaller wants a correspondingly larger
+weight to express the same preference. That scale dependence is a
+property of the global-`N` form rather than of this number; a queue an
+agent could actually perceive would not have it.
 
 Exit capacity can be configured per exit in the scenario config:
 

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -546,7 +546,16 @@ class RouteCostConfig:
 
     w_smoke: float = 1.0
     w_fed: float = 10.0
-    w_queue: float = 1.0
+    # Calibrated against Fahy Table 2 on assets/station_fahy (rerouting on, three
+    # seeds): 0.03 reproduces a 53.3 % front-door share against the measured
+    # 52.9 %, where the former default of 1.0 gave 22.9 %. See
+    # scripts/sweep_queue_weight.py. The calibration holds at that deck's crowd
+    # of 333, and only there: the term is w_queue * v0 * N / c, so its weight
+    # against the path-length differences it competes with grows linearly with
+    # the population. A scenario an order of magnitude smaller wants a
+    # correspondingly larger w_queue -- the scale dependence is a property of
+    # the global-N form, not of this number.
+    w_queue: float = 0.03
     fed_rejection_threshold: float = 1.0
     # Asymmetric FED hysteresis (Schmitt trigger) to stop agents flip-flopping
     # when a route's predicted dose wobbles across the rejection threshold. The
@@ -586,7 +595,7 @@ class RouteCostConfig:
         return cls(
             w_smoke=routing.get("w_smoke", 1.0),
             w_fed=routing.get("w_fed", 10.0),
-            w_queue=routing.get("w_queue", 1.0),
+            w_queue=routing.get("w_queue", 0.03),
             fed_rejection_threshold=routing.get("fed_rejection_threshold", 1.0),
             visibility_extinction_threshold=routing.get(
                 "visibility_extinction_threshold", 0.5

--- a/scripts/sweep_queue_weight.py
+++ b/scripts/sweep_queue_weight.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Sweep the route-cost queue weight against Fahy Table 2's front-door share.
+
+    .venv/bin/python scripts/sweep_queue_weight.py
+
+The Station asset ships no ``routing`` block, so it runs on the library
+defaults. This script writes one scenario bundle per (w_queue, seed) into the
+output directory -- the committed asset is never edited -- runs each with
+``run.py``, and scores it with ``assets/station_fahy/validate.py``'s own
+``observed_matrix``, so the curve is directly comparable to the shares reported
+in the validation table.
+
+``w_queue`` is read from the scenario in exactly one place
+(``RouteCostConfig.from_routing_params``), and the initial exit assignment uses
+the same config object as rerouting (``scenario.py``), so injecting the block
+sweeps both the opening choice and every re-evaluation.
+
+Outputs, under ``--out``:
+
+    sweep.csv          one row per (w_queue, seed): front-door share, per-door
+                       shares, evacuation counts
+    summary.csv        mean/min/max front-door share per w_queue
+    sweep.png          front-door share vs w_queue, with Fahy's 52.9 % marked
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+ASSET = REPO / "assets" / "station_fahy"
+sys.path.insert(0, str(ASSET))
+
+import fahy_table2 as F  # noqa: E402
+import validate as V  # noqa: E402
+
+DEFAULT_WEIGHTS = (0.0, 0.02, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1.0)
+DEFAULT_SEEDS = (420, 421, 422)
+
+
+def write_variant(out_dir: Path, w_queue: float, seed: int) -> tuple[Path, str]:
+    """Write a scenario bundle whose only change is ``routing.w_queue``.
+
+    Returns the bundle and a digest of what was written, so a reused trajectory
+    can be checked against the deck it actually came from.
+    """
+    bundle = out_dir / "variants" / f"wq{w_queue:g}_seed{seed}"
+    bundle.mkdir(parents=True, exist_ok=True)
+    cfg = json.loads((ASSET / "config.json").read_text())
+    cfg["routing"] = dict(cfg.get("routing") or {}, w_queue=w_queue)
+    config_text = json.dumps(cfg)
+    geometry_text = (ASSET / "geometry.wkt").read_text()
+    (bundle / "config.json").write_text(config_text)
+    (bundle / "geometry.wkt").write_text(geometry_text)
+    digest = hashlib.sha256(f"{config_text}{geometry_text}{seed}".encode()).hexdigest()
+    return bundle, digest
+
+
+def run_one(job: tuple[float, int, str, bool]) -> dict:
+    """Run one (w_queue, seed) point and return its scored row.
+
+    A run that dies inside the solver (JuPedSim can push an agent outside the
+    accessible area on this geometry) is reported as a failed point rather than
+    taking the whole sweep down with it -- one lost seed should not cost the
+    other twenty-six.
+    """
+    w_queue, seed, out, reuse = job
+    out_dir = Path(out)
+    bundle, digest = write_variant(out_dir, w_queue, seed)
+    sqlite = bundle / "run.sqlite"
+    log = bundle / "run.log"
+    stamp = bundle / "deck.sha256"
+    # Only reuse a trajectory that came from this exact deck and seed. Rebuilding
+    # the asset (build_scenario.py) changes the digest, so a stale run.sqlite is
+    # rerun instead of being silently scored against labels it never saw.
+    reusable = (
+        reuse
+        and sqlite.exists()
+        and stamp.exists()
+        and stamp.read_text().strip() == digest
+    )
+    if not reusable:
+        with log.open("w") as handle:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(REPO / "run.py"),
+                    "--scenario",
+                    str(bundle),
+                    "--seed",
+                    str(seed),
+                    "--output-sqlite",
+                    str(sqlite),
+                    "--cleanup",
+                ],
+                cwd=REPO,
+                stdout=handle,
+                stderr=subprocess.STDOUT,
+                check=False,
+            )
+        if completed.returncode != 0:
+            return {"w_queue": w_queue, "seed": seed, "status": f"see {log}"}
+        stamp.write_text(digest)
+    matrix, stuck = V.observed_matrix(sqlite, ASSET / "config.json", reach=2.0)
+    total = sum(sum(v.values()) for v in matrix.values())
+    row = {
+        "w_queue": w_queue,
+        "seed": seed,
+        "status": "ok",
+        "source": "reused" if reusable else "fresh",
+        "reached_door": total,
+        "never_reached": sum(stuck.values()),
+        "row_mad": row_deviations(matrix),
+    }
+    for door in F.DOORS:
+        n = sum(v.get(door, 0) for v in matrix.values())
+        row[f"share_{door}"] = n / total if total else 0.0
+    return row
+
+
+def row_deviations(matrix: dict) -> float:
+    """Mean |observed - Fahy| over every scored (origin row, door) cell.
+
+    The front-door share is an aggregate, so a weight can hit it while getting
+    the origin-to-door structure wrong. This is the companion number that says
+    whether it did.
+    """
+    devs = []
+    for row in F.PLACEABLE:
+        target = F.door_shares(row)
+        obs = matrix.get(row, {})
+        n = sum(obs.values())
+        if not target or not n:
+            continue
+        devs += [abs(obs.get(d, 0) / n - target[d]) for d in F.DOORS]
+    return sum(devs) / len(devs) if devs else 0.0
+
+
+def summarise(rows: list[dict]) -> list[dict]:
+    """Collapse the per-seed rows to one row per ``w_queue``."""
+    by_weight: dict[float, list[dict]] = {}
+    for row in rows:
+        if row["status"] != "ok":
+            continue
+        by_weight.setdefault(row["w_queue"], []).append(row)
+    out = []
+    for w_queue in sorted(by_weight):
+        group = by_weight[w_queue]
+        shares = [r["share_front"] for r in group]
+        mads = [r["row_mad"] for r in group]
+        out.append(
+            {
+                "w_queue": w_queue,
+                "n_seeds": len(shares),
+                "front_mean": sum(shares) / len(shares),
+                "front_min": min(shares),
+                "front_max": max(shares),
+                "row_mad_mean": sum(mads) / len(mads),
+            }
+        )
+    return out
+
+
+def write_csv(path: Path, rows: list[dict]) -> None:
+    fields: list[str] = []
+    for row in rows:
+        fields += [k for k in row if k not in fields]
+    with path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, restval="")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def plot(summary: list[dict], out_path: Path) -> None:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    target = F.aggregate_door_shares()["front"]
+    weights = [s["w_queue"] for s in summary]
+    means = [s["front_mean"] for s in summary]
+    lo = [s["front_mean"] - s["front_min"] for s in summary]
+    hi = [s["front_max"] - s["front_mean"] for s in summary]
+
+    fig, ax = plt.subplots(figsize=(7.0, 4.4))
+    ax.errorbar(
+        weights,
+        means,
+        yerr=[lo, hi],
+        marker="o",
+        capsize=3,
+        color="#1f77b4",
+        label="front-door share",
+    )
+    ax.axhline(target, color="#d62728", ls="--", label=f"Fahy {target:.1%}")
+    ax.set_xlabel("$w_{queue}$")
+    ax.set_ylabel("front-door share of door users")
+    ax.set_title("Station: front-door share vs queue weight (rerouting on)")
+
+    twin = ax.twinx()
+    twin.plot(
+        weights,
+        [s["row_mad_mean"] for s in summary],
+        marker="s",
+        ls=":",
+        color="#7f7f7f",
+        label="mean row deviation",
+    )
+    twin.set_ylabel("mean |observed - Fahy| per row/door cell")
+    handles, labels = ax.get_legend_handles_labels()
+    h2, l2 = twin.get_legend_handles_labels()
+    ax.legend(handles + h2, labels + l2, loc="upper right", fontsize=8)
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", type=Path, default=REPO / "results" / "queue_weight_sweep")
+    ap.add_argument("--weights", type=float, nargs="+", default=list(DEFAULT_WEIGHTS))
+    ap.add_argument("--seeds", type=int, nargs="+", default=list(DEFAULT_SEEDS))
+    ap.add_argument("--jobs", type=int, default=4)
+    ap.add_argument(
+        "--reuse-existing",
+        action="store_true",
+        help="score a point from its existing run.sqlite instead of rerunning it",
+    )
+    args = ap.parse_args()
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    jobs = [
+        (w, s, str(args.out), args.reuse_existing)
+        for w in args.weights
+        for s in args.seeds
+    ]
+    print(f"{len(jobs)} runs, {args.jobs} at a time -> {args.out}", flush=True)
+
+    rows: list[dict] = []
+    with ProcessPoolExecutor(max_workers=args.jobs) as pool:
+        for row in pool.map(run_one, jobs):
+            rows.append(row)
+            detail = (
+                f"front={row['share_front']:.1%}  "
+                f"(n={row['reached_door']}, stuck={row['never_reached']}, "
+                f"{row['source']})"
+                if row["status"] == "ok"
+                else f"FAILED, {row['status']}"
+            )
+            print(
+                f"  w_queue={row['w_queue']:<5g} seed={row['seed']}  {detail}",
+                flush=True,
+            )
+
+    rows.sort(key=lambda r: (r["w_queue"], r["seed"]))
+    write_csv(args.out / "sweep.csv", rows)
+    summary = summarise(rows)
+    write_csv(args.out / "summary.csv", summary)
+    plot(summary, args.out / "sweep.png")
+
+    target = F.aggregate_door_shares()["front"]
+    print(
+        f"\n{'w_queue':>8s} {'front (mean)':>13s} {'range':>16s} "
+        f"{'row MAD':>9s}   Fahy {target:.1%}"
+    )
+    for s in summary:
+        print(
+            f"{s['w_queue']:8g} {s['front_mean']:12.1%}  "
+            f"{s['front_min']:6.1%}-{s['front_max']:<6.1%} "
+            f"{s['row_mad_mean']:9.1%}  n={s['n_seeds']}"
+        )
+    failed = [r for r in rows if r["status"] != "ok"]
+    if failed:
+        print(f"\n{len(failed)} run(s) failed and are excluded from the means:")
+        for r in failed:
+            print(f"  w_queue={r['w_queue']:g} seed={r['seed']}  {r['status']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sweep_queue_weight.py
+++ b/scripts/sweep_queue_weight.py
@@ -41,7 +41,11 @@ sys.path.insert(0, str(ASSET))
 import fahy_table2 as F  # noqa: E402
 import validate as V  # noqa: E402
 
-DEFAULT_WEIGHTS = (0.0, 0.02, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1.0)
+# The grid reported in docs/routing.md and on #88. The cluster between 0.02 and
+# 0.05 is where the front-door share crosses Fahy's 52.9 %, so the calibrated
+# 0.03 is a point the defaults actually visit -- running this script with no
+# flags reproduces the published table.
+DEFAULT_WEIGHTS = (0.0, 0.02, 0.03, 0.035, 0.04, 0.05, 0.1, 0.2, 0.35, 0.5, 0.75, 1.0)
 DEFAULT_SEEDS = (420, 421, 422)
 
 

--- a/tests/test_initial_exit_from_cognitive_map.py
+++ b/tests/test_initial_exit_from_cognitive_map.py
@@ -196,7 +196,13 @@ def test_no_reroute_in_the_spawn_timestep():
         _corridor_scenario("full", None),
         seed=SEED,
         reroute_config=RerouteConfig(
-            reevaluation_interval_s=5.0, cost_config=RouteCostConfig()
+            reevaluation_interval_s=5.0,
+            # w_queue is pinned, not taken from the default: this test only
+            # detects the same-timestep re-rank if the queue term is strong
+            # enough to scatter the crowd, and the default is now calibrated
+            # small (0.03). On the default it would pass whether or not the
+            # bug was present.
+            cost_config=RouteCostConfig(w_queue=1.0),
         ),
     )
     try:

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1581,7 +1581,8 @@ class TestStageNodeCapacity:
 class TestQueueConfigAndFields:
     def test_route_cost_config_defaults(self):
         config = RouteCostConfig()
-        assert config.w_queue == 1.0
+        # Calibrated against Fahy Table 2 -- see scripts/sweep_queue_weight.py.
+        assert config.w_queue == 0.03
         assert config.default_exit_capacity == 1.3
 
     def test_route_cost_config_queue_disabled(self):

--- a/tests/verification/test_s4_tjunction_reroute.py
+++ b/tests/verification/test_s4_tjunction_reroute.py
@@ -124,7 +124,7 @@ def test_smoke_forces_switch_to_clear_exit():
 
 
 def test_reroute_latency_within_interval():
-    """Every reroute lands within one interval of that agent's spawn (B5.2).
+    """Every reroute lands within one interval of smoke onset (B5.2).
 
     Everyone is inside and walking before the smoke appears at ``smoke_onset_s``,
     so that is the instant the smoky cost becomes visible and each agent must


### PR DESCRIPTION
Closes #88.

**Rebased.** This PR originally carried its own fix for #86 and the Station deck.
Both landed on `main` independently — #86 via #87 (`4dff49b`), and the deck with
it — so those commits were dropped in a rebase and what remains is only the
`w_queue` calibration.

## The problem

At `w_queue = 1.0` the congestion term decided the exit outright: 333 agents on
one door contribute `1.0 * 1.3 * 333 / 1.3 = 333 m` of cost, an order of
magnitude more than the tens of metres separating the Station's exits. The deck
reproduced a 22.9 % front-door share against the 52.9 % of door users Fahy,
Proulx & Flynn measured — capping what any cognitive map could express.

## The sweep

`scripts/sweep_queue_weight.py` (new) sweeps the weight on `assets/station_fahy`
with rerouting on, three seeds per point, scoring each run with that asset's own
`validate.py`. Strictly monotone, seed spread ≤ 2 pp:

| `w_queue` | 0 | 0.02 | **0.03** | 0.05 | 0.1 | 0.35 | 1.0 |
|---|---|---|---|---|---|---|---|
| front-door share | 65.9 % | 58.1 % | **53.3 %** | 48.4 % | 44.9 % | 30.5 % | 22.9 % |
| mean row deviation | 18.2 % | 17.1 % | **17.9 %** | 18.0 % | 18.9 % | 20.8 % | 21.8 % |

**Re-verified against #87's implementation after the rebase**, since the original
numbers were measured against this PR's own (now dropped) version of the #86 fix:
`0.03 -> 53.3 %` and `1.0 -> 22.9 %`, identical per seed. Running the untouched
asset on the shipped default gives 53.5 % end-to-end.

Row deviation is flat across 0.02–0.05 while the front share swings 58.1 % ->
48.4 %, so **0.03 is fixed by the aggregate target alone**, not by a two-metric
fit. It does confirm low weights beat 1.0.

## What the calibration does and does not buy

It reproduces the front-door share. It does **not** reproduce the exit
distribution:

| `w_queue` | front | bar_door | stage | kitchen |
|---|---|---|---|---|
| **Fahy** | **52.9 %** | **29.6 %** | **9.6 %** | **7.9 %** |
| **0.03** | **53.3 %** ✓ | 6.9 % | 18.8 % | 20.9 % |
| 1.0 | 22.9 % | **28.6 %** ✓ | 32.3 % | 16.2 % |

The front door is matched at 0.03, the bar door at 1.0. Excluding front, mean
error over the other three doors falls monotonically 13.3 % -> 10.7 % as
`w_queue` goes 0 -> 1.0 — the reverse ranking. **The doors want incompatible
weights**, and 0.03 buys the front door by paying at the bar door. That is not an
argument against merging (0.03 beats 1.0 on the issue's target, on all-door
error, and on row deviation) but it is the primary motivation recorded in #89.

## The calibration holds at one crowd size

`N` is a global tally, so the term grows linearly with population while the path
lengths it competes with do not. 0.03 was fitted at 333 agents. Recorded as such
everywhere the number appears; #89 tracks replacing the form.

Not claimed anywhere: that `0.03 x 333 ~ 10` means agents perceive ~10 people at
the door. `w_queue` and `N` enter only as a product, so the sweep cannot separate
them. Logged as a hypothesis in #89.

## Provenance recorded

`route_graph.py` (default + `from_routing_params` fallback), `docs/routing.md`
(new provenance section), `docs/routing-and-signs-notes.md` (the two "NOT
calibrated" claims, now split — `w_smoke`/`w_fed` still uncalibrated),
`README.md`, and `../pyFDS-evac-paper` §4 + parameter table with a `Fahy2011`
bib entry (pushed separately).

## Test note

`test_initial_exit_from_cognitive_map.py` pins `w_queue=1.0` explicitly. It only
detects the same-timestep re-rank when the queue term is strong enough to
scatter the crowd, so on the new default it would have passed whether or not the
bug was present.

516 tests pass; `ruff check` / `ruff format` clean.

## Unrelated finding

One sweep point (`w_queue=0.5`, seed 421) died inside JuPedSim with
`Point (10.94, -4.71) is outside of accessible area` at `simulation.iterate()`.
Deterministic, independent of this change, not caused by the harness — the sweep
records such a point as failed rather than aborting.