### PR TITLE
fix(core): place a stage's node inside its own polygon, not at its centroid

### DIFF
--- a/pyfds_evac/core/geometry.py
+++ b/pyfds_evac/core/geometry.py
@@ -1,0 +1,51 @@
+"""Geometry helpers shared by the routing and visibility layers."""
+
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def node_position(polygon) -> tuple[float, float]:
+    """The point that stands for a stage, guaranteed to lie inside it.
+
+    Stages are polygons but every layer needs a single point for them: the
+    route graph measures edge lengths between these points, and the
+    visibility layer puts a node's default sign at one.  The obvious choice,
+    the area centroid, is wrong for a non-convex polygon -- an L, a C, or a
+    room wrapping around an obstruction -- where the area-weighted average
+    lands in the concavity, off the shape entirely.
+
+    A point that is not on the walkable floor breaks both callers:
+
+    * routing asks the navmesh for a path from it, the navmesh rejects it as
+      inaccessible, and the edge falls back to a straight ray whose length
+      ignores every wall in between (four Station spawn areas hit this, and
+      their route costs were straight-line distances);
+    * visibility puts the node's sign inside a wall, where no agent can ever
+      read it, so a discovery agent never learns that node exists.
+
+    Both layers must also agree, or a node is routed to one point and seen
+    from another.  Hence one helper, used by both.
+
+    The centroid is kept whenever it is already interior, so node positions
+    are unchanged for every well-behaved polygon and no calibration resting
+    on them shifts silently.  ``representative_point`` is used only where the
+    centroid is unusable: it is always interior, though not always central.
+    """
+    centroid = polygon.centroid
+    try:
+        if polygon.contains(centroid):
+            return float(centroid.x), float(centroid.y)
+        interior = polygon.representative_point()
+    except Exception as exc:
+        # A self-intersecting or degenerate polygon can refuse both queries.
+        # The centroid is then no worse than aborting, and the stage setup
+        # skips unusable polygons anyway.
+        _logger.warning("Cannot place a node inside %s: %s", polygon.geom_type, exc)
+        return float(centroid.x), float(centroid.y)
+    _logger.debug(
+        "Centroid of a %s lies outside it; using an interior point", polygon.geom_type
+    )
+    return float(interior.x), float(interior.y)

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -20,7 +20,14 @@ _SECONDS_PER_MINUTE = 60.0
 
 @dataclass(frozen=True)
 class StageNode:
-    """A node in the stage graph representing one stage."""
+    """A node in the stage graph representing one stage.
+
+    The ``centroid_*`` fields hold :func:`~pyfds_evac.core.geometry.node_position`,
+    which is the polygon's centroid for every convex stage but an interior
+    point for a concave one, whose centroid falls outside itself.  The names
+    predate that distinction and are kept because they are load-bearing across
+    the routing layer.
+    """
 
     stage_id: str
     centroid_x: float

--- a/pyfds_evac/core/route_graph.py
+++ b/pyfds_evac/core/route_graph.py
@@ -10,6 +10,7 @@ from typing import Protocol
 
 from shapely.geometry import Polygon
 
+from .geometry import node_position as _node_position
 from .smoke_speed import speed_factor_from_extinction
 
 _logger = logging.getLogger(__name__)
@@ -98,7 +99,7 @@ class StageGraph:
                     polygon = Polygon(coords)
                 if polygon is None:
                     continue
