### PR TITLE
fix(core): gate cognitive-map arrival learning by visibility, learn reverse edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,7 +496,12 @@ is reachable in the cognitive map, the agent heads toward the nearest
 known-but-unexplored node instead (a doorway it knows exists but hasn't
 been through) — expanding its knowledge on arrival and re-evaluating from
 there, until an exit becomes known. Reroute events for this show up in
-`route_history` with `reason="explore"`. Once an exit is known, the agent
+`route_history` with `reason="explore"`. When every known node has been
+visited and still no exit is reachable, the agent wanders: it patrols the
+nodes it knows in a deterministic rotation (`reason="wander"`), because
+sign legibility depends on position — a leg walked between two known nodes
+can make a sign readable that never was from either node, restarting
+discovery. Once an exit is known, the agent
 also reroutes onto a cheaper *path* to that same exit as its knowledge
 grows, not only when a different exit becomes preferable
 (`reason="better_path"`).

--- a/README.md
+++ b/README.md
@@ -481,10 +481,15 @@ Default when the key is absent: `"full"` (backward compatible).
    each exit drawn as known by a scalar `familiarity`, and any adjacent node
    whose sign is currently visible from the spawn centroid. It then picks its
    first exit by ranking that map, not by geometry.
-2. **On arrival** — when an agent physically reaches a node, all immediate
-   neighbours are added to the cognitive map unconditionally.
+2. **On arrival** — when an agent physically reaches a node, the immediate
+   neighbours whose sign is visible from where it stands are added (all of
+   them when no visibility model is supplied).
 3. **At reevaluation** — adjacent nodes whose sign is visible from the
    agent's current position are added.
+
+Learning an edge also learns its reverse when the graph has one: knowledge
+of a corridor is bidirectional, so an agent can always retrace its steps
+out of a dead end whose far side shows it nothing new.
 
 Routing (Dijkstra) runs over the agent's known sub-graph only. If no exit
 is reachable in the cognitive map, the agent heads toward the nearest

