### PR TITLE
feat(webapp): results-only runs, and upload your own scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,9 @@ celerybeat.pid
 # Web GUI default output directory (scenario run artifacts)
 /results/
 
+# Web GUI scenario uploads (user-supplied config.json + geometry.wkt)
+/uploads/
+
 # Environments
 .env
 .venv

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -8,7 +8,11 @@ streaming and JS helpers are unchanged from the original.
 from __future__ import annotations
 
 import asyncio
+import io
 import json
+import re
+import shutil
+import zipfile
 from pathlib import Path
 from urllib.parse import quote
 
@@ -297,12 +301,14 @@ _AUTOFILL_JS = """
     output_smoke_history:      function (n, d) { return d + '/' + n + '_smoke_history.csv'; },
     output_fed_history:        function (n, d) { return d + '/' + n + '_fed_history.csv'; },
     output_route_history:      function (n, d) { return d + '/' + n + '_route_history.csv'; },
-    output_route_cost_history: function (n, d) { return d + '/' + n + '_route_cost_history.csv'; }
+    output_route_cost_history: function (n, d) { return d + '/' + n + '_route_cost_history.csv'; },
+    export_app_bundle:         function (n, d) { return d + '/bundle'; }
   };
   function scenarioName() {
-    var inp = document.querySelector('input[name="scenario"]');
-    var sel = document.querySelector('#scenario select');
-    return (inp && inp.value) || (sel && sel.value) || '';
+    // The picker is a <select id="scenario">, not a wrapper around one, so
+    // match on the form name -- that holds however it ends up being rendered.
+    var el = document.querySelector('[name="scenario"]');
+    return (el && el.value) || '';
   }
   function fdsDirValue() {
     var el = document.getElementById('fds_dir');
@@ -317,12 +323,28 @@ _AUTOFILL_JS = """
     return (el && el.value) || 'probabilistic';
   }
   function clean(n) { return n.replace(/\\.json$/i, '').replace(/\\//g, '_'); }
+  // The typed "Output folder", normalised. Empty means "use the derived path".
+  function outputBase() {
+    var el = document.getElementById('output_base');
+    if (!el) return '';
+    return el.value.trim().replace(/\\\\/g, '/').replace(/\\/+$/, '');
+  }
   function fill(n) {
     var base = n ? clean(n) : '';
-    var dir = base ? 'results/' + base + '/' + modeValue() + '/seed' + seedValue() : '';
+    var derived = base ? 'results/' + base + '/' + modeValue() + '/seed' + seedValue() : '';
+    // Show the derived folder as a placeholder rather than a value, so an empty
+    // box still tells you where output lands while a typed path clearly wins.
+    var ob = document.getElementById('output_base');
+    if (ob) ob.placeholder = derived || 'results/<scenario>';
+    var dir = outputBase() || derived;
     Object.keys(OUT).forEach(function (id) {
       var el = document.getElementById(id);
       if (el && !el.dataset.userEdited) el.value = base ? OUT[id](base, dir) : '';
+    });
+    // Preview lines under the folder box, so the section shows the real
+    // filenames instead of a literal "<run>".
+    document.querySelectorAll('.artifact-preview').forEach(function (el) {
+      el.textContent = (base || '<run>') + el.dataset.suffix;
     });
   }
   var last = null;
@@ -333,7 +355,7 @@ _AUTOFILL_JS = """
     if (el && !el.dataset.userEdited) el.value = fdsDir ? fdsDir + '/vis_cache.npz' : '';
   }
   setInterval(function () {
-    var k = scenarioName() + '|' + seedValue() + '|' + modeValue();
+    var k = scenarioName() + '|' + seedValue() + '|' + modeValue() + '|' + outputBase();
     if (k !== last) { last = k; fill(scenarioName()); }
     var fdsDir = fdsDirValue();
     if (fdsDir !== lastFdsDir) { lastFdsDir = fdsDir; fillVisCache(); }
@@ -386,14 +408,21 @@ document.addEventListener('click', function (e) {
 # the active run.
 _RUN_BTN_JS = """
 (function () {
-  function runBtn() { return document.getElementById('run-btn'); }
+  // Both submit buttons post to /run; either one starting a run must lock out
+  // the other, so they are relabelled together.
+  var LABELS = {
+    'run-btn':     { idle: 'Run scenario', icon: '▶' },
+    'results-btn': { idle: 'Results only', icon: '↓' }
+  };
   function setRunning(on) {
-    var b = runBtn(); if (!b) return;
-    b.disabled = on;
-    var lbl = b.querySelector('.run-btn-label');
-    var ico = b.querySelector('.run-btn-icon');
-    if (lbl) lbl.textContent = on ? 'Scenario in progress…' : 'Run scenario';
-    if (ico) ico.textContent = on ? '⏳' : '▶';
+    Object.keys(LABELS).forEach(function (id) {
+      var b = document.getElementById(id); if (!b) return;
+      b.disabled = on;
+      var lbl = b.querySelector('.run-btn-label');
+      var ico = b.querySelector('.run-btn-icon');
+      if (lbl) lbl.textContent = on ? 'Scenario in progress…' : LABELS[id].idle;
+      if (ico) ico.textContent = on ? '⏳' : LABELS[id].icon;
+    });
   }
   function isRunPath(d) {
     var p = (d && d.pathInfo && (d.pathInfo.requestPath || d.pathInfo.path)) ||
@@ -556,6 +585,56 @@ document.addEventListener('DOMContentLoaded', window._renderMath);
 """
 
 
+# Drag-and-drop onto the upload zone. A file <input> can only be populated from
+# a DataTransfer, so the drop handler assigns dataTransfer.files directly rather
+# than trying to read the files itself.
+_UPLOAD_JS = """
+(function () {
+  function zone() { return document.getElementById('upload-drop'); }
+  function input() { var z = zone(); return z && z.querySelector('input[type=file]'); }
+  function names(list) {
+    return Array.prototype.map.call(list, function (f) { return f.name; }).join(', ');
+  }
+  function show() {
+    var i = input(), out = document.getElementById('upload-picked');
+    if (!i || !out) return;
+    out.textContent = i.files && i.files.length ? names(i.files) : '';
+  }
+  document.addEventListener('change', function (e) {
+    if (e.target && e.target.matches('#upload-drop input[type=file]')) show();
+  });
+  ['dragenter', 'dragover'].forEach(function (ev) {
+    document.addEventListener(ev, function (e) {
+      var z = zone(); if (!z || !z.contains(e.target)) return;
+      e.preventDefault(); z.classList.add('over');
+    });
+  });
+  ['dragleave', 'drop'].forEach(function (ev) {
+    document.addEventListener(ev, function (e) {
+      var z = zone(); if (!z || !z.contains(e.target)) return;
+      z.classList.remove('over');
+    });
+  });
+  document.addEventListener('drop', function (e) {
+    var z = zone(), i = input();
+    if (!z || !i || !z.contains(e.target)) return;
+    e.preventDefault();
+    if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length) {
+      i.files = e.dataTransfer.files;
+      show();
+    }
+  });
+  // A successful upload swaps in a new picker; clear the staged files so the
+  // same drop can't be submitted twice by accident.
+  document.body.addEventListener('htmx:afterSwap', function (e) {
+    if (e.target && e.target.id === 'scenario-block') {
+      var i = input(); if (i) { i.value = ''; show(); }
+    }
+  });
+})();
+"""
+
+
 @rt("/")
 def index():
     grid = Div(
@@ -577,6 +656,7 @@ def index():
         Script(_MATH_JS),
         Script(_TENABILITY_JS),
         Script(_RUN_BTN_JS),
+        Script(_UPLOAD_JS),
     )
 
 
@@ -695,6 +775,143 @@ def browse_dir(path: str = "", mode: str = "dir", field: str = "fds_dir"):
     )
 
 
+# ── scenario upload ───────────────────────────────────────────────────────────
+_UPLOAD_MAX_BYTES = 25 * 1024 * 1024
+_UPLOAD_SUFFIXES = {".json", ".wkt"}
+
+
+def _slugify(raw: str) -> str:
+    """Filesystem-safe directory name. Never trust a client-supplied path."""
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", (raw or "").strip()).strip("-._")
+    return cleaned[:64] or "scenario"
+
+
+def _unique_dir(root: Path, slug: str) -> Path:
+    candidate = root / slug
+    n = 2
+    while candidate.exists():
+        candidate = root / f"{slug}-{n}"
+        n += 1
+    return candidate
+
+
+def _extract_zip(blob: bytes, dest: Path) -> list[str]:
+    """Extract the .json/.wkt members of a zip flat into *dest*.
+
+    zipfile does not sanitise member names, so an archive can carry '../' or an
+    absolute path and write outside the target ("zip slip"). Such members are
+    rejected outright; ordinary nested ones ("t_junction/config.json", the
+    shape you get zipping a scenario folder) keep just their basename.
+    """
+    written: list[str] = []
+    with zipfile.ZipFile(io.BytesIO(blob)) as zf:
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            raw = info.filename.replace("\\", "/")
+            parts = [p for p in raw.split("/") if p not in ("", ".")]
+            # Drop traversal and absolute members outright rather than
+            # flattening them to a basename: a '../' entry is malformed at
+            # best, and flattening would quietly add a stray .json that the
+            # picker would then offer as an alternate config.
+            if not parts or ".." in parts or raw.startswith("/") or ":" in parts[0]:
+                continue
+            # A zip of a folder ("t_junction/config.json") is the normal case,
+            # so a nested member keeps its basename.
+            name = parts[-1]
+            if Path(name).suffix.lower() not in _UPLOAD_SUFFIXES:
+                continue
+            target = (dest / name).resolve()
+            if dest.resolve() not in target.parents:  # defence in depth
+                continue
+            if info.file_size > _UPLOAD_MAX_BYTES:
+                raise ValueError(f"{name} is too large.")
+            target.write_bytes(zf.read(info))
+            written.append(name)
+    return written
+
+
+def _upload_error(message: str, selected: str | None = None):
+    return params.scenario_block(
+        selected,
+        note=Div(
+            message,
+            style=(
+                f"{_MONO};font-size:10.5px;color:#E01E37;margin-top:6px;line-height:1.5"
+            ),
+        ),
+    )
+
+
+@rt("/upload-scenario")
+async def upload_scenario(request: Request):
+    form = await request.form()
+    current = str(form.get("scenario") or "") or None
+    uploads = [f for f in form.getlist("files") if getattr(f, "filename", "")]
+    if not uploads:
+        return _upload_error(
+            "Pick a config JSON + geometry WKT, or a .zip bundle.", current
+        )
+
+    blobs: list[tuple[str, bytes]] = []
+    total = 0
+    for item in uploads:
+        data = await item.read()
+        total += len(data)
+        if total > _UPLOAD_MAX_BYTES:
+            return _upload_error("Upload is over the 25 MB limit.", current)
+        blobs.append((Path(item.filename).name, data))
+
+    allowed = _UPLOAD_SUFFIXES | {".zip"}
+    accepted = [(n, d) for n, d in blobs if Path(n).suffix.lower() in allowed]
+    ignored = [n for n, _ in blobs if Path(n).suffix.lower() not in allowed]
+    if not accepted:
+        return _upload_error(
+            "Nothing usable here. Expected .json / .wkt files, or a .zip bundle.",
+            current,
+        )
+
+    name_field = str(form.get("upload_name") or "").strip()
+    fallback = next(
+        (Path(n).stem for n, _ in accepted if Path(n).suffix.lower() != ".wkt"),
+        Path(accepted[0][0]).stem,
+    )
+    params._UPLOAD_ROOT.mkdir(parents=True, exist_ok=True)
+    dest = _unique_dir(params._UPLOAD_ROOT, _slugify(name_field or fallback))
+    dest.mkdir(parents=True)
+
+    try:
+        written: list[str] = []
+        for filename, data in accepted:
+            if Path(filename).suffix.lower() == ".zip":
+                written += _extract_zip(data, dest)
+            else:
+                (dest / Path(filename).name).write_bytes(data)
+                written.append(Path(filename).name)
+        if not written:
+            raise ValueError("The archive held no .json or .wkt files.")
+        # The one real check: if load_scenario accepts it, the run will too.
+        # Cheaper and more honest than re-implementing format validation.
+        load_scenario(str(dest))
+    except Exception as exc:
+        shutil.rmtree(dest, ignore_errors=True)
+        return _upload_error(
+            f"Could not load that scenario. {type(exc).__name__}: {exc}", current
+        )
+
+    value = f"{params.UPLOAD_PREFIX}{dest.name}"
+    summary = f"Added “{dest.name}” · {', '.join(sorted(written))}"
+    if ignored:
+        summary += f" · ignored {', '.join(sorted(ignored))}"
+    return params.scenario_block(
+        value,
+        note=Div(
+            summary,
+            style=f"{_MONO};font-size:10.5px;color:#F4C430;margin-top:6px;line-height:1.5",
+        ),
+    )
+
+
 # ── run routes ────────────────────────────────────────────────────────────────
 @rt("/run")
 async def post(request: Request):
@@ -713,7 +930,7 @@ async def post(request: Request):
         return _running_stream_view()
 
     try:
-        scenario = load_scenario(f"assets/{scenario_name}")
+        scenario = load_scenario(str(params.scenario_path(scenario_name)))
         opts = params.form_to_opts(form)
         # Normalise the FDS dir and fail fast on a bogus value. Without this,
         # a stale/garbage field (e.g. a pasted error string) is handed to
@@ -738,6 +955,8 @@ async def post(request: Request):
             scenario_name,
             post_run=post_run,
             fds_dir=getattr(opts, "fds_dir", None),
+            results_only=bool(form.get("results_only")),
+            opts=opts,
         )
     except Exception as exc:
         return Div(
@@ -832,14 +1051,8 @@ def _running_card(ev) -> Div:
     )
 
 
-def _finished_view() -> Div:
-    result = manager.result
-    scenario = None
-    try:
-        scenario = load_scenario(f"assets/{manager.scenario_name}")
-    except Exception:
-        pass
-
+def _kpi_tiles(result) -> Div:
+    """The four headline numbers, shared by both finished views."""
     status = "finished" if result.agents_remaining == 0 else "stopped"
     metrics = [
         ("Status", f"{status} ({result.metrics.get('success')})"),
@@ -848,8 +1061,7 @@ def _finished_view() -> Div:
         ("Remaining", f"{result.agents_remaining}"),
     ]
     accents = ["#F4C430", "#F4C430", "#3B82F6", "#E01E37"]
-
-    kpi_tiles = Div(
+    return Div(
         *[
             Div(
                 Div(
@@ -866,6 +1078,17 @@ def _finished_view() -> Div:
         ],
         style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;margin-bottom:18px",
     )
+
+
+def _finished_view() -> Div:
+    result = manager.result
+    scenario = None
+    try:
+        scenario = load_scenario(str(params.scenario_path(manager.scenario_name)))
+    except Exception:
+        pass
+
+    kpi_tiles = _kpi_tiles(result)
     if manager.artifacts:
         art = Div(
             Div(
@@ -899,6 +1122,123 @@ def _finished_view() -> Div:
             "Cognitive map growth", plots.cognitive_map_figure(result), "fig-cogmap"
         ),
         cls="space-y-6",
+        style="display:flex;flex-direction:column;gap:18px",
+    )
+
+
+def _fmt_size(path: Path) -> str:
+    """Human byte count for a file, or the summed contents of a directory."""
+    try:
+        if path.is_dir():
+            total = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        else:
+            total = path.stat().st_size
+    except OSError:
+        return "?"
+    for unit in ("B", "KB", "MB", "GB"):
+        if total < 1024 or unit == "GB":
+            return f"{total:.0f} {unit}" if unit == "B" else f"{total:.1f} {unit}"
+        total /= 1024.0
+    return "?"
+
+
+# Every artifact apply_outputs can write: the opts attribute holding its path,
+# a label, and the RunResult field it is gated on (None = always written).
+_ARTIFACT_SPECS = [
+    ("output_sqlite", "Trajectory SQLite", "sqlite_file"),
+    ("output_smoke_history", "Smoke history CSV", "smoke_history"),
+    ("output_fed_history", "FED history CSV", "fed_history"),
+    ("output_route_history", "Route switch CSV", "route_history"),
+    ("output_route_cost_history", "Route cost CSV", "route_cost_history"),
+    ("export_app_bundle", "Scenario bundle", None),
+]
+
+
+def _missing_reason(field: str, opts) -> str:
+    """Why a writer produced nothing -- these are settings, not failures."""
+    if field in ("smoke_history", "fed_history"):
+        no_smoke = not getattr(opts, "fds_dir", None) and not getattr(
+            opts, "constant_extinction", None
+        )
+        if no_smoke:
+            return "no smoke source: set an FDS dir or a constant extinction"
+        if field == "fed_history" and getattr(opts, "disable_tenability", False):
+            return "tenability disabled for this run"
+        return "the model recorded no samples"
+    if field in ("route_history", "route_cost_history"):
+        if not getattr(opts, "enable_rerouting", False):
+            return "rerouting disabled for this run"
+        return "no agent ever switched route"
+    if field == "sqlite_file":
+        return "no trajectory file was produced"
+    return "not produced by this run"
+
+
+def _artifact_rows(result, opts) -> Div:
+    rows = []
+    for attr, label, field in _ARTIFACT_SPECS:
+        raw = getattr(opts, attr, None) if opts is not None else None
+        produced = field is None or getattr(result, field, None) is not None
+        path = Path(raw) if raw else None
+        exists = bool(path and path.exists())
+
+        if exists:
+            detail, colour, mark = f"{path} · {_fmt_size(path)}", "#B2A9A3", "#F4C430"
+        elif not produced:
+            detail, colour, mark = _missing_reason(field, opts), "#837A74", "#3A343A"
+        else:
+            detail, colour, mark = "not written", "#837A74", "#3A343A"
+
+        rows.append(
+            Div(
+                Div(
+                    style=f"width:6px;height:6px;border-radius:99px;background:{mark};flex:none;margin-top:6px"
+                ),
+                Div(
+                    Div(label, style=f"{_GROTESK};font-size:12.5px;{_INK}"),
+                    Div(
+                        detail,
+                        style=f"{_MONO};font-size:10.5px;color:{colour};margin-top:3px;word-break:break-all",
+                    ),
+                ),
+                style="display:flex;gap:10px;align-items:flex-start;padding:8px 0;border-bottom:1px solid rgba(255,255,255,.05)",
+            )
+        )
+    return Div(*rows, style="display:flex;flex-direction:column")
+
+
+def _results_only_view() -> Div:
+    """Finished panel for a results-only run: numbers and files, no viewer."""
+    result = manager.result
+    opts = manager.opts
+    return Div(
+        _kpi_tiles(result),
+        _warnings_card(manager.warnings),
+        Div(
+            Div(
+                "Output files",
+                style=f"{_GROTESK};font-weight:600;font-size:15px;{_INK};margin-bottom:4px",
+            ),
+            Div(
+                "Same artifacts as a uv run of run.py.",
+                style=f"{_MONO};font-size:10.5px;{_MUTED};margin-bottom:10px",
+            ),
+            _artifact_rows(result, opts),
+            style=_CARD,
+        ),
+        Div(
+            Div(
+                "Viewer skipped",
+                style=f"{_GROTESK};font-weight:600;font-size:14px;color:#F4C430;margin-bottom:6px",
+            ),
+            P(
+                "The trajectory animation and the FED / smoke / cognitive-map plots "
+                "were not built for this run. Run the same scenario with "
+                "“Run scenario” to see them.",
+                style=f"font-size:.82rem;line-height:1.6;{_INK2};margin:0",
+            ),
+            style=_CARD,
+        ),
         style="display:flex;flex-direction:column;gap:18px",
     )
 
@@ -940,7 +1280,11 @@ async def progress():
             status = manager.status
             if status == "done":
                 try:
-                    finished = _finished_view()
+                    finished = (
+                        _results_only_view()
+                        if manager.results_only
+                        else _finished_view()
+                    )
                 except Exception as exc:
                     import traceback
 

--- a/pyfds_evac/webapp/params.py
+++ b/pyfds_evac/webapp/params.py
@@ -12,7 +12,17 @@ from argparse import Namespace
 from pathlib import Path
 from typing import Any, Dict, List
 
-from fasthtml.common import Button, Div, Form, Input, Label, NotStr, Option, Select
+from fasthtml.common import (
+    Button,
+    Div,
+    Form,
+    Input,
+    Label,
+    NotStr,
+    Optgroup,
+    Option,
+    Select,
+)
 
 try:
     from fasthtml.common import to_xml
@@ -23,6 +33,12 @@ except ImportError:
         from fasthtml.core import to_xml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
+_ASSET_ROOT = _REPO_ROOT / "assets"
+# Scenarios uploaded through the GUI. Gitignored, and kept out of assets/ so a
+# user's drop can never shadow or overwrite a bundled scenario.
+_UPLOAD_ROOT = _REPO_ROOT / "uploads"
+# Picker values for uploads carry this prefix; bundled scenarios carry none.
+UPLOAD_PREFIX = "uploads/"
 
 _INPUT = (
     "background:#2E2A2E;border:1px solid rgba(255,255,255,.09);"
@@ -96,22 +112,102 @@ def _is_bool(action: argparse.Action) -> bool:
     return action.nargs == 0 and action.const is True
 
 
-def _scenario_options() -> List[tuple]:
-    assets = _REPO_ROOT / "assets"
-    if not assets.is_dir():
+def _options_under(root: Path, prefix: str = "") -> List[tuple]:
+    """(label, value) pairs for every scenario directory under *root*.
+
+    A directory qualifies when it holds a config.json; each *other* *.json
+    beside it becomes an extra selectable option, matching what
+    ``load_scenario`` accepts for a directory and for a bare .json file.
+    """
+    if not root.is_dir():
         return []
     options: List[tuple] = []
-    for p in sorted(assets.iterdir()):
+    for p in sorted(root.iterdir()):
         if not (p.is_dir() and (p / "config.json").exists()):
             continue
-        options.append((p.name, p.name))
+        options.append((p.name, f"{prefix}{p.name}"))
         for json_file in sorted(p.glob("*.json")):
             if json_file.name == "config.json":
                 continue
             options.append(
-                (f"{p.name} / {json_file.name}", f"{p.name}/{json_file.name}")
+                (
+                    f"{p.name} / {json_file.name}",
+                    f"{prefix}{p.name}/{json_file.name}",
+                )
             )
     return options
+
+
+def _scenario_options() -> List[tuple]:
+    return _options_under(_ASSET_ROOT)
+
+
+def _upload_options() -> List[tuple]:
+    return _options_under(_UPLOAD_ROOT, UPLOAD_PREFIX)
+
+
+def scenario_path(name: str) -> Path:
+    """Resolve a scenario picker value to a real path on disk.
+
+    Values are ``<dir>`` or ``<dir>/<file>.json``, optionally carrying the
+    ``uploads/`` prefix. The resolved path is required to stay inside its root
+    so a crafted value ("../../etc", an absolute path, a symlink out) cannot
+    reach arbitrary files -- the value reaches us straight from a form field,
+    not only from the <select> we rendered.
+    """
+    raw = (name or "").strip().replace("\\", "/")
+    if not raw:
+        raise ValueError("No scenario selected.")
+    if raw.startswith(UPLOAD_PREFIX):
+        root, rel = _UPLOAD_ROOT, raw[len(UPLOAD_PREFIX) :]
+    else:
+        root, rel = _ASSET_ROOT, raw
+    if not rel or rel.startswith("/"):
+        raise ValueError(f"Invalid scenario: {name!r}")
+
+    resolved = (root / rel).resolve()
+    root_resolved = root.resolve()
+    if resolved != root_resolved and root_resolved not in resolved.parents:
+        raise ValueError(f"Scenario is outside {root.name}/: {name!r}")
+    if not resolved.exists():
+        raise ValueError(f"Scenario not found: {name!r}")
+    return resolved
+
+
+def upload_block() -> NotStr:
+    """Drop zone for a user's own scenario, shown under the scenario picker.
+
+    It lives *inside* the run form so there is one place to choose what runs:
+    the picker lists bundled and uploaded scenarios together, and this adds to
+    that list. HTML forbids nested forms, so rather than a <form> of its own the
+    upload is posted by htmx straight off the button, pulling in the two inputs
+    by hx-include. The run form drops them again via hx-params.
+    """
+    return NotStr(
+        "<div class='upload-block'>"
+        "<div class='upload-title'>Or upload your own</div>"
+        "<input type='text' id='upload-name' name='upload_name' "
+        "placeholder='Name (optional)' autocomplete='off' spellcheck='false' "
+        "class='upload-name'>"
+        "<label id='upload-drop' class='upload-drop'>"
+        "<input type='file' name='files' multiple accept='.json,.wkt,.zip' hidden>"
+        "<span class='upload-drop-title'>Drop files or click to browse</span>"
+        "<span class='upload-drop-sub'>config JSON + geometry WKT, or a .zip bundle</span>"
+        "<span id='upload-picked' class='upload-picked'></span>"
+        "</label>"
+        "<button type='button' class='upload-btn' "
+        "hx-post='/upload-scenario' hx-encoding='multipart/form-data' "
+        "hx-include=\"#upload-drop input, #upload-name, [name='scenario']\" "
+        # hx-params is inherited from the enclosing run form, whose filter drops
+        # exactly the two fields this request needs. Opt back in to all of them.
+        "hx-params='*' "
+        "hx-target='#scenario-block' hx-swap='outerHTML' "
+        "hx-indicator='#upload-busy'>"
+        "<span id='upload-busy' class='upload-busy'>…</span>Add to list</button>"
+        "<span class='upload-hint'>Geometry and configuration only. Fire data is "
+        "supplied separately through the FDS dir field under Smoke.</span>"
+        "</div>"
+    )
 
 
 def _browse_button(target_id: str, mode: str) -> Any:
@@ -164,6 +260,12 @@ _HELP_TEXT: Dict[str, str] = {
     "reconsidering.",
     "vis_cache": "Precomputed sign-visibility map (.npz). Lets agents lose sight of exit "
     "signs through smoke and walls. Needs an FDS dir + rerouting enabled.",
+    "output_base": "Folder the run writes into. Leave it blank to use the derived path "
+    "shown greyed out, which keeps each scenario / mode / seed in its own "
+    "folder. Type a path to override it and everything below goes there.",
+    "results_only": "Finishes sooner by skipping the trajectory viewer and plots. "
+    "Writes every output file to results/: the SQLite, the CSVs, and a "
+    "config + geometry snapshot. Same as 'uv run run.py'.",
 }
 
 
@@ -276,32 +378,55 @@ def _incap_toggle() -> Any:
     )
 
 
+_SELECT = (
+    "appearance:none;"
+    'background:#2E2A2E url("data:image/svg+xml;utf8,'
+    "<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'>"
+    "<path d='M2 4l4 4 4-4' stroke='%23837A74' stroke-width='1.5' fill='none'/>"
+    '</svg>") no-repeat right 12px center;'
+    "border:1px solid rgba(255,255,255,.09);border-radius:9px;"
+    f"padding:10px 32px 10px 12px;color:#F2EDE9;{_GROTESK};font-size:13px;"
+    "outline:none;width:100%"
+)
+
+
+def scenario_block(selected: str | None = None, note: Any = None) -> Any:
+    """The scenario picker, as a self-contained swap target.
+
+    Split out of ``_field`` so /upload-scenario can re-render it with the fresh
+    upload preselected. Bundled and uploaded scenarios go in separate optgroups
+    so it stays obvious which are yours.
+    """
+    bundled = _scenario_options()
+    uploaded = _upload_options()
+    vals = [v for _, v in bundled + uploaded]
+    default = selected if selected in vals else (vals[0] if vals else "")
+
+    def _opts(pairs):
+        return [Option(ol, value=ov, selected=(ov == default)) for ol, ov in pairs]
+
+    if uploaded:
+        children = [
+            Optgroup(*_opts(bundled), label="Bundled"),
+            Optgroup(*_opts(uploaded), label="Uploaded"),
+        ]
+    else:
+        children = _opts(bundled)
+
+    return Div(
+        _lbl("Scenario", "scenario"),
+        Select(*children, name="scenario", id="scenario", style=_SELECT),
+        *([note] if note is not None else []),
+        id="scenario-block",
+        style=_FIELD,
+    )
+
+
 def _field(action: argparse.Action) -> Any:
     dest = action.dest
 
     if dest == "scenario":
-        opts = _scenario_options()
-        vals = [v for _, v in opts]
-        default = "demo" if "demo" in vals else (vals[0] if vals else "")
-        return Div(
-            _lbl("Scenario", "scenario"),
-            Select(
-                *[Option(ol, value=ov, selected=(ov == default)) for ol, ov in opts],
-                name="scenario",
-                id="scenario",
-                style=(
-                    "appearance:none;"
-                    'background:#2E2A2E url("data:image/svg+xml;utf8,'
-                    "<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'>"
-                    "<path d='M2 4l4 4 4-4' stroke='%23837A74' stroke-width='1.5' fill='none'/>"
-                    '</svg>") no-repeat right 12px center;'
-                    "border:1px solid rgba(255,255,255,.09);border-radius:9px;"
-                    f"padding:10px 32px 10px 12px;color:#F2EDE9;{_GROTESK};font-size:13px;"
-                    "outline:none;width:100%"
-                ),
-            ),
-            style=_FIELD,
-        )
+        return scenario_block()
 
     if dest == "seed":
         return Div(
@@ -415,22 +540,84 @@ def _details_block(
     )
 
 
+def _results_only_button() -> Any:
+    """Secondary submit: same run, no viewer built afterwards.
+
+    The ? badge has to sit *outside* the <button> -- inside it, clicking to
+    read the help would submit the form and start a run. It reuses the same
+    .lblwrap/.badge-tip mechanism as the field labels.
+    """
+    import html as _html
+
+    return Div(
+        Div(
+            Button(
+                NotStr(
+                    '<span class="run-btn-icon">↓</span>'
+                    '<span class="run-btn-label">Results only</span>'
+                ),
+                id="results-btn",
+                type="submit",
+                name="results_only",
+                value="1",
+                cls="run-btn results-btn",
+                style=(
+                    "display:flex;align-items:center;justify-content:center;gap:6px;"
+                    "flex:1;padding:11px;border-radius:12px;cursor:pointer;"
+                    f"{_GROTESK};font-size:13.5px;font-weight:600;"
+                    "background:transparent;color:#F4C430;"
+                    "border:1px solid rgba(244,196,48,.45)"
+                ),
+            ),
+            NotStr(
+                '<span class="help-badge" style="flex:none;align-self:center" '
+                "onclick=\"this.closest('.lblwrap').classList.toggle('open')\">?</span>"
+            ),
+            style="display:flex;align-items:stretch;gap:8px",
+        ),
+        NotStr(
+            f'<div class="badge-tip">{_html.escape(_HELP_TEXT["results_only"])}</div>'
+        ),
+        cls="lblwrap",
+    )
+
+
+# Filename suffixes appended to the run name, in sidebar display order. The
+# preview lines are re-rendered client-side from the selected scenario, so the
+# names here must stay in step with _OUTPUT_DEFAULTS in form_to_opts.
+ARTIFACT_SUFFIXES = (
+    ".sqlite",
+    "_smoke_history.csv",
+    "_fed_history.csv",
+    "_route_history.csv",
+    "_route_cost_history.csv",
+)
+
+_DOT = (
+    '<span style="width:4px;height:4px;border-radius:99px;'
+    'background:#FF6A1A;flex:none;display:inline-block;margin-right:8px"></span>'
+)
+_PREVIEW_ROW = f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:#B2A9A3"
+
+
 def _output_files_section() -> NotStr:
     body = to_xml(
         Div(
             Div(
-                Label("Output folder", style=_LABEL),
+                _lbl("Output folder", "output_base"),
                 Input(
                     id="output_base",
                     name="output_base",
-                    placeholder="results/demo",
+                    autocomplete="off",
+                    spellcheck="false",
                     style=_INPUT,
                 ),
                 style=_FIELD,
             ),
             Div(
                 Div(
-                    "5 artifacts · auto-derived",
+                    "6 artifacts",
+                    id="artifact-heading",
                     style=f"{_GROTESK};font-size:9px;font-weight:600;letter-spacing:.07em;"
                     f"text-transform:uppercase;color:#837A74;margin-bottom:6px",
                 ),
@@ -442,31 +629,32 @@ def _output_files_section() -> NotStr:
                         "output_fed_history",
                         "output_route_history",
                         "output_route_cost_history",
+                        "export_app_bundle",
                     )
                 ],
+                # data-suffix lets the autofill script rewrite these to the real
+                # run name; the <run> text is what shows if the script is dead.
                 *[
                     Div(
+                        NotStr(_DOT),
                         NotStr(
-                            '<span style="width:4px;height:4px;border-radius:99px;'
-                            'background:#FF6A1A;flex:none;display:inline-block;margin-right:8px"></span>'
+                            f'<span class="artifact-preview" data-suffix="{suffix}">'
+                            f"&lt;run&gt;{suffix}</span>"
                         ),
-                        label,
-                        style=f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:#B2A9A3",
+                        style=_PREVIEW_ROW,
                     )
-                    for label in (
-                        "<run>.sqlite",
-                        "<run>_smoke_history.csv",
-                        "<run>_fed_history.csv",
-                        "<run>_route_history.csv",
-                        "<run>_route_cost_history.csv",
-                    )
+                    for suffix in ARTIFACT_SUFFIXES
                 ],
+                Div(
+                    NotStr(_DOT),
+                    "bundle/{config.json,geometry.wkt}",
+                    style=_PREVIEW_ROW,
+                ),
                 style=(
                     "background:#252127;border:1px solid rgba(255,255,255,.06);"
                     "border-radius:10px;padding:11px 12px;display:flex;flex-direction:column;gap:5px"
                 ),
             ),
-            _switch("export_app_bundle", "Export app bundle", checked=True),
             style="display:flex;flex-direction:column;gap:11px;padding:14px 4px 4px",
         )
     )
@@ -497,6 +685,10 @@ def build_form(post_url: str) -> Any:
         fields = [_field(by_dest[d]) for d in dests if d in by_dest]
         if not fields:
             continue
+        # Uploading is a way of adding to the scenario picker, so it belongs
+        # beside it rather than in a section of its own.
+        if title == "Core":
+            fields.append(upload_block())
         grouped.update(dests)
         open_ = title in ("Core", "Smoke", "FED & Tenability")
         sections.append(_details_block(title, accent, fields, open_))
@@ -527,10 +719,33 @@ def build_form(post_url: str) -> Any:
                 "box-shadow:0 6px 20px rgba(232,89,12,.28)"
             ),
         ),
+        _results_only_button(),
         hx_post=post_url,
         hx_target="#run-panel",
         hx_swap="innerHTML show:top",
+        # The upload inputs sit inside this form for layout only. Exclude them
+        # so a staged file is not serialised into the urlencoded run request.
+        hx_params="not files,upload_name",
         style="display:flex;flex-direction:column;gap:14px",
+    )
+
+
+def run_name(scenario: Any) -> str:
+    """Filename stem for a scenario's artifacts.
+
+    ``clean()`` in the sidebar's autofill script mirrors this; the two must
+    agree or the hidden fields and this server-side fallback would disagree on
+    where a run writes.
+    """
+    name = str(scenario or "")
+    return name.replace(".json", "").replace("/", "_") if name else "run"
+
+
+def default_output_base(scenario: Any, mode: Any, seed: Any) -> str:
+    """Derived output folder: one per scenario / incapacitation mode / seed."""
+    return (
+        f"results/{run_name(scenario)}/{mode or 'probabilistic'}/"
+        f"seed{seed if seed is not None else 'default'}"
     )
 
 
@@ -554,22 +769,34 @@ def form_to_opts(form: Dict[str, Any]) -> Namespace:
         opts[dest] = action.type(raw) if action.type else str(raw)
     opts["collect_route_cost_history"] = True
 
-    # Ensure output paths are always populated — JS autofill may not have run
-    # before form submission, so derive server-side from the scenario name.
-    def _clean(n: str) -> str:
-        return n.replace(".json", "").replace("/", "_") if n else "run"
-
-    sc = _clean(str(opts.get("scenario") or "run"))
+    # Ensure output paths are always populated: the JS autofill may not have run
+    # before submission, so derive them server-side too. The typed "Output
+    # folder" wins when present -- it used to be read by nobody, so a path typed
+    # there was silently discarded and the run went to the derived path anyway.
+    sc = run_name(opts.get("scenario"))
     mode = str(opts.get("incapacitation_mode") or "probabilistic")
-    seed = opts.get("seed")
-    base = f"results/{sc}/{mode}/seed{seed if seed is not None else 'default'}"
+    base = (
+        str(form.get("output_base") or "").strip().replace("\\", "/").rstrip("/")
+    ) or (default_output_base(opts.get("scenario"), mode, opts.get("seed")))
     _OUTPUT_DEFAULTS = {
         "output_sqlite": f"{base}/{sc}.sqlite",
         "output_smoke_history": f"{base}/{sc}_smoke_history.csv",
         "output_fed_history": f"{base}/{sc}_fed_history.csv",
         "output_route_history": f"{base}/{sc}_route_history.csv",
         "output_route_cost_history": f"{base}/{sc}_route_cost_history.csv",
+        "export_app_bundle": f"{base}/bundle",
     }
+    # --export-app-bundle takes a *directory*, but the sidebar used to render it
+    # as a checkbox; the posted "on" was passed straight through as a path, so
+    # every GUI run dumped its bundle into a literal ./on/ folder. Treat the
+    # checkbox-era truthy strings as "just use the default".
+    if str(opts.get("export_app_bundle") or "").strip().lower() in (
+        "on",
+        "true",
+        "1",
+        "yes",
+    ):
+        opts["export_app_bundle"] = ""
     for k, v in _OUTPUT_DEFAULTS.items():
         if not opts.get(k):
             opts[k] = v

--- a/pyfds_evac/webapp/runner.py
+++ b/pyfds_evac/webapp/runner.py
@@ -90,6 +90,8 @@ class RunManager:
         self.error: Optional[str] = None
         self.scenario_name: Optional[str] = None
         self.fds_dir: Optional[str] = None
+        self.results_only: bool = False
+        self.opts: Any = None
         self.artifacts: List[str] = []
         self.last_event: Optional[ProgressEvent] = None
         self.fed_snapshots: List[tuple] = []  # (sim_time, max_fed, mean_fed)
@@ -107,6 +109,8 @@ class RunManager:
         scenario_name: str,
         post_run: Optional[Callable[[ScenarioResult], List[str]]] = None,
         fds_dir: Optional[str] = None,
+        results_only: bool = False,
+        opts: Any = None,
     ) -> None:
         """Start a run on a background thread. Raises if one is already active.
 
@@ -114,6 +118,9 @@ class RunManager:
         status flips to ``done``; its returned strings (e.g. written output
         files) are stored on ``self.artifacts``. ``fds_dir`` is remembered so
         the results view can render the smoke field from the same FDS case.
+        ``results_only`` selects the finished view that skips building the
+        trajectory viewer and plots; ``opts`` is kept so that view can report
+        on every output path that was requested.
         """
         if not self._lock.acquire(blocking=False):
             raise RuntimeError("A run is already in progress.")
@@ -123,6 +130,8 @@ class RunManager:
         self.error = None
         self.scenario_name = scenario_name
         self.fds_dir = fds_dir
+        self.results_only = results_only
+        self.opts = opts
         self.artifacts = []
         self.last_event = None
         self.fed_snapshots = []

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -147,6 +147,52 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 /* run button running-state */
 .run-btn:disabled { cursor: progress; filter: saturate(.5) brightness(.92); opacity: .9; }
 .run-btn:disabled .run-btn-icon { animation: pulse 1.3s ease-in-out infinite; }
+.results-btn:hover:not(:disabled) { background: rgba(244,196,48,.10); }
+
+/* ---- scenario upload (sits under the picker, inside Core) ---- */
+.upload-block {
+  display: flex; flex-direction: column; gap: 8px;
+  border-top: 1px dashed rgba(255,255,255,.10); margin-top: 4px; padding-top: 11px;
+}
+.upload-title {
+  font-family: 'Space Grotesk', sans-serif; font-size: 10.5px; font-weight: 500;
+  letter-spacing: .07em; text-transform: uppercase; color: #837A74;
+}
+.upload-name {
+  background: #2E2A2E; border: 1px solid rgba(255,255,255,.09); border-radius: 9px;
+  padding: 9px 11px; color: #F2EDE9; font-family: 'JetBrains Mono', monospace;
+  font-size: 12px; outline: none; width: 100%; box-sizing: border-box;
+}
+.upload-drop {
+  display: flex; flex-direction: column; align-items: center; gap: 3px;
+  padding: 16px 12px; cursor: pointer; text-align: center;
+  border: 1px dashed rgba(255,255,255,.18); border-radius: 10px;
+  background: #211E21; transition: border-color .12s, background .12s;
+}
+.upload-drop:hover, .upload-drop.over {
+  border-color: var(--gold); background: rgba(244,196,48,.06);
+}
+.upload-drop-title {
+  font-family: 'Space Grotesk', sans-serif; font-size: 12px; color: #F2EDE9;
+}
+.upload-drop-sub, .upload-hint {
+  font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: #837A74;
+  line-height: 1.5;
+}
+.upload-picked {
+  font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: var(--gold);
+  word-break: break-all;
+}
+.upload-picked:empty { display: none; }
+.upload-btn {
+  display: flex; align-items: center; justify-content: center; gap: .35rem;
+  width: 100%; padding: 9px; border-radius: 9px; cursor: pointer;
+  border: 1px solid rgba(255,255,255,.12); background: #3A343A; color: #F2EDE9;
+  font-family: 'Space Grotesk', sans-serif; font-size: 12.5px; font-weight: 500;
+}
+.upload-btn:hover { border-color: var(--gold); color: var(--gold); }
+.upload-busy { display: none; }
+.upload-busy.htmx-request { display: inline; animation: pulse 1.3s ease-in-out infinite; }
 
 /* ---- header ---- */
 .app-header {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ dependencies = [
 gui = [
     "python-fasthtml",
     "monsterui",
+    # Starlette needs this to parse multipart forms (the scenario upload).
+    "python-multipart",
 ]
 
 [project.urls]

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,5 +1,10 @@
 """End-to-end tests for the FastHTML web GUI via Starlette's TestClient."""
 
+import io
+import pathlib
+import shutil
+import zipfile
+
 import pytest
 
 pytest.importorskip("fasthtml")
@@ -87,6 +92,21 @@ def test_invalid_option_combo_shows_error(client, tmp_path):
     assert "enable-rerouting" in r.text
 
 
+def _drop_temp_trajectory():
+    """Delete the run's temp sqlite, tolerating a Windows file lock.
+
+    Building the finished view reads the trajectory through pedpy, and on
+    Windows that handle can outlive the read, so unlink raises PermissionError.
+    It's a temp file either way, and the lock is not what any test is asserting.
+    """
+    result = manager.result
+    if result and result.sqlite_file:
+        try:
+            result.cleanup()
+        except OSError:
+            pass
+
+
 def _stream_until_terminal(client, max_lines=2000):
     events = []
     with client.stream("GET", "/progress") as s:
@@ -111,8 +131,7 @@ def test_full_run_streams_progress_and_completes(client):
     assert manager.status == "done"
     assert manager.result is not None
     assert manager.result.total_agents >= 1
-    if manager.result.sqlite_file:
-        manager.result.cleanup()
+    _drop_temp_trajectory()
 
 
 def test_second_run_rejected_while_active(client):
@@ -145,8 +164,421 @@ def test_second_run_rejected_while_active(client):
         manager.start(scenario, kwargs, "ISO-table21")
     # Drain to completion so the lock releases for other tests.
     _stream_until_terminal(client)
-    if manager.result and manager.result.sqlite_file:
-        manager.result.cleanup()
+    _drop_temp_trajectory()
+
+
+class TestScenarioPath:
+    """The picker value reaches load_scenario as a path, so it must be clamped.
+
+    It arrives in a plain form field, not necessarily from the <select> we
+    rendered, so a crafted value must not be able to walk out of assets/.
+    """
+
+    @staticmethod
+    def _fn():
+        from pyfds_evac.webapp.params import scenario_path
+
+        return scenario_path
+
+    def test_resolves_bundled_scenario(self):
+        assert self._fn()("t_junction").name == "t_junction"
+
+    def test_resolves_alternate_json(self):
+        assert self._fn()("t_junction/config_full.json").name == "config_full.json"
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "../etc",
+            "t_junction/../../etc",
+            "uploads/../assets",
+            "/etc/passwd",
+            "",
+        ],
+    )
+    def test_rejects_traversal(self, value):
+        with pytest.raises(ValueError):
+            self._fn()(value)
+
+
+class TestScenarioUpload:
+    """Uploading a scenario's non-FDS files (config JSON + WKT, or a zip)."""
+
+    WKT = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))"
+
+    @staticmethod
+    def _config():
+        import json
+        from pathlib import Path
+
+        return Path("assets/t_junction/config.json").read_text(), json
+
+    @staticmethod
+    def _uploads_root():
+        from pyfds_evac.webapp.params import _UPLOAD_ROOT
+
+        return _UPLOAD_ROOT
+
+    def _post(self, client, files, name="pytest-upload"):
+        return client.post("/upload-scenario", data={"upload_name": name}, files=files)
+
+    def test_json_and_wkt_pair_becomes_selectable(self, client):
+        cfg, _ = self._config()
+        r = self._post(
+            client,
+            [
+                ("files", ("config.json", cfg, "application/json")),
+                ("files", ("geometry.wkt", self.WKT, "text/plain")),
+            ],
+        )
+        assert r.status_code == 200
+        assert "uploads/pytest-upload" in r.text
+        assert "Uploaded" in r.text  # optgroup separating it from bundled
+        created = self._uploads_root() / "pytest-upload"
+        try:
+            assert (created / "config.json").exists()
+            assert (created / "geometry.wkt").exists()
+            # And it is now a runnable choice.
+            from pyfds_evac.webapp.params import _upload_options
+
+            assert "uploads/pytest-upload" in [v for _, v in _upload_options()]
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+
+    def test_zip_bundle_is_accepted(self, client):
+        cfg, _ = self._config()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("config.json", cfg)
+            zf.writestr("geometry.wkt", self.WKT)
+        r = self._post(
+            client,
+            [("files", ("bundle.zip", buf.getvalue(), "application/zip"))],
+            name="pytest-zip",
+        )
+        assert r.status_code == 200
+        assert "uploads/pytest-zip" in r.text
+        created = self._uploads_root() / "pytest-zip"
+        try:
+            assert (created / "config.json").exists()
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+
+    def test_zip_slip_member_is_rejected_not_flattened(self, client):
+        """A '../' member must not escape, and must not be kept at all.
+
+        Flattening it to a basename would leave a stray .json inside the
+        scenario dir, which the picker then offers as an alternate config.
+        """
+        cfg, _ = self._config()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("config.json", cfg)
+            zf.writestr("geometry.wkt", self.WKT)
+            zf.writestr("../../pwned.json", '{"evil": true}')
+        escaped = self._uploads_root().parent / "pwned.json"
+        r = self._post(
+            client,
+            [("files", ("evil.zip", buf.getvalue(), "application/zip"))],
+            name="pytest-slip",
+        )
+        created = self._uploads_root() / "pytest-slip"
+        try:
+            assert r.status_code == 200
+            assert not escaped.exists()  # nothing written outside uploads/
+            assert not (created / "pwned.json").exists()  # nor kept inside
+            assert sorted(p.name for p in created.iterdir()) == [
+                "config.json",
+                "geometry.wkt",
+            ]
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+            escaped.unlink(missing_ok=True)
+
+    def test_zip_of_a_folder_is_flattened(self, client):
+        """The common case: zipping the scenario folder, not its contents."""
+        cfg, _ = self._config()
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("t_junction/config.json", cfg)
+            zf.writestr("t_junction/geometry.wkt", self.WKT)
+            zf.writestr("t_junction/t_junction.fds", "&HEAD /")
+        r = self._post(
+            client,
+            [("files", ("folder.zip", buf.getvalue(), "application/zip"))],
+            name="pytest-folder",
+        )
+        created = self._uploads_root() / "pytest-folder"
+        try:
+            assert r.status_code == 200
+            # Nested members keep their basename; the FDS deck is not a
+            # scenario file and is left out.
+            assert sorted(p.name for p in created.iterdir()) == [
+                "config.json",
+                "geometry.wkt",
+            ]
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+
+    def test_non_scenario_files_are_ignored_and_reported(self, client):
+        cfg, _ = self._config()
+        r = self._post(
+            client,
+            [
+                ("files", ("config.json", cfg, "application/json")),
+                ("files", ("geometry.wkt", self.WKT, "text/plain")),
+                ("files", ("case.fds", "&HEAD /", "text/plain")),
+            ],
+            name="pytest-extra",
+        )
+        created = self._uploads_root() / "pytest-extra"
+        try:
+            assert r.status_code == 200
+            assert "ignored" in r.text and "case.fds" in r.text
+            assert not (created / "case.fds").exists()
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+
+    def test_unusable_upload_errors_and_leaves_nothing_behind(self, client):
+        r = self._post(
+            client,
+            [("files", ("notes.txt", "hello", "text/plain"))],
+            name="pytest-junk",
+        )
+        assert r.status_code == 200
+        assert "Nothing usable" in r.text
+        assert not (self._uploads_root() / "pytest-junk").exists()
+
+    def test_wkt_without_config_is_rejected_and_cleaned_up(self, client):
+        r = self._post(
+            client,
+            [("files", ("geometry.wkt", self.WKT, "text/plain"))],
+            name="pytest-nocfg",
+        )
+        assert r.status_code == 200
+        assert "Could not load that scenario" in r.text
+        assert not (self._uploads_root() / "pytest-nocfg").exists()
+
+    def test_empty_submission_is_rejected(self, client):
+        r = client.post("/upload-scenario", data={"upload_name": "x"})
+        assert r.status_code == 200
+        assert "Pick a config JSON" in r.text
+
+    def test_failed_upload_keeps_the_current_scenario_selected(self, client):
+        """A rejected upload must not silently reset the picker."""
+        r = client.post(
+            "/upload-scenario",
+            data={"upload_name": "x", "scenario": "t_junction/config_full.json"},
+            files=[("files", ("notes.txt", "hello", "text/plain"))],
+        )
+        assert r.status_code == 200
+        assert "Nothing usable" in r.text
+        # The still-selected option carries the selected attribute.
+        marker = 'value="t_junction/config_full.json" selected'
+        assert (
+            marker in r.text or 'selected value="t_junction/config_full.json"' in r.text
+        )
+
+    def test_uploaded_scenario_can_actually_be_run(self, client, tmp_path):
+        """The whole point: an upload has to be runnable, not just listed."""
+        cfg = pathlib.Path("assets/ISO-table21/config.json").read_text()
+        wkt = pathlib.Path("assets/ISO-table21/geometry.wkt").read_text()
+        r = self._post(
+            client,
+            [
+                ("files", ("config.json", cfg, "application/json")),
+                ("files", ("geometry.wkt", wkt, "text/plain")),
+            ],
+            name="pytest-runnable",
+        )
+        assert r.status_code == 200
+        created = self._uploads_root() / "pytest-runnable"
+        try:
+            out = tmp_path / "out"
+            r = client.post(
+                "/run",
+                data={
+                    "scenario": "uploads/pytest-runnable",
+                    "seed": "420",
+                    "results_only": "1",
+                    "output_sqlite": str(out / "run.sqlite"),
+                    "export_app_bundle": str(out / "bundle"),
+                },
+            )
+            assert r.status_code == 200
+            assert "sse-connect" in r.text or "sse_connect" in r.text
+            events = _stream_until_terminal(client)
+            assert events[-1] == "done"
+            assert manager.status == "done"
+            assert manager.result.total_agents >= 1
+            assert (out / "run.sqlite").exists()
+            _drop_temp_trajectory()
+        finally:
+            shutil.rmtree(created, ignore_errors=True)
+
+
+def test_results_only_run_skips_viewer_but_writes_files(client, tmp_path):
+    """The results-only button runs the sim and reports files, with no viewer."""
+    out = tmp_path / "out"
+    r = client.post(
+        "/run",
+        data={
+            "scenario": "ISO-table21",
+            "seed": "420",
+            "results_only": "1",
+            "output_sqlite": str(out / "run.sqlite"),
+            "output_fed_history": str(out / "fed.csv"),
+            "export_app_bundle": str(out / "bundle"),
+        },
+    )
+    assert r.status_code == 200
+    events = _stream_until_terminal(client)
+    assert events[-1] == "done"
+    assert manager.results_only is True
+
+    from fasthtml.common import to_xml
+
+    from pyfds_evac.webapp.app import _results_only_view
+
+    html = to_xml(_results_only_view())
+    assert "Output files" in html
+    assert "Viewer skipped" in html
+    assert "<canvas" not in html  # the trajectory animator was never built
+    assert "Trajectory SQLite" in html
+
+    # The artifacts really landed, and the bundle path is a directory now that
+    # export_app_bundle is a path field rather than a checkbox.
+    assert (out / "run.sqlite").exists()
+    assert (out / "bundle" / "config.json").exists()
+    assert (out / "bundle" / "geometry.wkt").exists()
+    _drop_temp_trajectory()
+
+
+def test_normal_run_still_builds_the_viewer(client):
+    """The default button path is unchanged: results_only stays off."""
+    r = client.post("/run", data={"scenario": "ISO-table21", "seed": "420"})
+    assert r.status_code == 200
+    assert manager.results_only is False
+    _stream_until_terminal(client)
+    _drop_temp_trajectory()
+
+
+def test_upload_sits_inside_core_beside_the_picker(client):
+    """One place to choose what runs, not two competing sections.
+
+    The upload is a way of adding to the scenario picker, so it renders inside
+    Core just after it. It cannot be its own <form> there (HTML forbids nested
+    forms), so it posts via htmx off the button instead.
+    """
+    r = client.get("/")
+    assert r.status_code == 200
+    body = r.text
+
+    # It is inside the Core block, after the scenario field. Match the markup
+    # rather than a bare class name, which also appears in the stylesheet.
+    core = body.index(">Core<")
+    picker = body.index('id="scenario-block"')
+    upload = body.index("id='upload-drop'")
+    assert core < picker < upload
+
+    # And no longer a separate collapsible section of its own.
+    assert "Upload your own scenario" not in body
+    assert "<form id='upload-form'" not in body
+
+    # Posted by htmx off the button, with multipart encoding.
+    assert "hx-encoding='multipart/form-data'" in body
+    assert "hx-post='/upload-scenario'" in body
+    # The staged file must not ride along on the urlencoded run request.
+    assert "not files,upload_name" in body
+
+
+class TestOutputBase:
+    """The "Output folder" box used to be wired to nothing at either end.
+
+    Nothing filled it and nothing read it, so a path typed there was silently
+    discarded and the run went to the derived path regardless.
+    """
+
+    @staticmethod
+    def _opts(**extra):
+        from pyfds_evac.webapp.params import form_to_opts
+
+        form = {"scenario": "t_junction", "seed": "42"}
+        form.update(extra)
+        return form_to_opts(form)
+
+    def test_blank_uses_the_derived_folder(self):
+        opts = self._opts()
+        assert opts.output_sqlite == (
+            "results/t_junction/probabilistic/seed42/t_junction.sqlite"
+        )
+
+    def test_typed_folder_is_honoured(self):
+        opts = self._opts(output_base="D:/scratch/my run")
+        assert opts.output_sqlite == "D:/scratch/my run/t_junction.sqlite"
+        assert opts.output_fed_history == "D:/scratch/my run/t_junction_fed_history.csv"
+        assert opts.export_app_bundle == "D:/scratch/my run/bundle"
+
+    def test_typed_folder_is_normalised(self):
+        # Backslashes and a trailing separator must not double up in the path.
+        opts = self._opts(output_base="out\\runs\\")
+        assert opts.output_sqlite == "out/runs/t_junction.sqlite"
+
+    def test_whitespace_only_falls_back_to_derived(self):
+        opts = self._opts(output_base="   ")
+        assert opts.output_sqlite.startswith("results/t_junction/")
+
+    def test_explicit_path_still_beats_the_folder(self):
+        # A fully-specified output path (hidden field) is not overridden.
+        opts = self._opts(output_base="out", output_sqlite="exact/place.sqlite")
+        assert opts.output_sqlite == "exact/place.sqlite"
+
+
+def test_artifact_preview_lines_are_rewritable(client):
+    """The sidebar preview must carry the data the script needs to fill it in.
+
+    Without data-suffix the list is stuck showing a literal "<run>".
+    """
+    from pyfds_evac.webapp.params import ARTIFACT_SUFFIXES
+
+    r = client.get("/")
+    assert r.status_code == 200
+    for suffix in ARTIFACT_SUFFIXES:
+        assert f'data-suffix="{suffix}"' in r.text
+    assert "artifact-preview" in r.text
+    assert "outputBase()" in r.text  # the script reads the folder box
+
+
+def test_run_name_matches_the_client_side_clean():
+    from pyfds_evac.webapp.params import default_output_base, run_name
+
+    assert run_name("t_junction") == "t_junction"
+    assert run_name("t_junction/config_full.json") == "t_junction_config_full"
+    assert run_name("uploads/mine") == "uploads_mine"
+    assert run_name(None) == "run"
+    assert (
+        default_output_base("t_junction", "deterministic", 7)
+        == "results/t_junction/deterministic/seed7"
+    )
+    assert default_output_base("t_junction", None, None).endswith(
+        "/probabilistic/seeddefault"
+    )
+
+
+def test_export_app_bundle_is_a_path_not_a_checkbox():
+    """Regression: the checkbox posted 'on', so bundles landed in ./on/.
+
+    --export-app-bundle takes a directory. The sidebar used to render it as a
+    switch, and the posted "on" was passed straight through as the path.
+    """
+    from pyfds_evac.webapp.params import form_to_opts
+
+    opts = form_to_opts(
+        {"scenario": "t_junction", "seed": "42", "export_app_bundle": "on"}
+    )
+    assert opts.export_app_bundle != "on"
+    assert opts.export_app_bundle.endswith("/bundle")
+    assert opts.export_app_bundle.startswith("results/t_junction/")
 
 
 class TestTrajectorySampling:

--- a/uv.lock
+++ b/uv.lock
@@ -1066,6 +1066,7 @@ dependencies = [
 gui = [
     { name = "monsterui" },
     { name = "python-fasthtml" },
+    { name = "python-multipart" },
 ]
 
 [package.dev-dependencies]
@@ -1087,6 +1088,7 @@ requires-dist = [
     { name = "pedpy" },
     { name = "plotly" },
     { name = "python-fasthtml", marker = "extra == 'gui'" },
+    { name = "python-multipart", marker = "extra == 'gui'" },
     { name = "shapely" },
 ]
 provides-extras = ["gui"]


### PR DESCRIPTION
Two additions to the GUI, plus three bugs found on the way.

## Results only

A second submit button that runs the same simulation but skips building the results page.

Worth being explicit, because it shapes the feature: **the simulation itself is untouched and takes exactly as long.** What gets skipped is the tail. `_finished_view` loads the trajectory back through pedpy, resamples it into ~24 MB of inline JSON and re-reads the FDS case for smoke frames, all synchronously inside the `/progress` SSE generator once the run is done, and the browser then parses it. That is the whole saving.

In exchange the run reports every artifact `apply_outputs` can write, with a reason for the ones a given configuration legitimately produces nothing for ("no smoke source: set an FDS dir or a constant extinction") rather than leaving them silently absent. Checked against the CLI: `uv run run.py --scenario assets/ISO-table21 --seed 42` and the button produce byte-identical artifact sets.

## Upload your own scenario

A drop zone under the scenario picker taking a config JSON + geometry WKT, or a `.zip`.

`load_scenario` already accepts a directory, a bare `.json` or a zip, so validation is simply calling it — no second implementation of the format rules. A failure deletes the directory rather than leaving half a scenario behind. Uploads land in a gitignored `uploads/` and join the picker beside the bundled ones under `Bundled` / `Uploaded` optgroups, so there is a single place to choose what runs.

It cannot be its own `<form>` there (HTML forbids nesting), so htmx posts it off the button. The run form drops the file input via `hx-params="not files,upload_name"`, and because that attribute is inherited the button has to opt back in with `hx-params="*"` — without it the upload silently sends no files while passing every server-side test.

## Fixes along the way

- **`--export-app-bundle` was rendered as a checkbox.** It takes a directory. The posted `"on"` was passed straight through as the path, so every GUI run wrote its bundle into a literal `./on/` folder. It is now a path field, derived like the other outputs.
- **The scenario name reached `load_scenario` unsanitised**, interpolated as `"assets/" + name` from a form field. `scenario_path()` now resolves it and requires the result to stay inside `assets/` or `uploads/`. Zip members that traverse (`../`) are rejected outright rather than flattened, which would otherwise leave a stray `.json` the picker offers as an alternate config.
- **The autofill script could never find the scenario picker.** It matched on `input[name="scenario"]` and `#scenario select`, but the picker is a `<select id="scenario">`, so neither ever hit. Output paths were therefore never filled client-side, and the visible "Output folder" box was read by nobody at either end — a path typed there was silently discarded and the run went to the derived path anyway. The box now shows the derived folder as a placeholder and is honoured when set, and the artifact preview resolves `<run>` to the real scenario name.

## Tests

`tests/test_webapp.py` goes from 14 to 42. New coverage: path-traversal rejection, upload of a pair / a zip / a zip of a folder, zip-slip rejection, non-scenario files ignored and reported, failed upload leaves nothing behind and keeps the current selection, an uploaded scenario actually running end to end, results-only emitting the artifact list with no trajectory canvas, `output_base` honoured and normalised, and the export-bundle regression.

## Note for reviewers

The scenario picker value and `output_base` both accept paths; the former is clamped to `assets/`/`uploads/`, the latter deliberately is not, matching what `--output-*` already allows on the CLI. Say if the GUI should clamp it.
