### PR TITLE
fix: default w_queue to 0, move the Station's calibration into its deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,13 +354,11 @@ The routing system implements smoke-aware path planning with dynamic rerouting:
   records what each agent knows, every time it changes — see
   [docs/testing-familiarity.md](docs/testing-familiarity.md) and
   `scripts/animate_cognitive_map.py`
-- **Congestion-aware routing**: Optional exit-congestion term (`w_queue`,
-  default 0.03) balances load across exits based on current agent counts and
-  capacities. The default is calibrated against Fahy Table 2 on
-  `assets/station_fahy` — see
-  [Provenance of the queue weight](docs/routing.md#provenance-of-the-queue-weight)
-  and
-  `scripts/sweep_queue_weight.py`
+- **Congestion-aware routing**: Optional exit-congestion term (`w_queue`), **off
+  by default** — it scales with a global agent count, so no constant suits every
+  scenario. `assets/station_fahy` opts in at 0.03, calibrated against Fahy
+  Table 2 — see [docs/routing.md](docs/routing.md#why-it-is-opt-in-and-what-003-means)
+  and `scripts/sweep_queue_weight.py`
 - **Throughput throttling**: Optional exit flux limiting via
   `enable_throughput_throttling` and `max_throughput` in scenario config
 

--- a/assets/station_fahy/build_scenario.py
+++ b/assets/station_fahy/build_scenario.py
@@ -141,8 +141,9 @@ def build() -> dict:
     sim["model_type"] = "WarpDriverModel"
     sim["max_simulation_time"] = 600.0
     # The library default is 0 -- congestion-aware routing is opt-in, because
-    # w_queue * v0 * N / c scales with the population and no constant suits
-    # every deck. 0.03 is this deck's calibration: it reproduces Fahy's 52.9 %
+    # the queue term (w_queue * base_speed_m_per_s * N / exit capacity; no
+    # relation to this file's per-agent V0) scales with the population and no
+    # constant suits every deck. 0.03 is this deck's calibration: it reproduces Fahy's 52.9 %
     # front-door share at this crowd of 333 and nowhere else. See
     # scripts/sweep_queue_weight.py and docs/routing.md.
     cfg["routing"] = dict(cfg.get("routing") or {}, w_queue=0.03)

--- a/assets/station_fahy/build_scenario.py
+++ b/assets/station_fahy/build_scenario.py
@@ -140,6 +140,12 @@ def build() -> dict:
     sim = cfg["config"]["simulation_settings"]["simulationParams"]
     sim["model_type"] = "WarpDriverModel"
     sim["max_simulation_time"] = 600.0
+    # The library default is 0 -- congestion-aware routing is opt-in, because
+    # w_queue * v0 * N / c scales with the population and no constant suits
+    # every deck. 0.03 is this deck's calibration: it reproduces Fahy's 52.9 %
+    # front-door share at this crowd of 333 and nowhere else. See
+    # scripts/sweep_queue_weight.py and docs/routing.md.
+    cfg["routing"] = dict(cfg.get("routing") or {}, w_queue=0.03)
     return cfg
 
 

--- a/assets/station_fahy/config.json
+++ b/assets/station_fahy/config.json
@@ -31920,5 +31920,8 @@
       }
     ],
     "calibrationDistance": 24.2
+  },
+  "routing": {
+    "w_queue": 0.03
   }
 }

