### PR TITLE
feat(test): world generator in-repo, invariant tests on generated decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ The routing system implements smoke-aware path planning with dynamic rerouting:
   records what each agent knows, every time it changes — see
   [docs/testing-familiarity.md](docs/testing-familiarity.md) and
   `scripts/animate_cognitive_map.py`
+- **Discovery-world generator**: `scripts/generate_discovery_world.py` produces
+  random test decks (open room, convex obstacles, signed checkpoints, exits
+  optionally hidden from the spawn) for exercising discovery routing; the same
+  decks drive the invariant tests in `tests/test_generated_worlds.py`
 - **Congestion-aware routing**: Optional exit-congestion term (`w_queue`), **off
   by default** — it scales with a global agent count, so no constant suits every
   scenario. `assets/station_fahy` opts in at 0.03, calibrated against Fahy

--- a/docs/superpowers/specs/2026-08-10-cognitive-map-test-strategy-design.md
+++ b/docs/superpowers/specs/2026-08-10-cognitive-map-test-strategy-design.md
@@ -1,0 +1,97 @@
+# Cognitive-map test strategy — trustworthy results for the talk
+
+**Goal.** Full confidence that the cognitive-map/discovery pipeline works as
+specified, ahead of a talk in September 2026. "Full confidence" means: every
+rule of the model is pinned by a test that fails when the rule breaks, the
+integration between rules is exercised on uncurated geometry, and the known
+remaining risks are listed rather than implied.
+
+## What exists already (do not duplicate)
+
+| Area | Where |
+| --- | --- |
+| Perception acquisition vs persistence (memory) | `tests/test_cognitive_map_memory.py` |
+| Blind spawn, frontier hops, position-aware frontier ties | `tests/test_blind_spawn_discovery.py` |
+| Vis-gated arrival, reverse-edge learning, no invented exit reverses | `tests/test_blind_spawn_discovery.py` (PR #96) |
+| Visited-based frontier, explore/wander commitment, patrol-home | `tests/test_route_graph.py` (PR #96) |
+| Initial exit choice from the map, not geometry | `tests/test_initial_exit_from_cognitive_map.py` |
+| History replay equals engine state | `tests/test_cognitive_map_history.py` |
+| Familiarity tiers and scalar draw plumbing | `tests/test_familiarity_routing.py`, `tests/test_scalar_familiarity.py` |
+| Verification-grade map checks | `tests/verification/test_cognitive_map_verif.py` |
+| Invariants on generated worlds (this PR) | `tests/test_generated_worlds.py` |
+
+## Risk map (ordered by cost of being wrong on stage)
+
+1. **Through-wall knowledge** — an agent uses an exit it could never have
+   seen. Would invalidate the headline claim of the talk. *Covered*: unit
+   tests + the generated-world evidence invariant (every learned node was
+   sign-visible from the agent's position or physically adjacent).
+2. **Silent stall / infinite loop** — an agent freezes or shuttles although
+   it has somewhere informative to go. *Covered* for the failure modes found
+   in PR #96; *gap*: no test asserts "an agent with a reachable unvisited
+   frontier never stands idle for more than one reevaluation interval".
+3. **Wander patrol walking through an exit** — `_undirected_known_path`
+   builds paths over symmetric known edges; a known exit could appear as an
+   intermediate hop, and stepping into an exit stage evacuates the agent.
+   Reachable only when an exit is known but every route to it was rejected
+   (e.g. smoke), so rare — but it would silently *shorten* egress. *Gap*.
+4. **Familiarity semantics** — `full` must equal classical shortest-path
+   behaviour; scalar `p` must yield ≈ p fraction of agents knowing each exit.
+   *Partly covered* (tier plumbing); *gap*: no equivalence test full-vs-
+   no-cognitive-map, no statistical test of the scalar draw.
+5. **Multi-agent isolation** — one agent's learning must never leak into
+   another's map. *Gap*: all current behavioural tests are single-agent.
+6. **Flow-spawned agents** — two map-initialisation sites claim to produce
+   identical maps for the same agent (`_assign_initial_exit` vs reroute
+   pass). *Gap*: asserted in a comment, not a test.
+7. **Smoke-coupled discovery** — under a time-varying extinction field,
+   acquisition must stop where visibility ends and resume when it clears.
+   *Partly covered* in clear air; *gap*: no FDS-coupled discovery test.
+8. **Sign-position offsets** — audits flag "sign visible, centroid not";
+   benign today, but nothing pins that node visibility means *sign*
+   visibility. Low risk; document rather than test.
+
+## Layered plan
+
+- **Unit** (fast, per-rule): close gaps 3 and 6 with direct tests on
+  `wander_target` (exit never an intermediate hop — likely needs a fix, not
+  just a test) and on the two init sites (identical map for identical seed).
+- **Integration** (engine runs on small decks): close gaps 2, 4, 5 —
+  no-idle-with-reachable-frontier watchdog; `full` agent's route equals the
+  no-cognitive-map route on the same deck; a 2-group run (staff + visitors)
+  asserting per-agent map sizes never cross-contaminate.
+- **Statistical** (seeded, aggregate): scalar familiarity draw — over ~200
+  seeded map initialisations, exit-known fraction within a binomial
+  tolerance of p (mutation-tested: breaking the draw must fail it).
+- **End-to-end** (generated worlds, this PR): invariants on uncurated
+  geometry; extend later with a smoke-coupled seed once gap 7 is addressed.
+
+## Test cases to add (priority order)
+
+1. `wander_target` never returns a path with an exit as an intermediate node
+   (and engine fix if it can).
+2. Watchdog: agent with reachable unvisited frontier receives a switch
+   within one reevaluation interval (regression net over PR #96's class of
+   bugs).
+3. Full-familiarity equivalence: same deck, `familiarity=full` vs
+   `reroute_config` without cognitive maps — same exit chosen, comparable
+   egress (aggregate, not bit-exact; coupled runs are not reproducible).
+4. Two-group isolation: visitors' maps grow, staff maps stay complete, no
+   agent's known set ever contains a node only another agent could have
+   perceived at that time.
+5. Init-site parity: `init_cognitive_map` called from both sites with the
+   same seed yields identical maps.
+6. Scalar familiarity statistics (binomial band, fixed seeds).
+7. Smoke-coupled discovery on one FDS-backed deck (acquisition stops in
+   smoke, resumes in clear air) — needs an FDS fixture; schedule last.
+
+## Non-test controls
+
+- The per-run audit (`audit_worlds.py` pattern) stays the pre-talk gate for
+  any world shown publicly: learning-evidence check + egress table.
+- Videos remain the human check: sign arrows + amber wander phases make
+  violations visible even where no assertion looks.
+
+## Out of scope
+
+Multi-storey knowledge, agent-to-agent knowledge exchange, forgetting.

--- a/scripts/generate_discovery_world.py
+++ b/scripts/generate_discovery_world.py
@@ -320,7 +320,9 @@ def generate_world(seed: int, args: argparse.Namespace) -> tuple[Polygon, dict]:
             rng,
             room,
             placed,
-            lambda cx, cy: Point(cx, cy).buffer(CHECKPOINT_RADIUS, quad_segs=8),
+            # No quad_segs: 8 is already Shapely 2's default, and the keyword
+            # does not exist under Shapely 1.x (there it is `resolution`).
+            lambda cx, cy: Point(cx, cy).buffer(CHECKPOINT_RADIUS),
         )
         if circle is None:
             break

--- a/scripts/generate_discovery_world.py
+++ b/scripts/generate_discovery_world.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Generate one random discoverability-test world (geometry.wkt + config.json + zip).
+
+The world is a rectangular walkable area with a few convex obstacle holes,
+2-4 exits flush against the boundary walls, and 2-4 circular checkpoint
+"stages" carrying signs. The spawn area is placed as far from the exits as
+possible so agents must explore to discover them. Output layout matches
+cognitive_map_test.zip: a zip with geometry.wkt and config.json at its root.
+
+Usage:
+    .venv/bin/python scripts/generate_discovery_world.py --seed 42 --out worlds/
+
+Decks run directly with ``scripts/animate_cognitive_map.py --scenario worlds/world_42``
+and drive the generated-world invariant tests in ``tests/test_generated_worlds.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import zipfile
+from pathlib import Path
+
+import numpy as np
+from shapely.geometry import LineString, Point, Polygon, box
+from shapely.ops import unary_union
+
+WALL_MARGIN = 2.5  # obstacle keep-out from walls, keeps corridors walkable (m)
+CLEARANCE = 1.2  # minimum gap between any two placed shapes (m)
+EXIT_DEPTH = 0.8  # how far an exit rectangle reaches into the room (m)
+CHECKPOINT_RADIUS = 0.5
+
+# Defaults copied verbatim from the cognitive_map_test.zip reference project.
+SIMULATION_PARAMS = {
+    "max_simulation_time": 600,
+    "dt": 0.05,
+    "model_type": "WarpDriverModel",
+    "strength_neighbor_repulsion": 2.6,
+    "range_neighbor_repulsion": 0.1,
+    "gcfm_strength_neighbor_repulsion": 0.3,
+    "gcfm_strength_geometry_repulsion": 0.2,
+    "gcfm_max_neighbor_interaction_distance": 2,
+    "gcfm_max_geometry_interaction_distance": 2,
+    "gcfm_max_neighbor_repulsion_force": 9,
+    "gcfm_max_geometry_repulsion_force": 3,
+    "mass": 80,
+    "tau": 0.5,
+    "a_v": 1,
+    "a_min": 0.2,
+    "b_min": 0.2,
+    "b_max": 0.4,
+    "relaxation_time": 0.5,
+    "agent_strength": 2000,
+    "agent_range": 0.08,
+    "sfm_obstacle_scale": 2000,
+    "sfm_body_force": 120000,
+    "sfm_friction": 240000,
+    "T": 1,
+    "s0": 0.5,
+}
+
+
+def ring(poly: Polygon) -> list[list[float]]:
+    """Closed [[x, y], ...] ring (shapely exteriors repeat the first point)."""
+    return [[float(x), float(y)] for x, y in poly.exterior.coords]
+
+
+def make_room(rng: np.random.Generator, scale: float = 1.0) -> Polygon:
+    half_w = scale * rng.uniform(12.0, 20.0)
+    half_h = scale * rng.uniform(9.0, 15.0)
+    return box(-half_w, -half_h, half_w, half_h)
+
+
+def random_obstacle(rng: np.random.Generator, allowed: Polygon) -> Polygon | None:
+    minx, miny, maxx, maxy = allowed.bounds
+    for _ in range(300):
+        cx = rng.uniform(minx, maxx)
+        cy = rng.uniform(miny, maxy)
+        if not allowed.contains(Point(cx, cy)):
+            continue
+        radius = rng.uniform(1.2, 3.0)
+        n_pts = int(rng.integers(4, 8))
+        angles = np.sort(rng.uniform(0.0, 2.0 * math.pi, n_pts))
+        radii = radius * rng.uniform(0.6, 1.0, n_pts)
+        pts = [
+            (cx + r * math.cos(a), cy + r * math.sin(a)) for a, r in zip(angles, radii)
+        ]
+        poly = Polygon(pts).convex_hull
+        if not isinstance(poly, Polygon) or poly.area < 1.5:
+            continue
+        if allowed.contains(poly):
+            return poly
+    return None
+
+
+def place_obstacles(rng: np.random.Generator, room: Polygon, n: int) -> list[Polygon]:
+    # Extra inset guarantees holes never touch the boundary, so the walkable
+    # area stays connected and every exit remains discoverable.
+    allowed = room.buffer(-WALL_MARGIN)
+    obstacles: list[Polygon] = []
+    for _ in range(n * 40):
+        if len(obstacles) == n:
+            break
+        cand = random_obstacle(rng, allowed)
+        if cand is None:
+            continue
+        if all(cand.distance(o) >= CLEARANCE for o in obstacles):
+            obstacles.append(cand)
+    return obstacles
+
+
+def place_exits(rng: np.random.Generator, room: Polygon, n: int) -> list[Polygon]:
+    minx, miny, maxx, maxy = room.bounds
+    exits = []
+    for edge in rng.choice(["N", "S", "E", "W"], size=min(n, 4), replace=False):
+        width = rng.uniform(1.2, 2.5)
+        if edge in ("N", "S"):
+            x0 = rng.uniform(minx + 2.0, maxx - 2.0 - width)
+            y0 = maxy - EXIT_DEPTH if edge == "N" else miny
+            exits.append(box(x0, y0, x0 + width, y0 + EXIT_DEPTH))
+        else:
+            y0 = rng.uniform(miny + 2.0, maxy - 2.0 - width)
+            x0 = maxx - EXIT_DEPTH if edge == "E" else minx
+            exits.append(box(x0, y0, x0 + EXIT_DEPTH, y0 + width))
+    return exits
+
+
+def sample_clear_shape(
+    rng: np.random.Generator,
+    room: Polygon,
+    placed: list[Polygon],
+    make_shape,
+    margin: float = 1.0,
+) -> Polygon | None:
+    minx, miny, maxx, maxy = room.bounds
+    for _ in range(500):
+        cx = rng.uniform(minx + margin, maxx - margin)
+        cy = rng.uniform(miny + margin, maxy - margin)
+        shape = make_shape(cx, cy)
+        if not room.contains(shape):
+            continue
+        if all(shape.distance(p) >= CLEARANCE for p in placed):
+            return shape
+    return None
+
+
+def exits_hidden_from(
+    spawn: Polygon, exits: list[Polygon], obstacles: list[Polygon]
+) -> bool:
+    """True when every sightline from the spawn centre to every exit is blocked."""
+    if not obstacles:
+        return False
+    blockers = unary_union(obstacles)
+    origin = spawn.centroid
+    for e in exits:
+        targets = list(e.exterior.coords[:-1]) + [(e.centroid.x, e.centroid.y)]
+        if any(not LineString([origin, t]).intersects(blockers) for t in targets):
+            return False
+    return True
+
+
+def place_spawn(
+    rng: np.random.Generator,
+    room: Polygon,
+    placed: list[Polygon],
+    exits: list[Polygon],
+    obstacles: list[Polygon],
+    hide_exits: bool,
+) -> Polygon:
+    def make(cx: float, cy: float) -> Polygon:
+        return box(cx - 1.5, cy - 1.25, cx + 1.5, cy + 1.25)
+
+    candidates = []
+    for _ in range(120):
+        cand = sample_clear_shape(rng, room, placed, make, margin=2.5)
+        if cand is not None:
+            candidates.append(cand)
+    if hide_exits:
+        candidates = [c for c in candidates if exits_hidden_from(c, exits, obstacles)]
+        if not candidates:
+            raise RuntimeError("no spawn spot with all exits hidden; try another seed")
+    if not candidates:
+        raise RuntimeError("could not place a spawn area; try another seed")
+    return max(candidates, key=lambda c: min(c.distance(e) for e in exits))
+
+
+def sign_alpha_toward(sign_x: float, sign_y: float, focus: Point) -> float:
+    """Compass bearing (deg from north, CW) from the sign toward *focus*.
+
+    fdsvismap reads alpha as the centre of the sign's readable half-plane,
+    so a sign aimed at the space its readers walk in is legible from there.
+    Random orientations regularly leave a world unsolvable for discovery
+    agents: every sign reachable from the spawn side can face away, and a
+    blind agent then patrols its known legs forever without learning more.
+    """
+    return math.degrees(math.atan2(focus.x - sign_x, focus.y - sign_y)) % 360
+
+
+def checkpoint_entry(
+    rng: np.random.Generator, circle: Polygon, center: Point, focus: Point | None
+) -> dict:
+    sign_x = center.x + rng.uniform(-0.1, 0.1)
+    sign_y = center.y + rng.uniform(-0.1, 0.1)
+    alpha = (
+        float(rng.uniform(0.0, 360.0))
+        if focus is None
+        else sign_alpha_toward(sign_x, sign_y, focus)
+    )
+    return {
+        "type": "polygon",
+        "coordinates": ring(circle),
+        "waiting_time": 0,
+        "waiting_time_distribution": "constant",
+        "waiting_time_std": 1,
+        "enable_throughput_throttling": False,
+        "max_throughput": 1,
+        "speed_factor": 1,
+        "shape": "circle",
+        "center": [center.x, center.y],
+        "radius": CHECKPOINT_RADIUS,
+        "sign": {
+            "x": sign_x,
+            "y": sign_y,
+            "alpha": alpha,
+            "c": 3,
+        },
+    }
+
+
+def build_config(
+    rng: np.random.Generator,
+    seed: int,
+    n_agents: int,
+    exits: list[Polygon],
+    spawn: Polygon,
+    checkpoints: list[Polygon],
+    n_obstacles: int,
+    random_sign_alpha: bool = False,
+) -> dict:
+    exit_entries = {
+        f"jps-exits_{i}": {
+            "type": "polygon",
+            "coordinates": ring(e),
+            "enable_throughput_throttling": False,
+            "max_throughput": 0,
+        }
+        for i, e in enumerate(exits)
+    }
+    distribution = {
+        "type": "polygon",
+        "coordinates": ring(spawn),
+        "parameters": {
+            "number": n_agents,
+            "radius": 0.1,
+            "v0": 1.3,
+            "flow_start_time": 0,
+            "flow_end_time": 10,
+            "percentage": None,
+            "distribution_mode": "by_number",
+            "use_flow_spawning": False,
+            "use_premovement": False,
+            "premovement_distribution": "gamma",
+            "premovement_param_a": None,
+            "premovement_param_b": None,
+            "premovement_seed": None,
+            "radius_distribution": "constant",
+            "v0_distribution": "constant",
+        },
+        "journey_weights": [],
+    }
+    # Aim each checkpoint sign at the spawn area: agents encounter every
+    # sign travelling outward from the spawn, and a sign is read by the
+    # people approaching it -- the same convention real escape-route
+    # signage follows. (Aiming at the room interior instead leaves the
+    # signs nearest the spawn facing away from it, and the discovery
+    # chain never starts.) Exits stay hidden by geometry until approached.
+    focus = None if random_sign_alpha else spawn.centroid
+    checkpoint_entries = {
+        f"jps-checkpoints_{i}": checkpoint_entry(rng, c, c.centroid, focus)
+        for i, c in enumerate(checkpoints)
+    }
+    return {
+        "project_version": "2.0",
+        "config": {
+            "simulation_settings": {
+                "simulationParams": dict(SIMULATION_PARAMS),
+                "numberOfSimulations": 1,
+                "baseSeed": seed,
+            },
+            "ui_state": {"useShortestPaths": False, "boundaries": [{"mode": "manual"}]},
+        },
+        "exits": exit_entries,
+        "distributions": {"jps-distributions_0": distribution},
+        "checkpoints": checkpoint_entries,
+        "zones": {},
+        "journeys": [],
+        "transitions": [],
+        "obstacles": {f"jps-obstacles_{i}": {"height": 3} for i in range(n_obstacles)},
+        "journeys_v2": [],
+    }
+
+
+def generate_world(seed: int, args: argparse.Namespace) -> tuple[Polygon, dict]:
+    rng = np.random.default_rng(seed)
+    room = make_room(rng, args.room_scale)
+
+    n_obstacles = args.obstacles or int(rng.integers(3, 6))
+    n_exits = args.exits or int(rng.integers(2, 5))
+    n_stages = args.stages or int(rng.integers(2, 5))
+
+    obstacles = place_obstacles(rng, room, n_obstacles)
+    exits = place_exits(rng, room, n_exits)
+
+    placed = obstacles + exits
+    checkpoints: list[Polygon] = []
+    for _ in range(n_stages):
+        circle = sample_clear_shape(
+            rng,
+            room,
+            placed,
+            lambda cx, cy: Point(cx, cy).buffer(CHECKPOINT_RADIUS, quad_segs=8),
+        )
+        if circle is None:
+            break
+        checkpoints.append(circle)
+        placed.append(circle)
+
+    spawn = place_spawn(rng, room, placed, exits, obstacles, args.hide_exits)
+
+    walkable = Polygon(room.exterior.coords, [o.exterior.coords for o in obstacles])
+    if not walkable.is_valid:
+        raise RuntimeError("generated geometry is invalid; try another seed")
+
+    config = build_config(
+        rng,
+        seed,
+        args.agents,
+        exits,
+        spawn,
+        checkpoints,
+        len(obstacles),
+        random_sign_alpha=args.random_sign_alpha,
+    )
+    return walkable, config
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--seed", type=int, default=None, help="RNG seed (random if omitted)"
+    )
+    parser.add_argument(
+        "--out", type=Path, default=Path("worlds"), help="output directory"
+    )
+    parser.add_argument(
+        "--agents", type=int, default=10, help="agents in the spawn area"
+    )
+    parser.add_argument(
+        "--obstacles", type=int, default=None, help="fix obstacle count (3-5 random)"
+    )
+    parser.add_argument(
+        "--exits", type=int, default=None, help="fix exit count (2-4 random)"
+    )
+    parser.add_argument(
+        "--stages", type=int, default=None, help="fix stage count (2-4 random)"
+    )
+    parser.add_argument(
+        "--room-scale",
+        type=float,
+        default=1.0,
+        help="multiply the room half-extents (use >1 to fit many obstacles/stages)",
+    )
+    parser.add_argument(
+        "--hide-exits",
+        action="store_true",
+        help="require obstacles to block every sightline from the spawn to the exits",
+    )
+    parser.add_argument(
+        "--random-sign-alpha",
+        action="store_true",
+        help="orient checkpoint signs randomly instead of toward the interior "
+        "(random orientations can leave a world unsolvable for discovery agents)",
+    )
+    args = parser.parse_args()
+
+    seed = args.seed if args.seed is not None else int.from_bytes(os.urandom(4), "big")
+    walkable, config = generate_world(seed, args)
+
+    world_dir = args.out / f"world_{seed}"
+    world_dir.mkdir(parents=True, exist_ok=True)
+    (world_dir / "geometry.wkt").write_text(walkable.wkt)
+    (world_dir / "config.json").write_text(json.dumps(config, indent=2))
+
+    zip_path = args.out / f"world_{seed}.zip"
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        zf.write(world_dir / "geometry.wkt", "geometry.wkt")
+        zf.write(world_dir / "config.json", "config.json")
+
+    print(f"seed        {seed}")
+    print(f"obstacles   {len(walkable.interiors)}")
+    print(f"exits       {len(config['exits'])}")
+    print(f"stages      {len(config['checkpoints'])}")
+    print(f"wrote       {zip_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generated_worlds.py
+++ b/tests/test_generated_worlds.py
@@ -155,9 +155,21 @@ class TestDiscoveryInvariants:
             prev[event["agent_id"]] = set(event["known_nodes"])
             if event["time_s"] == 0.0:
                 continue  # spawn draw: seeded before the agent moved
-            pos = positions.get((event["agent_id"], round(event["time_s"] * fps)))
-            if pos is None:
-                continue
+            frame = round(event["time_s"] * fps)
+            pos = next(
+                (
+                    positions.get((event["agent_id"], f))
+                    for f in (frame, frame - 1, frame + 1)
+                    if (event["agent_id"], f) in positions
+                ),
+                None,
+            )
+            # A silent skip here would mask exactly the bug this test exists
+            # to catch, so a missing position is itself a failure.
+            assert pos is not None, (
+                f"no trajectory row near t={event['time_s']} for agent "
+                f"{event['agent_id']}; the evidence check cannot be skipped"
+            )
             ax, ay = pos
             for node_id in new:
                 cx, cy = centroids[node_id]

--- a/tests/test_generated_worlds.py
+++ b/tests/test_generated_worlds.py
@@ -1,0 +1,186 @@
+"""Cognitive-map invariants on randomly generated worlds.
+
+``scripts/generate_discovery_world.py`` produces discoverability-test decks
+(open room, convex obstacles, signed checkpoints, exits hidden from the
+spawn). The hand-built assets each pin one behaviour; these decks exercise
+the whole discovery pipeline on geometry nobody curated, and the assertions
+are invariants that must hold on *every* world:
+
+* a cognitive map only ever grows;
+* a node enters the map only through evidence -- the sign was legible from
+  where the agent stood, or the agent physically arrived next to it;
+* a ``full``-familiarity agent knows the complete graph from the start and
+  never learns.
+
+Coupled JuPedSim runs are not bit-reproducible under a fixed seed, so exact
+trajectories and timelines are deliberately not asserted -- see
+docs/testing-familiarity.md.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import math
+import sqlite3
+from pathlib import Path
+
+import pytest
+from shapely import wkt as shapely_wkt
+
+from pyfds_evac.core import load_scenario, run_scenario
+from pyfds_evac.core.route_graph import RerouteConfig, RouteCostConfig
+from pyfds_evac.core.visibility import VisibilityModel, extract_sign_descriptors
+
+# Keeps a pathological stall from dragging the suite; the small worlds below
+# evacuate far earlier, and every invariant holds on a truncated run too.
+MAX_SIM_TIME_S = 120
+# Nodes this close to the agent count as physical arrival, where the reveal
+# is unconditional by design (spawn draw at t=0 likewise).
+ARRIVAL_RADIUS_M = 1.2
+
+
+def _generator():
+    spec = importlib.util.spec_from_file_location(
+        "gdw", Path("scripts/generate_discovery_world.py")
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_deck(tmp_path: Path, seed: int, hide_exits: bool) -> Path:
+    gdw = _generator()
+    args = argparse.Namespace(
+        agents=1,
+        obstacles=None,
+        exits=2,
+        stages=3,
+        room_scale=1.0,
+        hide_exits=hide_exits,
+        random_sign_alpha=False,
+    )
+    walkable, config = gdw.generate_world(seed, args)
+    config["config"]["simulation_settings"]["simulationParams"][
+        "max_simulation_time"
+    ] = MAX_SIM_TIME_S
+    deck = tmp_path / f"world_{seed}"
+    deck.mkdir()
+    (deck / "geometry.wkt").write_text(walkable.wkt)
+    (deck / "config.json").write_text(json.dumps(config))
+    return deck
+
+
+def _run(deck: Path, familiarity: float):
+    cfg = json.loads((deck / "config.json").read_text())
+    for dist in cfg["distributions"].values():
+        dist["parameters"]["familiarity"] = familiarity
+    (deck / "config.json").write_text(json.dumps(cfg))
+
+    scenario = load_scenario(str(deck))
+    walkable = shapely_wkt.loads((deck / "geometry.wkt").read_text().strip())
+    vis = VisibilityModel.clear_air(walkable, extract_sign_descriptors(scenario.raw))
+    result = run_scenario(
+        scenario,
+        seed=1234,
+        reroute_config=RerouteConfig(
+            reevaluation_interval_s=1.0, cost_config=RouteCostConfig()
+        ),
+        vis_model=vis,
+        collect_cognitive_map_history=True,
+    )
+    history = list(result.cognitive_map_history or [])
+    positions: dict[tuple[int, int], tuple[float, float]] = {}
+    with sqlite3.connect(result.sqlite_file) as con:
+        fps = float(
+            con.execute("SELECT value FROM metadata WHERE key='fps'").fetchone()[0]
+        )
+        for aid, frame, x, y in con.execute(
+            "SELECT id, frame, pos_x, pos_y FROM trajectory_data"
+        ):
+            positions[(int(aid), int(frame))] = (x, y)
+    result.cleanup()
+    centroids = _node_centroids(cfg)
+    return cfg, vis, history, positions, fps, centroids
+
+
+def _node_centroids(cfg: dict) -> dict[str, tuple[float, float]]:
+    from shapely.geometry import Polygon
+
+    out = {}
+    for section in ("exits", "checkpoints", "distributions"):
+        for node_id, data in (cfg.get(section) or {}).items():
+            c = Polygon(data["coordinates"]).centroid
+            out[node_id] = (c.x, c.y)
+    return out
+
+
+SEEDS = [(7, True), (11, False)]
+
+
+@pytest.mark.parametrize("seed,hide_exits", SEEDS)
+class TestDiscoveryInvariants:
+    @pytest.fixture()
+    def run(self, tmp_path, seed, hide_exits):
+        deck = _make_deck(tmp_path, seed, hide_exits)
+        return _run(deck, familiarity=0.0)
+
+    def test_the_map_only_ever_grows(self, run):
+        _, _, history, _, _, _ = run
+        assert history, "a discovery run must record at least the spawn map"
+        per_agent: dict[int, tuple[set, set]] = {}
+        for event in history:
+            nodes = set(event["known_nodes"])
+            edges = set(event["known_edges"])
+            prev = per_agent.get(event["agent_id"])
+            if prev is not None:
+                assert prev[0] <= nodes, "known nodes shrank"
+                assert prev[1] <= edges, "known edges shrank"
+            per_agent[event["agent_id"]] = (nodes, edges)
+
+    def test_every_learned_node_has_evidence(self, run):
+        """Sign legible from the agent's position, or physical arrival.
+
+        This is the through-wall audit from PR #96 as a permanent test: a
+        node appearing in the map with neither justification is exactly the
+        leak that let one hallway arrival reveal rooms the agent had never
+        seen.
+        """
+        _, vis, history, positions, fps, centroids = run
+        prev: dict[int, set] = {}
+        for event in history:
+            new = set(event["known_nodes"]) - prev.get(event["agent_id"], set())
+            prev[event["agent_id"]] = set(event["known_nodes"])
+            if event["time_s"] == 0.0:
+                continue  # spawn draw: seeded before the agent moved
+            pos = positions.get((event["agent_id"], round(event["time_s"] * fps)))
+            if pos is None:
+                continue
+            ax, ay = pos
+            for node_id in new:
+                cx, cy = centroids[node_id]
+                if math.hypot(cx - ax, cy - ay) <= ARRIVAL_RADIUS_M:
+                    continue
+                assert vis.node_is_visible(event["time_s"], ax, ay, node_id), (
+                    f"{node_id} learned at t={event['time_s']} without "
+                    f"line-of-sight evidence from ({ax:.1f},{ay:.1f})"
+                )
+
+
+@pytest.mark.parametrize("seed,hide_exits", SEEDS)
+def test_a_full_agent_knows_everything_and_never_learns(tmp_path, seed, hide_exits):
+    deck = _make_deck(tmp_path, seed, hide_exits)
+    _, _, history, _, _, centroids = _run(deck, familiarity=1.0)
+    events_per_agent: dict[int, int] = {}
+    for event in history:
+        events_per_agent[event["agent_id"]] = (
+            events_per_agent.get(event["agent_id"], 0) + 1
+        )
+        assert set(event["known_nodes"]) == set(centroids), (
+            "a full-familiarity map must hold every node"
+        )
+    assert all(count == 1 for count in events_per_agent.values()), (
+        "a full map never changes, so at most its initial recording exists"
+    )


### PR DESCRIPTION
Brings `generate_discovery_world.py` into the repo (it authored the CrowdRL test worlds used to find the three PR #96 bugs) and adds `tests/test_generated_worlds.py`: the discovery pipeline runs on seeded generated decks and must satisfy world-independent invariants — monotone map growth, evidence for every learned node (sign legible from the agent's position or physical arrival), and complete/immutable maps for full-familiarity agents.

Also adds `docs/superpowers/specs/2026-08-10-cognitive-map-test-strategy-design.md`: the risk map and prioritized gap list for full confidence ahead of the September talk (wander-through-exit hop, frontier watchdog, full≡shortest-path equivalence, multi-agent isolation, init-site parity, scalar familiarity statistics, smoke-coupled discovery).

540 tests pass (6 new), ruff clean.