-                cx, cy = polygon.centroid.x, polygon.centroid.y
+                cx, cy = _node_position(polygon)
                 graph.nodes[dist_id] = StageNode(
                     stage_id=dist_id,
                     centroid_x=cx,
@@ -111,7 +112,7 @@ class StageGraph:
             polygon = info.get("polygon")
             if polygon is None:
                 continue
-            cx, cy = polygon.centroid.x, polygon.centroid.y
+            cx, cy = _node_position(polygon)
             stage_type = info.get("stage_type", "checkpoint")
             graph.nodes[stage_id] = StageNode(
                 stage_id=stage_id,

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -10,6 +10,8 @@ from typing import Protocol
 import numpy as np
 from shapely.geometry import Polygon
 
+from .geometry import node_position
+
 
 class _VisBackend(Protocol):
     """What VisibilityModel needs from its backend.
@@ -39,14 +41,19 @@ def _default_sign(entry: dict) -> dict | None:
     if not coords or len(coords) < 3:
         return None
     # Configs with unusable polygons simulate fine -- the stage setup skips
-    # them -- so a node that cannot yield a centroid gets no sign rather than
+    # them -- so a node that cannot yield a position gets no sign rather than
     # aborting the run the moment visibility is switched on.
+    #
+    # node_position, not the raw centroid: on a non-convex stage the centroid
+    # falls outside the polygon, which would bury this sign in a wall where no
+    # agent can read it. It is also the point the route graph routes to, and
+    # the two must agree or a node is seen from somewhere it is never routed.
     try:
-        centroid = Polygon(coords).centroid
+        x, y = node_position(Polygon(coords))
     except Exception as exc:
         _logger.warning("Cannot synthesise a sign from %r: %s", coords, exc)
         return None
-    return {"x": float(centroid.x), "y": float(centroid.y), "alpha": None, "c": 3}
+    return {"x": x, "y": y, "alpha": None, "c": 3}
 
 
 def extract_sign_descriptors(raw_config: dict) -> dict[str, dict]:

--- a/tests/test_generated_worlds.py
+++ b/tests/test_generated_worlds.py
@@ -20,6 +20,7 @@ docs/testing-familiarity.md.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import importlib.util
 import json
 import math
@@ -93,7 +94,11 @@ def _run(deck: Path, familiarity: float):
     )
     history = list(result.cognitive_map_history or [])
     positions: dict[tuple[int, int], tuple[float, float]] = {}
-    with sqlite3.connect(result.sqlite_file) as con:
+    # closing(), not `with sqlite3.connect(...)`: the connection's context
+    # manager only ends the transaction, it does not close the connection, so
+    # the file stays open and result.cleanup() below cannot delete it on
+    # Windows, where an open file may not be unlinked.
+    with contextlib.closing(sqlite3.connect(result.sqlite_file)) as con:
         fps = float(
             con.execute("SELECT value FROM metadata WHERE key='fps'").fetchone()[0]
         )

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -3,7 +3,7 @@
 import logging
 
 import pytest
-from shapely.geometry import Polygon
+from shapely.geometry import Point, Polygon
 
 from pyfds_evac.core.route_graph import (
     AgentRouteState,
@@ -2738,3 +2738,64 @@ class TestWanderCanGoHome:
         target, path = wander
         assert target == "D0"
         assert path == ["C1", "D0"]
+
+
+class TestNodePositionIsAlwaysWalkable:
+    """A stage's graph position must lie inside the stage's own polygon.
+
+    The area centroid of a non-convex polygon can land in a concavity the
+    shape wraps around, outside the polygon itself.  Such a point is not on
+    the walkable floor, so the routing engine rejects it and `_make_edge`
+    falls back to a straight centroid ray -- an edge cost that ignores every
+    wall between the two stages.  Four Station spawn areas hit exactly this
+    and had straight-line route costs as a result.
+    """
+
+    @staticmethod
+    def _c_shape() -> Polygon:
+        """A C, whose centroid sits in the mouth rather than in the shape."""
+        return Polygon(
+            [
+                (0, 0),
+                (10, 0),
+                (10, 3),
+                (3, 3),
+                (3, 7),
+                (10, 7),
+                (10, 10),
+                (0, 10),
+            ]
+        )
+
+    def test_a_concave_stage_gets_an_interior_position(self):
+        from pyfds_evac.core.geometry import node_position as _node_position
+
+        polygon = self._c_shape()
+        assert not polygon.contains(polygon.centroid), "fixture is not concave enough"
+
+        x, y = _node_position(polygon)
+        assert polygon.contains(Point(x, y))
+
+    def test_a_well_behaved_stage_keeps_its_centroid(self):
+        """Convex polygons must be untouched, or every deck's node positions
+        move and any calibration resting on them silently shifts.
+        """
+        from pyfds_evac.core.geometry import node_position as _node_position
+
+        polygon = Polygon([(0, 0), (4, 0), (4, 2), (0, 2)])
+        assert _node_position(polygon) == (polygon.centroid.x, polygon.centroid.y)
+
+    def test_the_graph_places_a_concave_spawn_inside_itself(self):
+        polygon = self._c_shape()
+        graph = StageGraph.from_scenario(
+            {
+                "EX": {
+                    "polygon": Polygon([(20, 20), (21, 20), (21, 21), (20, 21)]),
+                    "stage_type": "exit",
+                }
+            },
+            [{"from": "D0", "to": "EX"}],
+            distributions={"D0": {"polygon": polygon}},
+        )
+        node = graph.nodes["D0"]
+        assert polygon.contains(Point(node.centroid_x, node.centroid_y))


### PR DESCRIPTION
## TLDR

Rooms are drawn as shapes, but the code needs one point per shape. It used
the centre. For an L or C shaped room the centre isn't inside the room,
it's in the empty gap, so the point landed in a wall.

That broke two things:

- **Route distances.** The pathfinder rejects a point that isn't floor, so
  the code quietly fell back to straight-line distance, which goes through
  walls. Agents compared exits using distances that were too short.
- **Exit signs.** Signs get placed at that same point. A sign inside a wall
  can't be seen, so an exploring agent never learns that exit exists. No
  shipped deck hits this yet, but it would be silent when one did.

On `assets/station_fahy`, four spawn areas share a concave platform shape
and hit this: 40 warnings per run, and 29 agents choosing exits on
straight-line costs.

## The fix

`node_position`, in a new `pyfds_evac/core/geometry.py`, used by both
systems so they can't disagree on where a place is.

It keeps the centre whenever the centre is already inside the shape, so
nothing moves for normal rooms and no calibration shifts by accident.
Picking the *best* interior point is #104.

## Verification

| Check | Result |
| --- | --- |
| station_fahy warnings | 40 -> 0 |
| Node positions outside the walkable area | 0 |
| Agents reaching a door (seed 1) | 330 -> 331 |
| Full test suite | 543 passed, 0 failed (was 536 passed, 3 failed, 4 errors) |
| ruff | clean |

## Heads up: the Fahy number moves

| | front-door share | reached a door | never reached |
| --- | --- | --- | --- |
| before | 52.4% | 330 | 3 |
| after | 52.0% | 331 | 2 |
| Fahy | 52.9% | | |

0.4 points further from the real number (seed 1), in the expected
direction: those agents had been using distances that were too short.
But matching Fahy is the whole point of this deck, so whoever owns the
`w_queue = 0.03` calibration should sign off rather than have it drift
inside a bug fix.

Also: `build_scenario.py` claims the deck "reproduces Fahy's 52.9 %
front-door share", but seed 1 gives 52.4 % even before this change. That
number is seed-dependent and the comment doesn't say so.

## Also fixed: 6 tests that only failed on Windows

`test_generated_worlds.py` opened the trajectory database, never closed
it, then tried to delete the file. Windows won't delete an open file;
Linux will. Now uses `contextlib.closing`.