--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -315,6 +315,44 @@ def nearest_frontier_target(
     return node_id, path
 
 
+def wander_target(
+    cmap: AgentCognitiveMap,
+    graph,
+    source: str,
+    step: int,
+) -> tuple[str, list[str]] | None:
+    """The *step*-th stop of a patrol over the nodes the agent knows.
+
+    Called when the frontier is exhausted: every known node is visited and
+    no exit is reachable, so there is nowhere the agent *knows* to look.
+    Standing still would end discovery, but walking does not: perception
+    runs from the agent's position, and sign legibility depends on that
+    position (distance and the readable half-plane), so a leg between two
+    known nodes can make a sign readable that never was from either node.
+
+    The patrol is a deterministic rotation through the known nodes, not a
+    random draw: it needs no seeded state, reproduces under a fixed run
+    seed, and covers every known leg instead of favouring some. Returns
+    None when no other known node is reachable -- an agent alone on its
+    spawn node genuinely has nowhere to go.
+    """
+    candidates = sorted(
+        node_id
+        for node_id in cmap.known_nodes
+        if node_id != source and node_id in graph.nodes
+    )
+    if not candidates:
+        return None
+    sub = cognitive_subgraph(cmap, graph)
+    for offset in range(len(candidates)):
+        node_id = candidates[(step + offset) % len(candidates)]
+        result = sub.shortest_path_to(source, node_id)
+        if result is None:
+            continue
+        return node_id, result[1]
+    return None
+
+
 def _cost_from_agent(graph, path, cost: float, agent_position) -> float:
     """Replace the path's first leg with the walk from the agent's position."""
     if agent_position is None or len(path) < 2:

--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import heapq
+import math
 from dataclasses import dataclass, field
 
 
@@ -343,13 +345,55 @@ def wander_target(
     )
     if not candidates:
         return None
-    sub = cognitive_subgraph(cmap, graph)
     for offset in range(len(candidates)):
         node_id = candidates[(step + offset) % len(candidates)]
-        result = sub.shortest_path_to(source, node_id)
-        if result is None:
+        path = _undirected_known_path(cmap, graph, source, node_id)
+        if path is None:
             continue
-        return node_id, result[1]
+        return node_id, path
+    return None
+
+
+def _undirected_known_path(
+    cmap: AgentCognitiveMap, graph, source: str, target: str
+) -> list[str] | None:
+    """Shortest path over the known legs, walked in either direction.
+
+    The known subgraph is directed for routing (exits are terminal, nothing
+    points back at a spawn area), but a corridor the agent has walked or seen
+    is physically two-way -- without this an agent standing at its first
+    checkpoint cannot even patrol back to its own spawn area. Weights are
+    centroid distances, which is what the patrol optimises for.
+    """
+    adjacency: dict[str, set[str]] = {}
+    for a, b in cmap.known_edges:
+        if a in graph.nodes and b in graph.nodes:
+            adjacency.setdefault(a, set()).add(b)
+            adjacency.setdefault(b, set()).add(a)
+
+    def _dist(a: str, b: str) -> float:
+        na, nb = graph.nodes[a], graph.nodes[b]
+        return math.hypot(na.centroid_x - nb.centroid_x, na.centroid_y - nb.centroid_y)
+
+    best: dict[str, float] = {source: 0.0}
+    previous: dict[str, str] = {}
+    queue: list[tuple[float, str]] = [(0.0, source)]
+    while queue:
+        cost, node = heapq.heappop(queue)
+        if node == target:
+            path = [node]
+            while node in previous:
+                node = previous[node]
+                path.append(node)
+            return path[::-1]
+        if cost > best.get(node, math.inf):
+            continue
+        for neighbour in adjacency.get(node, ()):
+            candidate = cost + _dist(node, neighbour)
+            if candidate < best.get(neighbour, math.inf):
+                best[neighbour] = candidate
+                previous[neighbour] = node
+                heapq.heappush(queue, (candidate, neighbour))
     return None
 
 

--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -126,21 +126,53 @@ def init_cognitive_map(
     return cmap
 
 
+def _learn_edge(cmap: AgentCognitiveMap, graph, source: str, target: str) -> None:
+    """Learn an edge, and its reverse when the graph has one.
+
+    Route edges are directed, but knowledge of a corridor is not: an agent
+    that knows the leg A->B can walk it back. The reverse is added only when
+    the graph offers it -- exits are terminal and spawn areas have no inbound
+    edges -- so routing invariants hold. Without this, a discovery agent whose
+    arrival at a node reveals nothing new holds a known subgraph with no
+    outgoing edge, and :func:`nearest_frontier_target` cannot route it back
+    out of a dead end it can physically leave.
+    """
+    cmap.known_edges.add((source, target))
+    if any(edge.target == source for edge in graph.edges.get(target, [])):
+        cmap.known_edges.add((target, source))
+
+
 def expand_on_arrival(
     cmap: AgentCognitiveMap,
     arrived_node: str,
     graph,
+    vis_model=None,
+    time_s: float = 0.0,
+    ax: float | None = None,
+    ay: float | None = None,
 ) -> None:
-    """Expand map unconditionally when agent physically arrives at a node.
+    """Expand map when the agent physically arrives at a node.
 
-    The agent can now see all immediate neighbours (they are standing there).
+    Standing on a node does not mean seeing past its walls: auto-wired decks
+    keep nodes graph-adjacent to stages in other rooms, so with a visibility
+    model and a position each neighbour is revealed only if visible from
+    (ax, ay) -- the same gate perception uses in :func:`_expand_visible`.
+    Without one there is no evidence either way, and every neighbour is
+    revealed so an unperceiving agent can still progress hop by hop.
     """
     if cmap.familiarity == "full":
         return
     cmap.known_nodes.add(arrived_node)
     for edge in graph.edges.get(arrived_node, []):
+        if (
+            vis_model is not None
+            and ax is not None
+            and ay is not None
+            and not vis_model.node_is_visible(time_s, ax, ay, edge.target)
+        ):
+            continue
         cmap.known_nodes.add(edge.target)
-        cmap.known_edges.add((edge.source, edge.target))
+        _learn_edge(cmap, graph, edge.source, edge.target)
 
 
 def expand_from_visibility(
@@ -178,8 +210,9 @@ def _expand_visible(
     stage, so treating a neighbour as seen would hand every discovery agent most
     of the building's exits at t=0 and make ``familiarity`` inert in every run
     without a visibility cache. Perception is not the only way a map grows --
-    :func:`expand_on_arrival` still reveals neighbours on physical arrival, so
-    an agent is never stranded by this.
+    :func:`expand_on_arrival` still reveals visible neighbours on physical
+    arrival (and, without a visibility model, all of them), so an agent is
+    never stranded by this.
     """
     if vis_model is None:
         return
@@ -187,7 +220,7 @@ def _expand_visible(
         tgt = edge.target
         if vis_model.node_is_visible(time_s, ax, ay, tgt):
             cmap.known_nodes.add(tgt)
-            cmap.known_edges.add((edge.source, edge.target))
+            _learn_edge(cmap, graph, edge.source, edge.target)
 
 
 def cognitive_subgraph(cmap: AgentCognitiveMap, graph):

--- a/pyfds_evac/core/cognitive_map.py
+++ b/pyfds_evac/core/cognitive_map.py
@@ -17,6 +17,10 @@ class AgentCognitiveMap:
     familiarity: str  # "full" | "discovery"
     known_nodes: set[str] = field(default_factory=set)
     known_edges: set[tuple[str, str]] = field(default_factory=set)
+    # Nodes the agent has physically stood on. A visited node is a closed
+    # frontier: standing there taught the agent everything that position will
+    # ever teach, however little that was (see nearest_frontier_target).
+    visited_nodes: set[str] = field(default_factory=set)
 
 
 def familiarity_probability(value) -> float:
@@ -108,7 +112,11 @@ def init_cognitive_map(
             known_edges=all_edges,
         )
 
-    cmap = AgentCognitiveMap(familiarity="discovery", known_nodes={spawn_node})
+    cmap = AgentCognitiveMap(
+        familiarity="discovery",
+        known_nodes={spawn_node},
+        visited_nodes={spawn_node},
+    )
 
     if entrance is not None and entrance in graph.nodes:
         _learn_route_to(cmap, graph, spawn_node, entrance)
@@ -163,6 +171,7 @@ def expand_on_arrival(
     if cmap.familiarity == "full":
         return
     cmap.known_nodes.add(arrived_node)
+    cmap.visited_nodes.add(arrived_node)
     for edge in graph.edges.get(arrived_node, []):
         if (
             vis_model is not None
@@ -252,14 +261,22 @@ def nearest_frontier_target(
     source: str,
     agent_position: tuple[float, float] | None = None,
 ) -> tuple[str, list[str]] | None:
-    """Return the nearest known-but-unexplored node to head toward, if any.
+    """Return the nearest known-but-unvisited node to head toward, if any.
 
-    A frontier node is one already in the agent's cognitive map whose real
-    outgoing edges (in the full *graph*) are not all known yet — a doorway
-    the agent has seen but not been through. Used when no exit is reachable
-    in the known subgraph: instead of standing still, the agent heads to the
-    nearest such node, expanding its knowledge on arrival
-    (see :func:`expand_on_arrival`) and re-evaluating from there.
+    A frontier node is one already in the agent's cognitive map that the
+    agent has never physically stood on — a doorway it has seen but not been
+    through. Used when no exit is reachable in the known subgraph: instead of
+    standing still, the agent heads to the nearest such node, expanding its
+    knowledge on arrival (see :func:`expand_on_arrival`) and re-evaluating
+    from there.
+
+    Visiting closes a frontier even when arrival taught nothing: with
+    visibility-gated arrival a node can hold unknown edges forever (its
+    neighbours' signs face away), and an edges-based frontier keeps offering
+    such nodes. Two of them adjacent to each other then trap the explorer —
+    the nearest frontier from each is the other — while genuinely unvisited
+    nodes wait. Consuming one unvisited node per hop makes exploration
+    terminate.
 
     With *agent_position* the first leg is measured from where the agent
     actually stands rather than from *source*'s centroid, the same substitution
@@ -275,14 +292,7 @@ def nearest_frontier_target(
     Returns None once every known node has been fully explored (no frontier
     left — a genuine dead end).
     """
-    frontier = {
-        node_id
-        for node_id in cmap.known_nodes
-        if any(
-            (edge.source, edge.target) not in cmap.known_edges
-            for edge in graph.edges.get(node_id, [])
-        )
-    }
+    frontier = cmap.known_nodes - cmap.visited_nodes
     if not frontier:
         return None
 

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -1324,7 +1324,16 @@ def evaluate_and_reroute(
         if frontier is None:
             return None
         target_node, path = frontier
-        if wait_info.get("current_target_stage") == target_node:
+        # Already committed to this frontier: the agent's current target is an
+        # intermediate hop of the committed path, not the frontier node itself,
+        # so comparing against current_target_stage alone re-fires the same
+        # switch on every reevaluation until arrival.
+        committed = route_state.current_path
+        if wait_info.get("current_target_stage") == target_node or (
+            committed
+            and committed[-1] == target_node
+            and wait_info.get("current_target_stage") in committed
+        ):
             return None
         stage_configs = wait_info.get("stage_configs", {})
         changed = reroute_agent(wait_info, path, stage_configs)

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -1111,6 +1111,7 @@ class AgentRouteState:
     current_path: list[str] = field(default_factory=list)
     last_eval_time_s: float = -math.inf
     eval_offset_s: float = 0.0  # staggering offset
+    wander_step: int = 0  # position in the knowledge-exhausted patrol rotation
 
 
 @dataclass(frozen=True)
@@ -1318,21 +1319,41 @@ def evaluate_and_reroute(
         route_state.last_eval_time_s = current_time_s
         if cognitive_map is None:
             return None
-        from .cognitive_map import nearest_frontier_target
+        from .cognitive_map import nearest_frontier_target, wander_target
 
+        idle = wait_info.get("state") == "idle"
+        reason = "explore"
         frontier = nearest_frontier_target(cognitive_map, graph, source, agent_position)
+        if frontier is None:
+            # Knowledge exhausted: every known node is visited and none of it
+            # leads to an exit. Patrol the known nodes instead of standing --
+            # perception runs from the agent's position, so a walked leg can
+            # make a sign readable that never was from any node it stood on.
+            if idle and route_state.current_path:
+                # The previous patrol leg was completed; move on to the next
+                # stop, or a single-candidate rotation would re-offer the node
+                # the agent is standing on the way to.
+                route_state.wander_step += 1
+            frontier = wander_target(
+                cognitive_map, graph, source, route_state.wander_step
+            )
+            reason = "wander"
         if frontier is None:
             return None
         target_node, path = frontier
-        # Already committed to this frontier: the agent's current target is an
-        # intermediate hop of the committed path, not the frontier node itself,
+        # Already committed to this target: the agent's current target is an
+        # intermediate hop of the committed path, not the destination itself,
         # so comparing against current_target_stage alone re-fires the same
-        # switch on every reevaluation until arrival.
+        # switch on every reevaluation until arrival. An idle agent is never
+        # suppressed -- it is standing with no onward plan and must be routed.
         committed = route_state.current_path
-        if wait_info.get("current_target_stage") == target_node or (
-            committed
-            and committed[-1] == target_node
-            and wait_info.get("current_target_stage") in committed
+        if not idle and (
+            wait_info.get("current_target_stage") == target_node
+            or (
+                committed
+                and committed[-1] == target_node
+                and wait_info.get("current_target_stage") in committed
+            )
         ):
             return None
         stage_configs = wait_info.get("stage_configs", {})
@@ -1351,7 +1372,7 @@ def evaluate_and_reroute(
             new_exit=target_node,
             old_cost=None,
             new_cost=0.0,
-            reason="explore",
+            reason=reason,
         )
 
     best = ranked[0]

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -150,8 +150,8 @@ class StageGraph:
             # Connect a node only to those reachable without passing another,
             # so "neighbour" keeps its physical meaning.  A complete graph would
             # make it meaningless, and expand_on_arrival reveals every neighbour
-            # unconditionally -- so one arrival would expose the whole building
-            # and flatten the familiarity gradient.
+            # a vis-model-less run cannot rule out -- so one arrival would
+            # expose the whole building and flatten the familiarity gradient.
             # Only crossings can block. An exit is terminal -- you cannot pass
             # through one -- so an exit lying on the way to a farther exit must
             # not prune it, or that farther exit becomes unreachable outright.

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -2365,10 +2365,10 @@ def run_scenario(
                                             _acmap,
                                             _arrived,
                                             stage_graph,
-                                            vis_model,
-                                            current_time,
-                                            x,
-                                            y,
+                                            vis_model=vis_model,
+                                            time_s=current_time,
+                                            ax=x,
+                                            ay=y,
                                         )
                         continue
 
@@ -2389,15 +2389,17 @@ def run_scenario(
                             advance_path_target(wait_info)
                             _acmap = cognitive_maps.get(agent_id)
                             if _acmap is not None and stage_graph is not None:
-                                expand_on_arrival(
-                                    _acmap,
-                                    wait_info.get("current_origin", ""),
-                                    stage_graph,
-                                    vis_model,
-                                    current_time,
-                                    x,
-                                    y,
-                                )
+                                _arrived = wait_info.get("current_origin")
+                                if _arrived and _arrived in stage_graph.nodes:
+                                    expand_on_arrival(
+                                        _acmap,
+                                        _arrived,
+                                        stage_graph,
+                                        vis_model=vis_model,
+                                        time_s=current_time,
+                                        ax=x,
+                                        ay=y,
+                                    )
                         continue
 
             if collect_cognitive_map_history:

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -2365,6 +2365,10 @@ def run_scenario(
                                             _acmap,
                                             _arrived,
                                             stage_graph,
+                                            vis_model,
+                                            current_time,
+                                            x,
+                                            y,
                                         )
                         continue
 
@@ -2389,6 +2393,10 @@ def run_scenario(
                                     _acmap,
                                     wait_info.get("current_origin", ""),
                                     stage_graph,
+                                    vis_model,
+                                    current_time,
+                                    x,
+                                    y,
                                 )
                         continue
 

--- a/pyfds_evac/core/scenario.py
+++ b/pyfds_evac/core/scenario.py
@@ -1249,6 +1249,7 @@ def run_scenario(
         _cmap_seen: Dict[int, tuple[int, int]] = {}
         route_segment_cache: dict[tuple[str, str], Any] | None = None
         stage_graph: StageGraph | None = None
+        distribution_stage_configs: Dict[str, Dict[str, Any]] = {}
         reroute_debug_printed = False
         reroute_debug_samples = 0
         _fed_rate_adapter = None
@@ -1263,6 +1264,24 @@ def run_scenario(
                 walkable_polygon=scenario.walkable_polygon,
             )
             route_segment_cache = {}
+            # Spawn areas as steerable patrol stops. Stage configs are built
+            # from direct_steering_info, which holds crossings and exits only,
+            # so a wandering agent could never be routed back to its own
+            # spawn area -- and an agent that knows nothing but its spawn and
+            # the checkpoint it stands on would have no patrol at all.
+            for _dist_id, _dist in (scenario.raw.get("distributions") or {}).items():
+                _coords = _dist.get("coordinates")
+                if _dist_id in stage_graph.nodes and _coords and len(_coords) >= 3:
+                    distribution_stage_configs[_dist_id] = {
+                        "polygon": Polygon(_coords),
+                        "stage_type": "distribution",
+                        "waiting_time": 0.0,
+                        "waiting_time_distribution": "constant",
+                        "waiting_time_std": 1.0,
+                        "enable_throughput_throttling": False,
+                        "max_throughput": 1.0,
+                        "speed_factor": 1.0,
+                    }
             # Not every FED model can be sampled ahead of the agent -- the
             # constant-input ones only know the dose here and now -- and route
             # costs are the one caller that needs the spatial rate.
@@ -2043,6 +2062,9 @@ def run_scenario(
                     reroute_loop_agents += 1
                     if wait_info.get("state") == "done":
                         continue
+                    # Spawn areas become steerable patrol stops for wander.
+                    for _dist_id, _cfg in distribution_stage_configs.items():
+                        wait_info["stage_configs"].setdefault(_dist_id, _cfg)
                     # Initialize route state on first encounter.
                     if agent_id not in agent_route_state:
                         agent_route_state[agent_id] = AgentRouteState(

--- a/scripts/animate_cognitive_map.py
+++ b/scripts/animate_cognitive_map.py
@@ -141,6 +141,10 @@ def animate(
     """Render one agent's walk with the nodes it knows highlighted."""
     cfg = json.loads((bundle / "config.json").read_text())
     walkable = shapely_wkt.loads((bundle / "geometry.wkt").read_text().strip())
+    # The same descriptors the run's visibility model used, so the drawn
+    # orientation is the one that decided legibility. alpha is the compass
+    # bearing (deg from north, CW) of the readable side; None means omni.
+    signs = extract_sign_descriptors(cfg)
     nodes = {}
     for section, marker in (("exits", "s"), ("checkpoints", "o")):
         for node_id, data in (cfg.get(section) or {}).items():
@@ -167,6 +171,11 @@ def animate(
     if not frames:
         raise SystemExit(f"no trajectory rows for agent {agent_id}")
     history = [e for e in history if e["agent_id"] == agent_id]
+    # A stalled 600 s run has thousands of rows; cap the movie at ~600 frames
+    # so it stays watchable and renders in minutes, not hours. The trail is
+    # drawn from the kept rows only, which is visually indistinguishable.
+    stride = max(1, len(frames) // 600)
+    frames = frames[::stride]
 
     fig, ax = plt.subplots(figsize=(9, 7))
     writer = (
@@ -185,6 +194,31 @@ def animate(
             for ring in walkable.interiors:
                 rx, ry = ring.xy
                 ax.plot(rx, ry, color="#9298a8", lw=1)
+            for node_id, sign in signs.items():
+                sx, sy = float(sign["x"]), float(sign["y"])
+                alpha = sign.get("alpha")
+                if alpha is None:
+                    # Omni-directional: readable from every side.
+                    ax.plot(
+                        sx,
+                        sy,
+                        marker="o",
+                        ms=16,
+                        mfc="none",
+                        mec="#2e7d32",
+                        mew=1.0,
+                        zorder=3,
+                    )
+                    continue
+                rad = math.radians(float(alpha))
+                dx, dy = math.sin(rad), math.cos(rad)
+                ax.annotate(
+                    "",
+                    xy=(sx + 1.8 * dx, sy + 1.8 * dy),
+                    xytext=(sx, sy),
+                    arrowprops=dict(arrowstyle="-|>", color="#2e7d32", lw=1.6),
+                    zorder=5,
+                )
             for node_id, (nx, ny, marker) in nodes.items():
                 on = node_id in known
                 ax.plot(

--- a/scripts/animate_cognitive_map.py
+++ b/scripts/animate_cognitive_map.py
@@ -108,10 +108,12 @@ def build_variant(deck: Path, out: Path, familiarity: float) -> tuple[Path, dict
     return out, angles
 
 
-def run(bundle: Path, seed: int, sqlite_out: Path):
+def run(bundle: Path, seed: int, sqlite_out: Path, cell_size_m: float):
     scenario = load_scenario(str(bundle))
     walkable = shapely_wkt.loads((bundle / "geometry.wkt").read_text().strip())
-    vis = VisibilityModel.clear_air(walkable, extract_sign_descriptors(scenario.raw))
+    vis = VisibilityModel.clear_air(
+        walkable, extract_sign_descriptors(scenario.raw), cell_size_m=cell_size_m
+    )
     result = run_scenario(
         scenario,
         seed=seed,
@@ -208,8 +210,9 @@ def animate(
                 fontsize=11,
             )
             ax.set_aspect("equal")
-            ax.set_xlim(-20, 20)
-            ax.set_ylim(-15, 14)
+            minx, miny, maxx, maxy = walkable.bounds
+            ax.set_xlim(minx - 1, maxx + 1)
+            ax.set_ylim(miny - 1, maxy + 1)
             ax.set_xticks([])
             ax.set_yticks([])
             writer.grab_frame()
@@ -239,6 +242,14 @@ def main() -> int:
         default=None,
         help="agent to follow (default: the lowest id in the run)",
     )
+    ap.add_argument(
+        "--cell-size",
+        type=float,
+        default=0.5,
+        help="visibility grid resolution in m; walls thinner than one cell "
+        "stop occluding, so pick it below the deck's thinnest wall "
+        "(see VisibilityModel.clear_air)",
+    )
     ap.add_argument("--work", type=Path, default=Path("results/cognitive_map_movie"))
     args = ap.parse_args()
 
@@ -248,7 +259,7 @@ def main() -> int:
         print(f"  {node_id}: alpha={alpha}")
 
     sqlite_path = args.work / "run.sqlite"
-    history, switches = run(bundle, args.seed, sqlite_path)
+    history, switches = run(bundle, args.seed, sqlite_path, args.cell_size)
     print(f"\nlearning events: {len(history)}   route switches: {len(switches)}")
     for event in history:
         print(

--- a/scripts/animate_cognitive_map.py
+++ b/scripts/animate_cognitive_map.py
@@ -34,6 +34,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.animation import FFMpegWriter, PillowWriter  # noqa: E402
+from matplotlib.lines import Line2D  # noqa: E402
 from shapely import wkt as shapely_wkt  # noqa: E402
 from shapely.geometry import Point, Polygon  # noqa: E402
 
@@ -45,6 +46,7 @@ from pyfds_evac.core.visibility import (  # noqa: E402
 )
 
 UNKNOWN, KNOWN, AGENT = "#c4c4cc", "#d62728", "#5b4fc4"
+WANDER, SIGN = "#e08a1e", "#2e7d32"
 
 
 def inward_alpha(exit_polygon: Polygon, interior_point) -> float:
@@ -137,8 +139,15 @@ def animate(
     out_path: Path,
     fps: int,
     agent_id: int | None = None,
+    switches=None,
 ) -> None:
-    """Render one agent's walk with the nodes it knows highlighted."""
+    """Render one agent's walk with the nodes it knows highlighted.
+
+    *switches* is the run's route history; when given, the agent and its
+    trail turn amber for the stretches where the last switch was a
+    ``wander`` -- knowledge-exhausted patrolling -- so those phases are
+    tellable apart from purposeful explore/exit legs at a glance.
+    """
     cfg = json.loads((bundle / "config.json").read_text())
     walkable = shapely_wkt.loads((bundle / "geometry.wkt").read_text().strip())
     # The same descriptors the run's visibility model used, so the drawn
@@ -171,13 +180,79 @@ def animate(
     if not frames:
         raise SystemExit(f"no trajectory rows for agent {agent_id}")
     history = [e for e in history if e["agent_id"] == agent_id]
+    switches = [s for s in (switches or []) if s["agent_id"] == agent_id]
     # A stalled 600 s run has thousands of rows; cap the movie at ~600 frames
     # so it stays watchable and renders in minutes, not hours. The trail is
     # drawn from the kept rows only, which is visually indistinguishable.
     stride = max(1, len(frames) // 600)
     frames = frames[::stride]
+    wandering = [_wandering_at(switches, frame / sim_fps) for frame, _, _ in frames]
 
-    fig, ax = plt.subplots(figsize=(9, 7))
+    fig, ax = plt.subplots(figsize=(9, 7.6))
+    fig.legend(
+        handles=[
+            Line2D(
+                [],
+                [],
+                marker="s",
+                ls="",
+                mfc=KNOWN,
+                mec="#40404a",
+                ms=9,
+                label="exit, known",
+            ),
+            Line2D(
+                [],
+                [],
+                marker="s",
+                ls="",
+                mfc=UNKNOWN,
+                mec="#40404a",
+                ms=9,
+                label="exit, unknown",
+            ),
+            Line2D(
+                [],
+                [],
+                marker="o",
+                ls="",
+                mfc=KNOWN,
+                mec="#40404a",
+                ms=9,
+                label="stage, known",
+            ),
+            Line2D(
+                [],
+                [],
+                marker="o",
+                ls="",
+                mfc=UNKNOWN,
+                mec="#40404a",
+                ms=9,
+                label="stage, unknown",
+            ),
+            Line2D(
+                [],
+                [],
+                marker="*",
+                ls="",
+                mfc=KNOWN,
+                mec="#40404a",
+                ms=12,
+                label="spawn",
+            ),
+            Line2D([], [], color=SIGN, lw=1.6, label="sign facing"),
+            Line2D([], [], marker="o", ls="-", color=AGENT, ms=8, label="agent"),
+            Line2D(
+                [], [], marker="o", ls="-", color=WANDER, ms=8, label="agent, wandering"
+            ),
+        ],
+        loc="lower center",
+        ncol=4,
+        frameon=False,
+        fontsize=9,
+    )
+    fig.subplots_adjust(bottom=0.12)
     writer = (
         FFMpegWriter(fps=fps)
         if shutil.which("ffmpeg") and out_path.suffix == ".mp4"
@@ -231,14 +306,35 @@ def animate(
                     mew=0.6,
                     zorder=4,
                 )
+            # Trail, drawn as runs of constant mode so wander stretches stay
+            # amber after the fact. Runs overlap by one point to keep the
+            # line unbroken.
+            start = 0
+            for j in range(1, i + 1):
+                if wandering[j] != wandering[start]:
+                    ax.plot(
+                        [p[1] for p in frames[start : j + 1]],
+                        [p[2] for p in frames[start : j + 1]],
+                        color=WANDER if wandering[start] else AGENT,
+                        lw=2,
+                        alpha=0.75,
+                    )
+                    start = j
             ax.plot(
-                [p[1] for p in frames[: i + 1]],
-                [p[2] for p in frames[: i + 1]],
-                color=AGENT,
+                [p[1] for p in frames[start : i + 1]],
+                [p[2] for p in frames[start : i + 1]],
+                color=WANDER if wandering[start] else AGENT,
                 lw=2,
                 alpha=0.75,
             )
-            ax.plot(x, y, marker="o", ms=11, color=AGENT, zorder=6)
+            ax.plot(
+                x,
+                y,
+                marker="o",
+                ms=11,
+                color=WANDER if wandering[i] else AGENT,
+                zorder=6,
+            )
             ax.set_title(
                 f"t = {t:5.2f} s     known nodes: {len(known)} / {len(nodes)}",
                 fontsize=11,
@@ -251,6 +347,16 @@ def animate(
             ax.set_yticks([])
             writer.grab_frame()
     plt.close(fig)
+
+
+def _wandering_at(switches, t: float) -> bool:
+    """Whether the last route switch at time *t* put the agent in wander mode."""
+    reason = None
+    for s in switches:
+        if s["time_s"] > t:
+            break
+        reason = s["reason"]
+    return reason == "wander"
 
 
 def _known_at(history, t: float) -> set[str]:
@@ -304,7 +410,9 @@ def main() -> int:
         print(f"  switch t={s['time_s']:.2f} -> {s['new_exit']} ({s['reason']})")
 
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    animate(bundle, sqlite_path, history, args.out, args.fps, args.agent)
+    animate(
+        bundle, sqlite_path, history, args.out, args.fps, args.agent, switches=switches
+    )
     print(f"\nwrote {args.out}")
     return 0
 

--- a/tests/test_blind_spawn_discovery.py
+++ b/tests/test_blind_spawn_discovery.py
@@ -226,8 +226,9 @@ class TestTheMapGrowsHopByHop:
         assert {"C2", "C3"} <= cmap.known_nodes
 
     def test_but_still_no_exit(self):
-        """``expand_on_arrival`` ignores visibility and reveals every neighbour,
-        so this holds only because pruning kept the exits non-adjacent to C1.
+        """``expand_on_arrival`` without a visibility model reveals every
+        neighbour, so this holds only because pruning kept the exits
+        non-adjacent to C1.
 
         If pruning regresses, this fails and says so, instead of the scenario
         silently collapsing to a single hop.
@@ -383,3 +384,129 @@ class TestTheKnownSubgraphIsHonest:
         sub = cognitive_subgraph(cmap, graph)
         assert "E_west" not in sub.nodes
         assert "E_east" not in sub.nodes
+
+
+class TestArrivalRespectsVisibility:
+    """Arrival reveals a neighbour only when the agent can actually see it.
+
+    Auto-wiring keeps "neighbour" physical by pruning, but on a deck whose
+    crossings do not cover every doorway a node stays graph-adjacent to stages
+    in other rooms. Revealing those unconditionally hands a discovery agent
+    exits behind walls -- the exact leak ``_expand_visible`` refuses for
+    perception -- so with a visibility model the arrival reveal must run
+    through the same gate. Without one there is no evidence either way and
+    every neighbour is revealed, or an unperceiving agent could never leave
+    its first node.
+    """
+
+    class _WallVis:
+        def __init__(self, visible):
+            self.visible = visible
+
+        def node_is_visible(self, time, x, y, node_id):
+            return node_id in self.visible
+
+    @staticmethod
+    def _hallway_graph():
+        from pyfds_evac.core.route_graph import StageNode, _make_edge
+
+        graph = StageGraph()
+        graph.nodes = {
+            "C0": StageNode("C0", 0.0, 0.0, "checkpoint"),
+            "C_corridor": StageNode("C_corridor", 0.0, -10.0, "checkpoint"),
+            "E_walled": StageNode("E_walled", 5.0, -5.0, "exit"),
+        }
+        for tgt in ("C_corridor", "E_walled"):
+            graph.edges.setdefault("C0", []).append(
+                _make_edge(graph.nodes["C0"], graph.nodes[tgt], None)
+            )
+        return graph
+
+    def _arrive(self, vis_model):
+        graph = self._hallway_graph()
+        cmap = init_cognitive_map("C0", graph, "discovery", None, 0.0)
+        expand_on_arrival(
+            cmap, "C0", graph, vis_model=vis_model, time_s=1.0, ax=0.0, ay=0.0
+        )
+        return cmap
+
+    def test_a_neighbour_behind_a_wall_stays_unknown(self):
+        cmap = self._arrive(self._WallVis({"C_corridor"}))
+        assert "C_corridor" in cmap.known_nodes
+        assert "E_walled" not in cmap.known_nodes
+        assert ("C0", "E_walled") not in cmap.known_edges
+
+    def test_without_a_visibility_model_every_neighbour_is_revealed(self):
+        cmap = self._arrive(None)
+        assert {"C_corridor", "E_walled"} <= cmap.known_nodes
+
+
+class TestTraversalTeachesTheWayBack:
+    """Learning a leg teaches its reverse leg, when the graph has one.
+
+    Route edges are directed, but knowledge of a corridor is not: an agent
+    that knows A->B can walk it back. Without the reverse edge a discovery
+    agent whose arrival reveals nothing new -- a doorway whose far side is
+    all walls -- holds a known subgraph with no outgoing edge at all, so
+    ``nearest_frontier_target`` cannot route it anywhere and it stands at a
+    node it can physically leave for the rest of the run.
+    """
+
+    class _BlindVis:
+        def node_is_visible(self, time, x, y, node_id):
+            return False
+
+    @staticmethod
+    def _corridor_graph():
+        from pyfds_evac.core.route_graph import StageNode, _make_edge
+
+        graph = StageGraph()
+        graph.nodes = {
+            "C0": StageNode("C0", 0.0, 0.0, "checkpoint"),
+            "C_dead_end": StageNode("C_dead_end", 0.0, -10.0, "checkpoint"),
+            "E0": StageNode("E0", 5.0, 0.0, "exit"),
+        }
+        for src, tgt in (("C0", "C_dead_end"), ("C_dead_end", "C0"), ("C0", "E0")):
+            graph.edges.setdefault(src, []).append(
+                _make_edge(graph.nodes[src], graph.nodes[tgt], None)
+            )
+        return graph
+
+    def test_the_reverse_leg_is_learned_with_the_leg(self):
+        graph = self._corridor_graph()
+        cmap = init_cognitive_map("C0", graph, "discovery", None, 0.0)
+        expand_on_arrival(cmap, "C0", graph)
+        assert ("C0", "C_dead_end") in cmap.known_edges
+        assert ("C_dead_end", "C0") in cmap.known_edges
+
+    def test_but_no_reverse_edge_is_invented_into_a_terminal_exit(self):
+        graph = self._corridor_graph()
+        cmap = init_cognitive_map("C0", graph, "discovery", None, 0.0)
+        expand_on_arrival(cmap, "C0", graph)
+        assert ("C0", "E0") in cmap.known_edges
+        assert ("E0", "C0") not in cmap.known_edges
+
+    def test_an_agent_at_a_blind_dead_end_can_still_be_routed_back(self):
+        """From C0 only the corridor is visible, so the exit edge stays
+        unknown and C0 remains a frontier. After walking into the dead end
+        and seeing nothing, the reverse leg is the agent's only known way
+        out -- without it the frontier is unreachable and it stands forever.
+        """
+
+        class _CorridorOnlyVis:
+            def node_is_visible(self, time, x, y, node_id):
+                return node_id == "C_dead_end"
+
+        graph = self._corridor_graph()
+        cmap = init_cognitive_map("C0", graph, "discovery", None, 0.0)
+        expand_on_arrival(
+            cmap, "C0", graph, vis_model=_CorridorOnlyVis(), ax=0.0, ay=0.0
+        )
+        expand_on_arrival(
+            cmap, "C_dead_end", graph, vis_model=self._BlindVis(), ax=0.0, ay=-10.0
+        )
+        frontier = nearest_frontier_target(cmap, graph, "C_dead_end", (0.0, -10.0))
+        assert frontier is not None
+        target, path = frontier
+        assert target == "C0"
+        assert path == ["C_dead_end", "C0"]

--- a/tests/test_blind_spawn_discovery.py
+++ b/tests/test_blind_spawn_discovery.py
@@ -464,9 +464,16 @@ class TestTraversalTeachesTheWayBack:
         graph.nodes = {
             "C0": StageNode("C0", 0.0, 0.0, "checkpoint"),
             "C_dead_end": StageNode("C_dead_end", 0.0, -10.0, "checkpoint"),
+            "C_far": StageNode("C_far", 20.0, 0.0, "checkpoint"),
             "E0": StageNode("E0", 5.0, 0.0, "exit"),
         }
-        for src, tgt in (("C0", "C_dead_end"), ("C_dead_end", "C0"), ("C0", "E0")):
+        for src, tgt in (
+            ("C0", "C_dead_end"),
+            ("C_dead_end", "C0"),
+            ("C0", "C_far"),
+            ("C_far", "C0"),
+            ("C0", "E0"),
+        ):
             graph.edges.setdefault(src, []).append(
                 _make_edge(graph.nodes[src], graph.nodes[tgt], None)
             )
@@ -487,26 +494,99 @@ class TestTraversalTeachesTheWayBack:
         assert ("E0", "C0") not in cmap.known_edges
 
     def test_an_agent_at_a_blind_dead_end_can_still_be_routed_back(self):
-        """From C0 only the corridor is visible, so the exit edge stays
-        unknown and C0 remains a frontier. After walking into the dead end
-        and seeing nothing, the reverse leg is the agent's only known way
-        out -- without it the frontier is unreachable and it stands forever.
+        """From C0 the corridor and a far doorway are visible; the far one
+        stays unvisited. After walking into the dead end and seeing nothing,
+        the reverse leg is the agent's only known way back out toward that
+        frontier -- without it the frontier is unreachable and the agent
+        stands at a node it can physically leave for the rest of the run.
         """
 
-        class _CorridorOnlyVis:
+        class _FromC0Vis:
             def node_is_visible(self, time, x, y, node_id):
-                return node_id == "C_dead_end"
+                return node_id in ("C_dead_end", "C_far")
 
         graph = self._corridor_graph()
         cmap = init_cognitive_map("C0", graph, "discovery", None, 0.0)
-        expand_on_arrival(
-            cmap, "C0", graph, vis_model=_CorridorOnlyVis(), ax=0.0, ay=0.0
-        )
+        expand_on_arrival(cmap, "C0", graph, vis_model=_FromC0Vis(), ax=0.0, ay=0.0)
         expand_on_arrival(
             cmap, "C_dead_end", graph, vis_model=self._BlindVis(), ax=0.0, ay=-10.0
         )
         frontier = nearest_frontier_target(cmap, graph, "C_dead_end", (0.0, -10.0))
         assert frontier is not None
         target, path = frontier
-        assert target == "C0"
-        assert path == ["C_dead_end", "C0"]
+        assert target == "C_far"
+        assert path == ["C_dead_end", "C0", "C_far"]
+
+
+class TestExploringNeverLoops:
+    """A visited node is a closed frontier, whatever it failed to teach.
+
+    With visibility-gated arrival, a visited node can keep unknown edges
+    forever -- its neighbours' signs face away, so no amount of standing
+    there reveals them. If such nodes stay frontiers, two of them adjacent
+    to each other trap the explorer: the nearest frontier from each is the
+    other, and the agent shuttles between them for the rest of the run
+    while genuinely unvisited nodes wait. Closing frontiers on arrival
+    makes every explore hop consume one unvisited node, so exploration
+    terminates.
+    """
+
+    class _BlindVis:
+        def node_is_visible(self, time, x, y, node_id):
+            return False
+
+    @staticmethod
+    def _cluster_graph():
+        from pyfds_evac.core.route_graph import StageNode, _make_edge
+
+        graph = StageGraph()
+        graph.nodes = {
+            "S": StageNode("S", 0.0, 0.0, "distribution"),
+            "A": StageNode("A", 0.0, -5.0, "checkpoint"),
+            "B": StageNode("B", 3.0, -5.0, "checkpoint"),
+            "C_far": StageNode("C_far", -20.0, -5.0, "checkpoint"),
+            "X": StageNode("X", 3.0, -20.0, "checkpoint"),
+        }
+        pairs = (
+            ("S", "A"),
+            ("A", "B"),
+            ("B", "A"),
+            ("A", "C_far"),
+            ("C_far", "A"),
+            ("A", "X"),
+            ("B", "X"),
+        )
+        for src, tgt in pairs:
+            graph.edges.setdefault(src, []).append(
+                _make_edge(graph.nodes[src], graph.nodes[tgt], None)
+            )
+        return graph
+
+    def _walk_a_then_b(self):
+        graph = self._cluster_graph()
+
+        class _FromAVis:
+            def node_is_visible(self, time, x, y, node_id):
+                return node_id in ("B", "C_far")
+
+        cmap = init_cognitive_map("S", graph, "discovery", None, 0.0)
+        expand_on_arrival(cmap, "A", graph, vis_model=_FromAVis(), ax=0.0, ay=-5.0)
+        expand_on_arrival(cmap, "B", graph, vis_model=self._BlindVis(), ax=3.0, ay=-5.0)
+        return graph, cmap
+
+    def test_a_visited_neighbour_is_not_offered_again(self):
+        """A and B both still have the unknown edge to X, but both were
+        visited: the frontier from B must be the unvisited C_far, not the
+        2 m hop back to A that taught nothing last time.
+        """
+        graph, cmap = self._walk_a_then_b()
+        frontier = nearest_frontier_target(cmap, graph, "B", (3.0, -5.0))
+        assert frontier is not None
+        assert frontier[0] == "C_far"
+
+    def test_exploration_terminates_when_every_known_node_was_visited(self):
+        graph, cmap = self._walk_a_then_b()
+        expand_on_arrival(
+            cmap, "C_far", graph, vis_model=self._BlindVis(), ax=-20.0, ay=-5.0
+        )
+        assert nearest_frontier_target(cmap, graph, "C_far", (-20.0, -5.0)) is None

--- a/tests/test_familiarity_routing.py
+++ b/tests/test_familiarity_routing.py
@@ -187,6 +187,10 @@ class TestNearestFrontierTarget:
             familiarity="discovery",
             known_nodes={"D0", "C0", "E0"},
             known_edges={("D0", "C0"), ("C0", "E0")},
+            # Explored means visited: with gated arrival a visited node may
+            # keep unknown edges forever, so edge-completeness no longer
+            # defines the frontier (see nearest_frontier_target).
+            visited_nodes={"D0", "C0", "E0"},
         )
         assert nearest_frontier_target(cmap, g, "D0") is None
 

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2535,3 +2535,67 @@ class TestAnIdleAgentIsNotRetired:
             config=RerouteConfig(cost_config=RouteCostConfig(base_speed_m_per_s=1.3)),
         )
         assert switch is None
+
+
+class TestExploreCommitmentIsNotReissued:
+    """An explore switch to a multi-hop frontier must be recorded once.
+
+    The frontier target sits at the end of the path, but the agent's
+    current_target_stage is the next intermediate hop -- so a guard that
+    compares the frontier against the current target re-fires the same
+    switch on every reevaluation until arrival, resetting the leg and
+    flooding route_history (13 identical switches in 13 s were observed in
+    a CrowdRL world).
+    """
+
+    @staticmethod
+    def _chain_graph():
+        direct = {
+            "A": {"polygon": _box(0, 10), "stage_type": "checkpoint"},
+            "F": {"polygon": _box(0, 20), "stage_type": "checkpoint"},
+            "EX": {"polygon": _box(50, 0), "stage_type": "exit"},
+        }
+        trans = [
+            {"from": "D0", "to": "A"},
+            {"from": "A", "to": "F"},
+            {"from": "F", "to": "EX"},
+        ]
+        graph = StageGraph.from_scenario(
+            direct, trans, distributions={"D0": {"polygon": _box(0, 0)}}
+        )
+        return graph
+
+    def _evaluate(self, graph, wait_info, route_state, cmap, t):
+        return evaluate_and_reroute(
+            agent_id=0,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=graph,
+            current_time_s=t,
+            current_fed=0.0,
+            extinction_sampler=ConstantExtinctionField(0.0),
+            fed_rate_sampler=None,
+            config=RerouteConfig(cost_config=RouteCostConfig(base_speed_m_per_s=1.0)),
+            cognitive_map=cmap,
+        )
+
+    def test_the_switch_fires_once_and_stays_committed(self):
+        from pyfds_evac.core.cognitive_map import AgentCognitiveMap
+
+        graph = self._chain_graph()
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "A", "F"},
+            known_edges={("D0", "A"), ("A", "F")},
+            visited_nodes={"D0", "A"},
+        )
+        wait_info = _make_wait_info(graph, "D0", "D0")
+        route_state = AgentRouteState()
+
+        first = self._evaluate(graph, wait_info, route_state, cmap, 0.0)
+        assert first is not None
+        assert first.reason == "explore"
+        assert first.new_exit == "F"
+        # Mid-walk to the intermediate hop: same frontier, same commitment.
+        second = self._evaluate(graph, wait_info, route_state, cmap, 1.0)
+        assert second is None

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2599,3 +2599,102 @@ class TestExploreCommitmentIsNotReissued:
         # Mid-walk to the intermediate hop: same frontier, same commitment.
         second = self._evaluate(graph, wait_info, route_state, cmap, 1.0)
         assert second is None
+
+
+class TestWanderWhenKnowledgeIsExhausted:
+    """No reachable exit, no unvisited frontier: patrol the known nodes.
+
+    Standing still ends discovery: perception evaluates from the agent's
+    position, and sign legibility is position-dependent (distance and the
+    readable half-plane), so a leg walked between two known nodes can make
+    a sign readable that never was from either node. The patrol rotates
+    deterministically through the known nodes -- reproducible under a fixed
+    run seed and guaranteed to cover every known leg, where a random draw
+    could favour some.
+    """
+
+    @staticmethod
+    def _graph_and_cmap():
+        from pyfds_evac.core.cognitive_map import AgentCognitiveMap
+
+        direct = {
+            "A": {"polygon": _box(0, 10), "stage_type": "checkpoint"},
+            "F": {"polygon": _box(0, 20), "stage_type": "checkpoint"},
+            "EX": {"polygon": _box(50, 0), "stage_type": "exit"},
+        }
+        trans = [
+            {"from": "D0", "to": "A"},
+            {"from": "A", "to": "F"},
+            {"from": "A", "to": "D0"},
+            {"from": "F", "to": "A"},
+            {"from": "F", "to": "EX"},
+        ]
+        graph = StageGraph.from_scenario(
+            direct, trans, distributions={"D0": {"polygon": _box(0, 0)}}
+        )
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "A", "F"},
+            known_edges={("D0", "A"), ("A", "F"), ("A", "D0"), ("F", "A")},
+            visited_nodes={"D0", "A", "F"},
+        )
+        return graph, cmap
+
+    def _evaluate(self, graph, wait_info, route_state, cmap, t):
+        return evaluate_and_reroute(
+            agent_id=0,
+            wait_info=wait_info,
+            route_state=route_state,
+            graph=graph,
+            current_time_s=t,
+            current_fed=0.0,
+            extinction_sampler=ConstantExtinctionField(0.0),
+            fed_rate_sampler=None,
+            config=RerouteConfig(cost_config=RouteCostConfig(base_speed_m_per_s=1.0)),
+            cognitive_map=cmap,
+        )
+
+    def test_the_agent_patrols_instead_of_standing(self):
+        graph, cmap = self._graph_and_cmap()
+        wait_info = _make_wait_info(graph, "D0", "D0")
+        route_state = AgentRouteState()
+
+        switch = self._evaluate(graph, wait_info, route_state, cmap, 0.0)
+        assert switch is not None
+        assert switch.reason == "wander"
+        assert switch.old_exit is None
+        assert switch.new_exit == "A"  # first stop of the sorted rotation
+
+    def test_a_committed_leg_is_not_reissued_mid_walk(self):
+        graph, cmap = self._graph_and_cmap()
+        wait_info = _make_wait_info(graph, "D0", "D0")
+        route_state = AgentRouteState()
+
+        self._evaluate(graph, wait_info, route_state, cmap, 0.0)
+        assert self._evaluate(graph, wait_info, route_state, cmap, 1.0) is None
+
+    def test_arrival_advances_the_patrol_to_the_next_stop(self):
+        graph, cmap = self._graph_and_cmap()
+        wait_info = _make_wait_info(graph, "D0", "D0")
+        route_state = AgentRouteState()
+
+        first = self._evaluate(graph, wait_info, route_state, cmap, 0.0)
+        wait_info["state"] = "idle"
+        wait_info["current_origin"] = first.new_exit
+        wait_info["current_target_stage"] = first.new_exit
+        second = self._evaluate(graph, wait_info, route_state, cmap, 10.0)
+        assert second is not None
+        assert second.reason == "wander"
+        assert second.new_exit == "F"
+
+    def test_still_stands_when_it_knows_nowhere_else(self):
+        from pyfds_evac.core.cognitive_map import AgentCognitiveMap
+
+        graph, _ = self._graph_and_cmap()
+        loner = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0"},
+            visited_nodes={"D0"},
+        )
+        wait_info = _make_wait_info(graph, "D0", "D0")
+        assert self._evaluate(graph, wait_info, AgentRouteState(), loner, 0.0) is None

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2698,3 +2698,43 @@ class TestWanderWhenKnowledgeIsExhausted:
         )
         wait_info = _make_wait_info(graph, "D0", "D0")
         assert self._evaluate(graph, wait_info, AgentRouteState(), loner, 0.0) is None
+
+
+class TestWanderCanGoHome:
+    """The patrol can walk back to the spawn area it came from.
+
+    Auto-wiring never points an edge at a distribution, so a directed
+    search over known edges cannot route the agent home -- and an agent
+    that knows only its spawn and the one checkpoint it stands on then
+    has no patrol at all and stands still. Corridors are physically
+    two-way: the patrol treats every known leg as walkable in both
+    directions.
+    """
+
+    @staticmethod
+    def _two_node_world():
+        from pyfds_evac.core.cognitive_map import AgentCognitiveMap
+
+        direct = {"C1": {"polygon": _box(0, 10), "stage_type": "checkpoint"}}
+        graph = StageGraph.from_scenario(
+            direct,
+            [{"from": "D0", "to": "C1"}],
+            distributions={"D0": {"polygon": _box(0, 0)}},
+        )
+        cmap = AgentCognitiveMap(
+            familiarity="discovery",
+            known_nodes={"D0", "C1"},
+            known_edges={("D0", "C1")},
+            visited_nodes={"D0", "C1"},
+        )
+        return graph, cmap
+
+    def test_the_only_patrol_stop_is_the_spawn_it_came_from(self):
+        from pyfds_evac.core.cognitive_map import wander_target
+
+        graph, cmap = self._two_node_world()
+        wander = wander_target(cmap, graph, "C1", 0)
+        assert wander is not None
+        target, path = wander
+        assert target == "D0"
+        assert path == ["C1", "D0"]


### PR DESCRIPTION
## Problem

On a deck with no authored transitions the stage graph is auto-wired, and its pruning is a reachability test, not a visibility test — so a node can stay graph-adjacent to stages in other rooms. `expand_on_arrival` then revealed **every** graph neighbour when an agent physically reached a node: in the `cognitive_map_test` deck, one arrival at a hallway crossing taught a discovery agent 6 of 11 nodes, 5 of them with no line of sight (verified with exact segment-in-polygon checks). The agent then committed to an exit it had never seen, flattening the familiarity gradient and understating discovery time.

## Fix 1 — arrival learning goes through the visibility gate

`expand_on_arrival` now checks each neighbour with the same `node_is_visible` query perception uses, evaluated from the agent's actual position at arrival time. Without a visibility model the reveal-all behaviour is unchanged, so vis-model-less decks still progress hop by hop.

## Fix 2 — a masked stranding defect

Honest learning exposed a bug the leak had been hiding: an agent that walked `spawn → C0 → C2` and saw nothing new at `C2` held only *inbound* known edges (`C0→C2`, never `C2→C0`). Its known subgraph had no outgoing edge, `nearest_frontier_target` found every frontier unreachable, and the agent stood at a physically leavable dead end for the remaining 585 s of the run. Learning an edge now also learns its reverse when the graph offers one — knowledge of a corridor is bidirectional. Exits stay terminal and spawn areas keep no inbound edges, so routing invariants hold.

## Result

Same deck, same seed, before → after:

| | before | after |
|---|---|---|
| t=4.8 s map | 8/11 nodes (5 through walls) | 3/11 nodes (line-of-sight only) |
| behaviour | walks straight to a never-seen exit | explore → dead end → backtrack → explore → first sight of exit → commit |
| egress | 11.9 s via leaked knowledge | 24.7 s, honestly discovered, 5/11 nodes known at exit |

## Also

- `scripts/animate_cognitive_map.py`: new `--cell-size` flag (walls thinner than the 0.5 m default grid cell stop occluding; this deck's are 0.40 m) and axis limits from the walkable bounds instead of hard-coded values.
- Three new tests in `tests/test_blind_spawn_discovery.py`: wall-gated arrival, no invented reverse edge into a terminal exit, and an agent at a blind dead end can still be routed back.
- README discovery rules updated; companion paper prose updated separately in its own repo.

526 tests pass, ruff check/format clean.