--- a/docs/routing-and-signs-notes.md
+++ b/docs/routing-and-signs-notes.md
@@ -68,11 +68,12 @@ Symbols used below:
    queue_distance = base_speed · queue_time
    ```
    **The three routing weights live here:** `w_smoke = 1.0`, `w_fed = 10.0`,
-   `w_queue = 0.03`. `w_smoke` and `w_fed` are still hand-picked and NOT
-   calibrated. `w_queue` is calibrated against Fahy Table 2 on
-   `assets/station_fahy` (`scripts/sweep_queue_weight.py`), but at that deck's
-   crowd of 333 only — the term scales with a global `N`, so the weight that
-   expresses a given preference depends on the population size.
+   `w_queue = 0.0`. `w_smoke` and `w_fed` are hand-picked and NOT calibrated.
+   The queue term is **off by default**: it scales with a global `N`, so the
+   weight expressing a given preference depends on the population and no
+   constant suits every deck. `assets/station_fahy` opts in at `w_queue = 0.03`,
+   calibrated against Fahy Table 2 at that deck's crowd of 333
+   (`scripts/sweep_queue_weight.py`).
 
 5. **Pathfinding uses live edge weights, not raw geometry.**
    `rank_routes()` (`route_graph.py:668`) runs in three phases:
@@ -252,9 +253,9 @@ for picking weights. Key tensions:
 ---
 
 ### One-line takeaways
-- `w_smoke` and `w_fed` are uncalibrated — the core issue. `w_queue` now is
-  calibrated (Fahy Table 2), but only at one crowd size, because it scales with
-  a global agent tally.
+- `w_smoke` and `w_fed` are uncalibrated — the core issue. `w_queue` is off by
+  default: it scales with a global agent tally, so any constant is calibrated at
+  one crowd size only. The Station deck opts in at 0.03 (Fahy Table 2).
 - `w_smoke` is redundant: smoke's real effect (slowdown) is already the calibrated
   Lund speed law → route on travel-time instead.
 - Toxicity is a threshold, not a preference → keep it as the reject, drop `w_fed`.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -151,7 +151,7 @@ from pyfds_evac.core.route_graph import RouteCostConfig
 config = RouteCostConfig(
     w_smoke=1.0,                          # smoke cost weight
     w_fed=10.0,                           # FED cost weight
-    w_queue=0.03,                         # queueing cost weight (0 disables)
+    w_queue=0.0,                          # congestion weight (0 = off, the default)
     fed_rejection_threshold=1.0,          # reject if FED_max exceeds
     visibility_extinction_threshold=0.5,  # K threshold for visibility
     sampling_step_m=2.0,                  # ray sample spacing
@@ -187,10 +187,30 @@ The queue term is applied at route-level ranking (Phase 3) only,
 not in Dijkstra edge weights, because it is a per-exit constant
 that cannot change which path is selected to a given exit.
 
-Setting `w_queue = 0` disables congestion-aware routing entirely
-(backward compatible with existing behaviour).
+**Congestion-aware routing is off by default** (`w_queue = 0`); set it in a
+scenario's `routing` block to switch it on.
 
-#### Provenance of the queue weight
+#### Why it is opt-in, and what 0.03 means
+
+The term is `w_queue * v0 * N / c` with `N` a **global** tally of every agent
+targeting the exit. With the default `v0` and capacity the penalty is simply
+`w_queue * N` metres, so it grows without bound in the population while the
+path-length differences it competes against are fixed by the geometry:
+
+| N | `w_queue = 1.0` | `w_queue = 0.03` |
+|---|---|---|
+| 25 | 25 m | 0.8 m |
+| 50 | 50 m | 1.5 m |
+| 333 | 333 m | 10 m |
+
+No constant is right at more than one crowd size. 1.0 puts 333 m on a door at
+Station scale; the 0.03 that fixes that is inert in an ordinary room. So the
+library ships no congestion weight at all, and the calibrated value lives with
+the deck it was calibrated on — `assets/station_fahy` sets `w_queue = 0.03` in
+its own `routing` block. Issue #89 tracks replacing the global `N` with a queue
+the agent can perceive, which would remove the scale dependence.
+
+#### Provenance of the Station's 0.03
 
 Calibrated, not conventional. `scripts/sweep_queue_weight.py` sweeps the
 weight on `assets/station_fahy` with rerouting on, three seeds per

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -193,7 +193,10 @@ scenario's `routing` block to switch it on.
 #### Why it is opt-in, and what 0.03 means
 
 The term is `w_queue * v0 * N / c` with `N` a **global** tally of every agent
-targeting the exit. With the default `v0` and capacity the penalty is simply
+targeting the exit — where `v0` is the `base_speed_m_per_s` conversion constant
+(not any agent's desired speed) and `c` is the exit's `capacity_agents_per_s`,
+falling back to `default_exit_capacity`. With both at their 1.3 defaults the
+penalty is simply
 `w_queue * N` metres, so it grows without bound in the population while the
 path-length differences it competes against are fixed by the geometry:
 
@@ -234,7 +237,8 @@ confirms that low weights beat 1.0 without discriminating 0.03 within
 that band. The value is fixed by the aggregate target alone.
 
 **This calibration holds at one crowd size.** The term is
-`w_queue * v0 * N / c` with `N` a global tally, so its magnitude
+`w_queue * v0 * N / c` (`v0`, `c` as above) with `N` a global tally, so its
+magnitude
 relative to the path-length differences it competes with grows linearly
 with the population — 0.03 was fitted at the Station's 333 agents, and
 a scenario an order of magnitude smaller wants a correspondingly larger

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -546,16 +546,18 @@ class RouteCostConfig:
 
     w_smoke: float = 1.0
     w_fed: float = 10.0
-    # Calibrated against Fahy Table 2 on assets/station_fahy (rerouting on, three
-    # seeds): 0.03 reproduces a 53.3 % front-door share against the measured
-    # 52.9 %, where the former default of 1.0 gave 22.9 %. See
-    # scripts/sweep_queue_weight.py. The calibration holds at that deck's crowd
-    # of 333, and only there: the term is w_queue * v0 * N / c, so its weight
-    # against the path-length differences it competes with grows linearly with
-    # the population. A scenario an order of magnitude smaller wants a
-    # correspondingly larger w_queue -- the scale dependence is a property of
-    # the global-N form, not of this number.
-    w_queue: float = 0.03
+    # Off by default. The term is w_queue * v0 * N / c with N a *global* tally
+    # of every agent targeting the exit, so with the default v0 and capacity the
+    # penalty is simply w_queue * N metres: it grows without bound in the
+    # population while the path lengths it competes against are fixed by the
+    # geometry. No constant is therefore right at more than one crowd size --
+    # 1.0 put 333 m on a door at Station scale, and the 0.03 that fixes that is
+    # inert (0.8 m at N = 25) in an ordinary room. Rather than ship a number
+    # calibrated on one deck as the default for every deck, congestion-aware
+    # routing is opt-in; assets/station_fahy sets it in its own routing block.
+    # See issue #89 for the perceivable-queue form that would remove the scale
+    # dependence.
+    w_queue: float = 0.0
     fed_rejection_threshold: float = 1.0
     # Asymmetric FED hysteresis (Schmitt trigger) to stop agents flip-flopping
     # when a route's predicted dose wobbles across the rejection threshold. The
@@ -595,7 +597,7 @@ class RouteCostConfig:
         return cls(
             w_smoke=routing.get("w_smoke", 1.0),
             w_fed=routing.get("w_fed", 10.0),
-            w_queue=routing.get("w_queue", 0.03),
+            w_queue=routing.get("w_queue", 0.0),
             fed_rejection_threshold=routing.get("fed_rejection_threshold", 1.0),
             visibility_extinction_threshold=routing.get(
                 "visibility_extinction_threshold", 0.5

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -546,9 +546,13 @@ class RouteCostConfig:
 
     w_smoke: float = 1.0
     w_fed: float = 10.0
-    # Off by default. The term is w_queue * v0 * N / c with N a *global* tally
-    # of every agent targeting the exit, so with the default v0 and capacity the
-    # penalty is simply w_queue * N metres: it grows without bound in the
+    # Off by default. The term is
+    #     w_queue * base_speed_m_per_s * N / capacity_agents_per_s
+    # with N a *global* tally of every agent targeting the exit. (The paper
+    # writes this v0 * N / c; base_speed_m_per_s is that conversion constant,
+    # NOT any agent's desired speed.) With both speed and capacity at their
+    # 1.3 defaults the penalty is simply w_queue * N metres: it grows without
+    # bound in the
     # population while the path lengths it competes against are fixed by the
     # geometry. No constant is therefore right at more than one crowd size --
     # 1.0 put 333 m on a door at Station scale, and the 0.03 that fixes that is

--- a/scripts/sweep_queue_weight.py
+++ b/scripts/sweep_queue_weight.py
@@ -3,8 +3,9 @@
 
     .venv/bin/python scripts/sweep_queue_weight.py
 
-The Station asset ships no ``routing`` block, so it runs on the library
-defaults. This script writes one scenario bundle per (w_queue, seed) into the
+The Station asset ships ``routing.w_queue = 0.03`` -- its own calibration,
+since the library default is 0. This script overrides that value per variant:
+it writes one scenario bundle per (w_queue, seed) into the
 output directory -- the committed asset is never edited -- runs each with
 ``run.py``, and scores it with ``assets/station_fahy/validate.py``'s own
 ``observed_matrix``, so the curve is directly comparable to the shares reported

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -1581,13 +1581,22 @@ class TestStageNodeCapacity:
 class TestQueueConfigAndFields:
     def test_route_cost_config_defaults(self):
         config = RouteCostConfig()
-        # Calibrated against Fahy Table 2 -- see scripts/sweep_queue_weight.py.
-        assert config.w_queue == 0.03
+        # Congestion-aware routing is opt-in: the term scales with the agent
+        # count, so no default suits every deck (see the field comment).
+        assert config.w_queue == 0.0
         assert config.default_exit_capacity == 1.3
 
-    def test_route_cost_config_queue_disabled(self):
-        config = RouteCostConfig(w_queue=0.0)
-        assert config.w_queue == 0.0
+    def test_route_cost_config_queue_opt_in(self):
+        """An explicit weight survives; the default does not silently apply one.
+
+        Asserting ``RouteCostConfig(w_queue=0.0).w_queue == 0.0`` would now be
+        vacuous -- 0.0 is the default, so it would pass however the field were
+        wired. Pin the opt-in direction instead.
+        """
+        assert RouteCostConfig(w_queue=1.0).w_queue == 1.0
+        assert RouteCostConfig.from_routing_params({"w_queue": 0.5}).w_queue == 0.5
+        assert RouteCostConfig.from_routing_params({}).w_queue == 0.0
+        assert RouteCostConfig.from_routing_params(None).w_queue == 0.0
 
     def test_route_cost_has_queue_time_field(self, linear_graph):
         field = ConstantExtinctionField(0.0)


### PR DESCRIPTION
Follow-up to #90, correcting a category error in it.

## The mistake

#90 set a **library default** by fitting **one scenario**. `w_queue` governs
every deck; the Station is one case study.

The term is `w_queue * v0 * N / c` with `N` a global tally, so with the default
`v0` and capacity the penalty is exactly `w_queue * N` metres:

| N | `w_queue = 1.0` (before #90) | `w_queue = 0.03` (#90) |
|---|---|---|
| 25 | 25 m | 0.8 m |
| 50 | 50 m | 1.5 m |
| 333 | 333 m | 10 m |

1.0 was absurd at Station scale. **0.03 is inert at ordinary scale** — a room of
25, most test decks — where 0.8 m cannot move any decision. #90 did not fix a
wrong default; it moved the error from large crowds to small ones and shipped it
labelled "calibrated".

## The change

- `w_queue` defaults to **0**: congestion-aware routing is opt-in.
- `assets/station_fahy` sets `w_queue = 0.03` in its own `routing` block — the
  calibrated number lives with the deck it was calibrated on. Verified
  end-to-end: the deck still gives **53.5 %** against Fahy's 52.9 %.
- Docs, README and the paper updated: the weight is presented as opt-in with the
  scale table, not as a calibrated default.
- The paper's Nash-equilibrium reading is now qualified. It rests on exit cost
  depending on `N_k`; at `w_q = 0` it does not, so no load-balancing equilibrium
  arises and the reevaluation schedule is a staggered best response to the
  hazard fields alone.

## Test note

`test_route_cost_config_queue_disabled` asserted that `w_queue=0.0` yields `0.0`
— now the default, so it could not fail. Replaced with the opt-in direction: an
explicit weight survives, and an absent or empty `routing` block yields 0.

521 tests pass; ruff clean; paper builds with no undefined citations.

Does not change what #89 asks for — the global-`N` form is still the underlying
problem, and this only stops it being imposed on every scenario by default.