### PR TITLE
fix(core): place a concave stage's node at its most open interior point

### DIFF
--- a/pyfds_evac/core/geometry.py
+++ b/pyfds_evac/core/geometry.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from shapely.ops import polylabel
+
 _logger = logging.getLogger(__name__)
 
 
@@ -31,14 +33,21 @@ def node_position(polygon) -> tuple[float, float]:
 
     The centroid is kept whenever it is already interior, so node positions
     are unchanged for every well-behaved polygon and no calibration resting
-    on them shifts silently.  ``representative_point`` is used only where the
-    centroid is unusable: it is always interior, though not always central.
+    on them shifts silently.  Where the centroid is unusable, ``polylabel``
+    (the pole of inaccessibility) picks the interior point furthest from any
+    edge: a sign there is occluded from the least of the stage, whereas a
+    merely-interior point can sit against a wall.
     """
     centroid = polygon.centroid
     try:
         if polygon.contains(centroid):
             return float(centroid.x), float(centroid.y)
-        interior = polygon.representative_point()
+        interior = polylabel(polygon, tolerance=0.01)
+        # polylabel has returned exterior points on some inputs (shapely
+        # #1383); interiority is the guarantee here, centrality only the
+        # preference, so fall back rather than trust it blindly.
+        if not polygon.contains(interior):
+            interior = polygon.representative_point()
     except Exception as exc:
         # A self-intersecting or degenerate polygon can refuse both queries.
         # The centroid is then no worse than aborting, and the stage setup

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2796,6 +2796,33 @@ class TestNodePositionIsAlwaysWalkable:
         x, y = _node_position(polygon)
         assert polygon.contains(Point(x, y))
 
+    def test_the_fallback_point_maximises_boundary_clearance(self):
+        """Where the centroid is unusable the node must sit at the polygon's
+        most open interior point, not merely any interior one: a sign near a
+        wall is occluded from more of the room than one out in the open (#104).
+        """
+        from shapely.ops import polylabel
+
+        from pyfds_evac.core.geometry import node_position as _node_position
+
+        polygon = self._c_shape()
+        x, y = _node_position(polygon)
+        best = polylabel(polygon, tolerance=0.01)
+        clearance = polygon.exterior.distance(Point(x, y))
+        assert clearance >= polygon.exterior.distance(best) - 0.05
+
+    def test_an_exterior_polylabel_result_is_not_trusted(self, monkeypatch):
+        """polylabel has returned exterior points on some inputs (shapely
+        #1383).  Interiority is node_position's guarantee, so a bad polylabel
+        answer must be replaced, not passed through.
+        """
+        from pyfds_evac.core import geometry
+
+        polygon = self._c_shape()
+        monkeypatch.setattr(geometry, "polylabel", lambda p, tolerance: Point(-5, -5))
+        x, y = geometry.node_position(polygon)
+        assert polygon.contains(Point(x, y))
+
     def test_a_well_behaved_stage_keeps_its_centroid(self):
         """Convex polygons must be untouched, or every deck's node positions
         move and any calibration resting on them silently shifts.

--- a/tests/test_route_graph.py
+++ b/tests/test_route_graph.py
@@ -2806,10 +2806,12 @@ class TestNodePositionIsAlwaysWalkable:
         from pyfds_evac.core.geometry import node_position as _node_position
 
         polygon = self._c_shape()
+        assert not polygon.contains(polygon.centroid), "fixture is not concave enough"
+
         x, y = _node_position(polygon)
         best = polylabel(polygon, tolerance=0.01)
-        clearance = polygon.exterior.distance(Point(x, y))
-        assert clearance >= polygon.exterior.distance(best) - 0.05
+        clearance = polygon.boundary.distance(Point(x, y))
+        assert clearance >= polygon.boundary.distance(best) - 0.05
 
     def test_an_exterior_polylabel_result_is_not_trusted(self, monkeypatch):
         """polylabel has returned exterior points on some inputs (shapely
@@ -2819,6 +2821,8 @@ class TestNodePositionIsAlwaysWalkable:
         from pyfds_evac.core import geometry
 
         polygon = self._c_shape()
+        assert not polygon.contains(polygon.centroid), "fixture is not concave enough"
+
         monkeypatch.setattr(geometry, "polylabel", lambda p, tolerance: Point(-5, -5))
         x, y = geometry.node_position(polygon)
         assert polygon.contains(Point(x, y))


### PR DESCRIPTION
## Summary

Where a stage polygon's centroid is exterior, `node_position` now falls back to `shapely.ops.polylabel` (the pole of inaccessibility) instead of `representative_point()`, so the node — and any default sign synthesised there — sits as far from the walls as possible instead of merely somewhere interior. Sign and routing positions stay shared: divergence was considered (see #104) and rejected, since a node seen from a point it is never routed to is its own hazard.

A containment guard keeps interiority the hard guarantee: polylabel has returned exterior points on some inputs (shapely/shapely#1383), and in that case the fallback reverts to `representative_point()`. Centroid-interior polygons are untouched, so no well-behaved deck moves and no calibration shifts silently.

## Measured effect

A scan of every deck's stage polygons found exactly one exterior-centroid case: the concave polygon shared by station_fahy's four spawn distributions.

- Node moves (-2.28, -4.52) → (-2.88, -6.51); wall clearance 0.89 m → 1.49 m.
- 20 edge weights change; the direct spawn → `jps-checkpoints_5` edge is now pruned by the neighbour rule (the path from the deeper point passes another checkpoint), which still reaches it — nothing is stranded.
- Fahy Table 2 validation over seeds 420–422: front-door share 52.6/53.5/52.3 % before vs 53.8/53.8/53.2 % after (Fahy: 52.9 % of door users, ≥53 % criterion); same 331/333 agents reaching a door; same largest per-row deviation (the known Rear-bar row).

No other deck has a concave stage, and no current deck relies on a synthesised sign in a concave polygon, so nothing else moves.

## Tests

- New: fallback point maximises boundary clearance on a C-shaped polygon (red first, green after).
- New: an exterior polylabel result is replaced, not passed through (monkeypatched regression test for the shapely/shapely#1383 guard).
- Full suite: 561 passed; ruff check and format clean.

Closes #104