### PR TITLE
feat: clear-air sight by default for discovery decks, and placeable fires

### DIFF
--- a/docs/testing-familiarity.md
+++ b/docs/testing-familiarity.md
@@ -229,3 +229,22 @@ at all — see the "blind agent" issue in the tracker. A clear-air stand-in
 (line of sight against the walkable polygon plus the sign's readable half-plane)
 is enough to exercise the wiring without FDS output; the test suite and the
 animation script each carry one.
+
+## Clear-air visibility without an FDS run
+
+`VisibilityModel.clear_air(walkable, sign_descriptors, cell_size_m=...)` builds a
+visibility model from geometry alone: fdsvismap's own ray casting, view angle and
+`max_vis` handling, over a uniform zero extinction field. It exists because
+`vis_model=None` silently disables perception — a discovery agent's map then
+never grows — and because five separate approximations of fdsvismap had
+accumulated in this repo, none of them applying the view angle.
+
+**Resolution is a real parameter.** A cell blocks sight when its centre lies
+outside the walkable polygon, so a wall thinner than one cell disappears and
+sight passes through it — the same property an FDS mesh has. At the 0.5 m
+default the ~0.4 m walls of `assets/blind_spawn_discovery` vanish entirely and
+occlusion tests silently stop testing anything; 0.25 m resolves them. Cost grows
+as the inverse square. Pick it below the thinnest wall that must block.
+
+This requires the fdsvismap branch adding `set_grid` / `set_uniform_extco`
+(FireDynamics/fdsvismap#41); `pyproject.toml` pins it until that is released.

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -307,8 +307,6 @@ class VisibilityModel:
             force_recompute,
             expected_meta,
         )
-        # An FDS-backed field changes with time, so queries use the real clock.
-        self._static_time: float | None = None
         # Map node_id → internal waypoint index (insertion order preserved)
         self._wp_ids: dict[str, int] = {
             node_id: wp_id for wp_id, node_id in enumerate(sign_descriptors)
@@ -373,10 +371,6 @@ class VisibilityModel:
 
         model = cls.__new__(cls)
         model._vis = vis  # VisMap exposes the same wp_is_visible signature
-        # A uniform field does not change, so one time point is computed and
-        # every query resolves to it. Without this a query at t > 0 would be
-        # rejected as outside the computed range.
-        model._static_time = 0.0
         model._wp_ids = {
             node_id: wp_id for wp_id, node_id in enumerate(sign_descriptors)
         }
@@ -392,6 +386,6 @@ class VisibilityModel:
         wp_id = self._wp_ids.get(node_id)
         if wp_id is None:
             return True
-        if self._static_time is not None:
-            time = self._static_time
+        # A clear-air model computes one time point; fdsvismap resolves any
+        # query time onto a uniform field itself, so no clamping is needed here.
         return bool(self._vis.wp_is_visible(time=time, x=x, y=y, waypoint_id=wp_id))

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -98,6 +98,39 @@ def _make_meta(
     }
 
 
+def _blocked_runs(walkable, x_coords, y_coords, cell_size_m: float):
+    """Yield (x1, x2, y1, y2) rectangles covering every non-walkable cell.
+
+    Consecutive blocked cells in a row are merged into one rectangle, so a long
+    wall costs one call rather than one per cell, and the result still follows
+    an arbitrary polygon outline to the resolution of the grid.
+    """
+    from shapely.geometry import Point
+
+    half = cell_size_m / 2
+    for y in y_coords:
+        run_start = None
+        for i, x in enumerate(x_coords):
+            blocked = not walkable.covers(Point(float(x), float(y)))
+            if blocked and run_start is None:
+                run_start = x
+            elif not blocked and run_start is not None:
+                yield (
+                    float(run_start) - half,
+                    float(x_coords[i - 1]) + half,
+                    float(y) - half,
+                    float(y) + half,
+                )
+                run_start = None
+        if run_start is not None:
+            yield (
+                float(run_start) - half,
+                float(x_coords[-1]) + half,
+                float(y) - half,
+                float(y) + half,
+            )
+
+
 class _VisMapCache:
     """Lightweight visibility lookup backed by pre-computed numpy arrays.
 
@@ -274,10 +307,78 @@ class VisibilityModel:
             force_recompute,
             expected_meta,
         )
+        # An FDS-backed field changes with time, so queries use the real clock.
+        self._static_time: float | None = None
         # Map node_id → internal waypoint index (insertion order preserved)
         self._wp_ids: dict[str, int] = {
             node_id: wp_id for wp_id, node_id in enumerate(sign_descriptors)
         }
+
+    @classmethod
+    def clear_air(
+        cls,
+        walkable,
+        sign_descriptors: dict[str, dict],
+        *,
+        cell_size_m: float = 0.5,
+        extinction_per_m: float = 0.0,
+    ) -> "VisibilityModel":
+        """Build a model for a scene that has geometry but no fire.
+
+        ``fdsvismap`` normally takes its grid, extinction field and obstructions
+        from an FDS run.  Only the field has to: :meth:`VisMap.set_grid` and
+        :meth:`VisMap.set_uniform_extco` supply the other two, so a clear-air
+        deck is evaluated by the same ray casting, view angle and ``max_vis``
+        handling as a fire scene rather than by an approximation written here.
+
+        Obstructions come from *walkable*: every grid cell whose centre is
+        outside the walkable polygon blocks sight.  Cells are emitted as runs of
+        rectangles per row, which is what ``add_visual_obstruction`` accepts and
+        keeps arbitrary wall shapes exact to the grid.
+
+        ``cell_size_m`` is the resolution the scene is rasterised at, and it
+        matters.  A cell blocks sight when its centre lies outside *walkable*,
+        so **a wall thinner than one cell disappears** and sight passes through
+        it -- the same property an FDS mesh has, for the same reason.  An FDS
+        deck inherits the resolution from its mesh; here it has to be chosen.
+        Pick it below the thinnest wall that must block: at 0.5 m the 0.4 m
+        walls of ``assets/blind_spawn_discovery`` vanish entirely, while 0.25 m
+        resolves them.  Cost grows as the inverse square, so halving it
+        quadruples the build.
+        """
+        from fdsvismap import VisMap
+
+        min_x, min_y, max_x, max_y = walkable.bounds
+        x_coords = np.arange(min_x + cell_size_m / 2, max_x, cell_size_m)
+        y_coords = np.arange(min_y + cell_size_m / 2, max_y, cell_size_m)
+
+        vis = VisMap()
+        vis.set_grid(x_coords, y_coords)
+        vis.set_uniform_extco(extinction_per_m)
+        vis.set_time_points([0.0])
+        for wp_id, (_node_id, sign) in enumerate(sign_descriptors.items()):
+            alpha = sign.get("alpha")
+            vis.set_waypoint(
+                wp_id,
+                float(sign["x"]),
+                float(sign["y"]),
+                c=float(sign.get("c", 3)),
+                alpha=None if alpha is None else float(alpha),
+            )
+        for x1, x2, y1, y2 in _blocked_runs(walkable, x_coords, y_coords, cell_size_m):
+            vis.add_visual_obstruction(x1, x2, y1, y2)
+        vis.compute_all(view_angle=True, obstructions=True, aa=True)
+
+        model = cls.__new__(cls)
+        model._vis = vis  # VisMap exposes the same wp_is_visible signature
+        # A uniform field does not change, so one time point is computed and
+        # every query resolves to it. Without this a query at t > 0 would be
+        # rejected as outside the computed range.
+        model._static_time = 0.0
+        model._wp_ids = {
+            node_id: wp_id for wp_id, node_id in enumerate(sign_descriptors)
+        }
+        return model
 
     def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
         """Return True if the sign at *node_id* is visible from (x, y) at *time*.
@@ -289,4 +390,6 @@ class VisibilityModel:
         wp_id = self._wp_ids.get(node_id)
         if wp_id is None:
             return True
-        return self._vis.wp_is_visible(time=time, x=x, y=y, waypoint_id=wp_id)
+        if self._static_time is not None:
+            time = self._static_time
+        return bool(self._vis.wp_is_visible(time=time, x=x, y=y, waypoint_id=wp_id))

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -348,6 +348,8 @@ class VisibilityModel:
         """
         from fdsvismap import VisMap
 
+        if cell_size_m <= 0:
+            raise ValueError(f"cell_size_m must be positive, got {cell_size_m}")
         min_x, min_y, max_x, max_y = walkable.bounds
         x_coords = np.arange(min_x + cell_size_m / 2, max_x, cell_size_m)
         y_coords = np.arange(min_y + cell_size_m / 2, max_y, cell_size_m)

--- a/pyfds_evac/core/visibility.py
+++ b/pyfds_evac/core/visibility.py
@@ -5,9 +5,24 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
+from typing import Protocol
 
 import numpy as np
 from shapely.geometry import Polygon
+
+
+class _VisBackend(Protocol):
+    """What VisibilityModel needs from its backend.
+
+    Satisfied structurally by both the npz-backed ``_VisMapCache`` and a live
+    ``fdsvismap.VisMap`` (the clear-air route), so ``clear_air`` can assign
+    either without lying to the type checker.
+    """
+
+    def wp_is_visible(
+        self, time: float, x: float, y: float, waypoint_id: int
+    ) -> bool: ...
+
 
 _logger = logging.getLogger(__name__)
 
@@ -298,7 +313,7 @@ class VisibilityModel:
             str(fds_dir), sign_descriptors, time_step_s, slice_height_m
         )
 
-        self._vis: _VisMapCache = _resolve_vis(
+        self._vis: _VisBackend = _resolve_vis(
             str(fds_dir),
             sign_descriptors,
             time_step_s,
@@ -351,6 +366,12 @@ class VisibilityModel:
         min_x, min_y, max_x, max_y = walkable.bounds
         x_coords = np.arange(min_x + cell_size_m / 2, max_x, cell_size_m)
         y_coords = np.arange(min_y + cell_size_m / 2, max_y, cell_size_m)
+        if x_coords.size < 2 or y_coords.size < 2:
+            raise ValueError(
+                f"walkable bounds {tuple(round(b, 2) for b in walkable.bounds)} "
+                f"span fewer than two cells at cell_size_m={cell_size_m}; "
+                "shrink the cell size or check the geometry"
+            )
 
         vis = VisMap()
         vis.set_grid(x_coords, y_coords)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ Repository = "https://github.com/PedestrianDynamics/pyFDS-Evac"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
+[tool.hatch.metadata]
+# Required while fdsvismap is pinned to a git branch (see the dependency
+# comment); remove together with the pin once a release is out.
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["pyfds_evac"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,11 @@ dependencies = [
     "nbformat>=4.2.0",
     "matplotlib",
     "shapely",
-    "fdsvismap>=0.1.3",
+    # Pinned to the branch adding set_grid()/set_uniform_extco(), which lets a
+    # scene with geometry but no fire be evaluated by fdsvismap itself instead
+    # of being approximated here. Repoint at a release once it lands:
+    # https://github.com/FireDynamics/fdsvismap/pull/41
+    "fdsvismap @ git+https://github.com/FireDynamics/fdsvismap.git@feat/synthetic-clear-air-grid",
     "numpy>=1.26.4",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     # scene with geometry but no fire be evaluated by fdsvismap itself instead
     # of being approximated here. Repoint at a release once it lands:
     # https://github.com/FireDynamics/fdsvismap/pull/41
-    "fdsvismap @ git+https://github.com/FireDynamics/fdsvismap.git@feat/synthetic-clear-air-grid",
+    "fdsvismap @ git+https://github.com/FireDynamics/fdsvismap.git@64d9aa73144b3902bdc6d2cdd1a08e3494ec5690",
     "numpy>=1.26.4",
 ]
 

--- a/scripts/animate_cognitive_map.py
+++ b/scripts/animate_cognitive_map.py
@@ -11,19 +11,12 @@ bug would live.
 
 Clear-air visibility
 --------------------
-The real :class:`~pyfds_evac.core.visibility.VisibilityModel` reads FDS output,
-so a deck without a fire cannot build one -- and with ``vis_model=None`` the
-perception step adds nothing (``cognitive_map._expand_visible``), leaving a
-discovery agent's map frozen at its spawn node. :class:`ClearAirVisibility`
-below stands in: it answers the same ``node_is_visible`` question with the two
-terms that survive in clear air -- line of sight against the walkable polygon,
-and the sign's readable half-plane. It is deliberately *not* a substitute for
-fdsvismap's optics; it exercises the map-expansion wiring, and the smoke terms
-it drops are exactly the ones a clear-air deck has none of.
-
-The same surrogate is written twice in the test suite (``OccludingVisMap`` in
-tests/test_blind_spawn_discovery.py, ``VisMapClearAir`` in
-tests/test_cognitive_map_memory.py); consolidating the three is a separate job.
+With ``vis_model=None`` the perception step adds nothing
+(``cognitive_map._expand_visible``), leaving a discovery agent's map frozen at
+its spawn node. A deck with no fire still has geometry and signs, so
+:meth:`VisibilityModel.clear_air` builds the model from those -- fdsvismap's own
+ray casting, view angle and ``max_vis`` handling, with a uniform zero
+extinction field.
 """
 
 from __future__ import annotations
@@ -42,55 +35,16 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.animation import FFMpegWriter, PillowWriter  # noqa: E402
 from shapely import wkt as shapely_wkt  # noqa: E402
-from shapely.geometry import LineString, Point, Polygon  # noqa: E402
+from shapely.geometry import Point, Polygon  # noqa: E402
 
 from pyfds_evac.core import load_scenario, run_scenario  # noqa: E402
 from pyfds_evac.core.route_graph import RerouteConfig, RouteCostConfig  # noqa: E402
-from pyfds_evac.core.visibility import extract_sign_descriptors  # noqa: E402
+from pyfds_evac.core.visibility import (  # noqa: E402
+    VisibilityModel,
+    extract_sign_descriptors,
+)
 
-MAX_VIS_M = 30.0
 UNKNOWN, KNOWN, AGENT = "#c4c4cc", "#d62728", "#5b4fc4"
-
-
-class ClearAirVisibility:
-    """``node_is_visible`` with the terms that survive in clear air.
-
-    A sign is readable when it is within *max_vis*, has unobstructed line of
-    sight across the walkable polygon, and the viewer stands inside its
-    half-plane of readability. Nodes with no descriptor stay unconditionally
-    visible, matching :class:`VisibilityModel`.
-    """
-
-    def __init__(self, signs: dict[str, dict], walkable, max_vis: float = MAX_VIS_M):
-        self._signs = signs
-        self._walkable = walkable
-        self._max_vis = max_vis
-
-    def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
-        del time  # clear air: legibility does not change with time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        sx, sy = float(sign["x"]), float(sign["y"])
-        if math.dist((x, y), (sx, sy)) > self._max_vis:
-            return False
-        if not self._walkable.covers(LineString([(x, y), (sx, sy)])):
-            return False
-        return _within_half_plane(sign.get("alpha"), sx, sy, x, y)
-
-
-def _within_half_plane(alpha, sx: float, sy: float, x: float, y: float) -> bool:
-    """Is the viewer inside the sign's readable half-plane?
-
-    ``alpha`` is a compass bearing in degrees from north, clockwise, pointing
-    at the side the sign can be read from -- the convention documented on
-    :class:`VisibilityModel` (90 = readable from the east). ``None`` means
-    omni-directional, so every viewer passes.
-    """
-    if alpha is None:
-        return True
-    bearing = math.degrees(math.atan2(x - sx, y - sy)) % 360.0
-    return abs((bearing - float(alpha) + 180.0) % 360.0 - 180.0) <= 90.0
 
 
 def inward_alpha(exit_polygon: Polygon, interior_point) -> float:
@@ -157,7 +111,7 @@ def build_variant(deck: Path, out: Path, familiarity: float) -> tuple[Path, dict
 def run(bundle: Path, seed: int, sqlite_out: Path):
     scenario = load_scenario(str(bundle))
     walkable = shapely_wkt.loads((bundle / "geometry.wkt").read_text().strip())
-    vis = ClearAirVisibility(extract_sign_descriptors(scenario.raw), walkable)
+    vis = VisibilityModel.clear_air(walkable, extract_sign_descriptors(scenario.raw))
     result = run_scenario(
         scenario,
         seed=seed,

--- a/scripts/generate_cognitive_map_states.py
+++ b/scripts/generate_cognitive_map_states.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import json
-import math
 from pathlib import Path
 
 import matplotlib
@@ -28,6 +27,7 @@ import matplotlib
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt  # noqa: E402
 from matplotlib.patches import Rectangle  # noqa: E402
+from shapely import wkt as shapely_wkt  # noqa: E402
 from shapely.geometry import Polygon  # noqa: E402
 
 from pyfds_evac.core.cognitive_map import (  # noqa: E402
@@ -40,6 +40,7 @@ from pyfds_evac.core.route_graph import (  # noqa: E402
     rank_routes,
 )
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField  # noqa: E402
+from pyfds_evac.core.visibility import VisibilityModel  # noqa: E402
 
 ASSET = Path("assets/cognitive_map_memory")
 MAX_VIS_M = 30.0
@@ -56,29 +57,6 @@ def _builder():
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-
-class VisMapClearAir:
-    """fdsvismap's clear-air rule, mirrored so the plot needs no FDS run."""
-
-    def __init__(self, signs):
-        self._signs = signs
-
-    def node_is_visible(self, time, x, y, node_id):
-        del time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        dx, dy = x - float(sign["x"]), y - float(sign["y"])
-        d = math.hypot(dx, dy)
-        if d == 0.0:
-            return True
-        alpha = sign.get("alpha")
-        if alpha is None:
-            return MAX_VIS_M >= d
-        a = math.radians(float(alpha))
-        view = min(1.0, max(0.0, (math.sin(a) * dx + math.cos(a) * dy) / d))
-        return view * MAX_VIS_M >= d
 
 
 def _load():
@@ -99,7 +77,8 @@ def _load():
 def main(out_path: Path) -> None:
     builder = _builder()
     graph, signs, _raw = _load()
-    vis = VisMapClearAir(signs)
+    walkable = shapely_wkt.loads((ASSET / "geometry.wkt").read_text().strip())
+    vis = VisibilityModel.clear_air(walkable, signs, cell_size_m=0.25)
 
     walkable = builder.CORRIDOR
     frames_y = [4.0, 10.0, 14.0, 20.0, 26.0, 30.0]

--- a/tests/test_blind_spawn_discovery.py
+++ b/tests/test_blind_spawn_discovery.py
@@ -13,9 +13,10 @@ that can hide them:
 
     view_angle * visibility * non_concealed >= distance
 
-``OccludingVisMap`` below reimplements that term on the walkable polygon, the
-same way ``VisMapClearAir`` in ``test_cognitive_map_memory.py`` reimplements the
-view-angle term.  No FDS output is needed.
+``VisibilityModel.clear_air`` supplies that term: fdsvismap evaluates the scene
+from the walkable polygon and a uniform zero extinction field, so the ray
+casting is the library's own rather than a local approximation.  No FDS output
+is needed.
 """
 
 from __future__ import annotations
@@ -28,7 +29,7 @@ from pathlib import Path
 
 import pytest
 from shapely import wkt as shapely_wkt
-from shapely.geometry import LineString, Polygon
+from shapely.geometry import Polygon
 
 from pyfds_evac.core.cognitive_map import (
     cognitive_subgraph,
@@ -38,34 +39,15 @@ from pyfds_evac.core.cognitive_map import (
 )
 from pyfds_evac.core.route_graph import RouteCostConfig, StageGraph, rank_routes
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField
+from pyfds_evac.core.visibility import VisibilityModel
 
 ASSET = Path("assets/blind_spawn_discovery")
+# Below the ~0.4 m walls of this asset: a cell blocks sight when its centre is
+# outside the walkable area, so at the 0.5 m default these walls fall between
+# centres and stop occluding anything -- which is the premise of the whole file.
+CELL_SIZE_M = 0.25
 MAX_VIS_M = 30.0
 SPAWN = "jps-distributions_0"
-
-
-class OccludingVisMap:
-    """Clear-air legibility including the line-of-sight mask.
-
-    ``view_angle`` is 1 for every sign in this asset (all omni-directional) and
-    ``visibility`` is ``max_vis`` in clear air, so the rule reduces to
-    "within 30 m and not behind a wall".
-    """
-
-    def __init__(self, signs: dict[str, dict], walkable, max_vis: float = MAX_VIS_M):
-        self._signs = signs
-        self._walkable = walkable
-        self._max_vis = max_vis
-
-    def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
-        del time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        target = (float(sign["x"]), float(sign["y"]))
-        if math.dist((x, y), target) > self._max_vis:
-            return False
-        return self._walkable.covers(LineString([(x, y), target]))
 
 
 def _builder():
@@ -107,7 +89,12 @@ def _load(variant: str = "discovery"):
         centroid = Polygon(value["coordinates"]).centroid
         # What _default_sign() synthesises for a crossing: omni-directional.
         signs[key] = {"x": centroid.x, "y": centroid.y, "c": 3}
-    return raw, graph, OccludingVisMap(signs, walkable), walkable
+    return (
+        raw,
+        graph,
+        VisibilityModel.clear_air(walkable, signs, cell_size_m=CELL_SIZE_M),
+        walkable,
+    )
 
 
 def _spawn_xy(graph):
@@ -174,8 +161,10 @@ class TestThePremise:
         """
         _, graph, _, walkable = _load()
         signs = {"E_west": {"x": 6.0, "y": 29.0, "c": 3}}
-        open_plan = OccludingVisMap(signs, walkable.envelope)
-        walled = OccludingVisMap(signs, walkable)
+        open_plan = VisibilityModel.clear_air(
+            walkable.envelope, signs, cell_size_m=CELL_SIZE_M
+        )
+        walled = VisibilityModel.clear_air(walkable, signs, cell_size_m=CELL_SIZE_M)
         x, y = _spawn_xy(graph)
         assert open_plan.node_is_visible(0.0, x, y, "E_west")
         assert not walled.node_is_visible(0.0, x, y, "E_west")

--- a/tests/test_cognitive_map_history.py
+++ b/tests/test_cognitive_map_history.py
@@ -10,43 +10,18 @@ only ever grows, and a ``full`` agent knows everything from the first frame.
 from __future__ import annotations
 
 import json
-import math
 import shutil
 from pathlib import Path
 
 import pytest
 from shapely import wkt as shapely_wkt
-from shapely.geometry import LineString
 
 from pyfds_evac.core import load_scenario, run_scenario
 from pyfds_evac.core.route_graph import RerouteConfig, RouteCostConfig
-from pyfds_evac.core.visibility import extract_sign_descriptors
+from pyfds_evac.core.visibility import VisibilityModel, extract_sign_descriptors
 
 ASSET = Path("assets/blind_spawn_discovery")
 MAX_VIS_M = 30.0
-
-
-class ClearAirVisMap:
-    """``node_is_visible`` reduced to line of sight, as in clear air.
-
-    Mirrors ``OccludingVisMap`` in test_blind_spawn_discovery: without it a
-    discovery agent perceives nothing (``cognitive_map._expand_visible`` returns
-    early when ``vis_model is None``) and the history has nothing to show.
-    """
-
-    def __init__(self, signs: dict[str, dict], walkable):
-        self._signs = signs
-        self._walkable = walkable
-
-    def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
-        del time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        target = (float(sign["x"]), float(sign["y"]))
-        if math.dist((x, y), target) > MAX_VIS_M:
-            return False
-        return self._walkable.covers(LineString([(x, y), target]))
 
 
 def _bundle(tmp_path: Path, variant: str) -> Path:
@@ -63,7 +38,9 @@ def _run(bundle: Path, *, collect: bool, with_vis: bool):
     vis = None
     if with_vis:
         walkable = shapely_wkt.loads((bundle / "geometry.wkt").read_text().strip())
-        vis = ClearAirVisMap(extract_sign_descriptors(scenario.raw), walkable)
+        vis = VisibilityModel.clear_air(
+            walkable, extract_sign_descriptors(scenario.raw), cell_size_m=0.25
+        )
     return run_scenario(
         scenario,
         seed=420,

--- a/tests/test_cognitive_map_memory.py
+++ b/tests/test_cognitive_map_memory.py
@@ -14,7 +14,7 @@ Persistence is the one that matters.  Delete the expansion rules and
 acquisition still appears to work for any agent that happens to start inside
 the band; only persistence catches it.
 
-No FDS output is needed: ``VisMapClearAir`` reimplements fdsvismap's clear-air
+No FDS output is needed: ``VisibilityModel.clear_air`` drives fdsvismap's own
 rule so the test exercises our map and routing rather than the third-party
 solver.
 """
@@ -22,10 +22,10 @@ solver.
 from __future__ import annotations
 
 import json
-import math
 from pathlib import Path
 
 import pytest
+from shapely import wkt as shapely_wkt
 from shapely.geometry import Polygon
 
 from pyfds_evac.core.cognitive_map import (
@@ -34,37 +34,14 @@ from pyfds_evac.core.cognitive_map import (
 )
 from pyfds_evac.core.route_graph import RouteCostConfig, StageGraph, rank_routes
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField
+from pyfds_evac.core.visibility import VisibilityModel
 
 ASSET = Path("assets/cognitive_map_memory")
+# The corridor is open, so this only has to be fine enough to keep the walls
+# from swallowing it; see VisibilityModel.clear_air on why it matters.
+CELL_SIZE_M = 0.25
 MAX_VIS_M = 30.0
 CENTRELINE_X = 2.0
-
-
-class VisMapClearAir:
-    """fdsvismap's clear-air legibility rule: view_angle * max_vis >= distance."""
-
-    def __init__(self, signs: dict[str, dict], max_vis: float = MAX_VIS_M):
-        self._signs = signs
-        self._max_vis = max_vis
-
-    def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
-        del time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        dx, dy = x - float(sign["x"]), y - float(sign["y"])
-        distance = math.hypot(dx, dy)
-        if distance == 0.0:
-            return True
-        alpha = sign.get("alpha")
-        if alpha is None:
-            view_angle = 1.0
-        else:
-            a = math.radians(float(alpha))
-            view_angle = min(
-                1.0, max(0.0, (math.sin(a) * dx + math.cos(a) * dy) / distance)
-            )
-        return view_angle * self._max_vis >= distance
 
 
 def _load():
@@ -82,7 +59,9 @@ def _load():
     )
     signs = {eid: data["sign"] for eid, data in raw["exits"].items()}
     spawn = Polygon(next(iter(distributions.values()))["coordinates"]).centroid
-    return graph, (spawn.x, spawn.y), VisMapClearAir(signs)
+    walkable = shapely_wkt.loads((ASSET / "geometry.wkt").read_text().strip())
+    vis = VisibilityModel.clear_air(walkable, signs, cell_size_m=CELL_SIZE_M)
+    return graph, (spawn.x, spawn.y), vis
 
 
 def _walk(y_positions):

--- a/tests/test_exit_visibility_alpha.py
+++ b/tests/test_exit_visibility_alpha.py
@@ -11,7 +11,7 @@ That is why the agents are ``discovery`` tier: a ``full`` agent knows every
 exit from t=0 and would walk to the near one under either bearing -- correctly,
 since it does not need to read a sign to find a door it already knows.
 
-No FDS output is needed.  ``VisMapClearAir`` below reimplements the rule
+No FDS output is needed.  ``VisibilityModel.clear_air`` drives fdsvismap itself
 fdsvismap applies in clear air, so the test exercises our routing decision
 rather than the third-party visibility solver.
 """
@@ -23,60 +23,22 @@ import math
 from pathlib import Path
 
 import pytest
+from shapely import wkt as shapely_wkt
 from shapely.geometry import Polygon
 
 from pyfds_evac.core.cognitive_map import init_cognitive_map
 from pyfds_evac.core.route_graph import RouteCostConfig, StageGraph, rank_routes
 from pyfds_evac.core.smoke_speed import ConstantExtinctionField
+from pyfds_evac.core.visibility import VisibilityModel
 
 ASSET = Path("assets/exit_visibility_alpha")
 
 
 # fdsvismap's clear-air visibility distance saturates at this default.
 MAX_VIS_M = 30.0
-
-
-class VisMapClearAir:
-    """fdsvismap's legibility rule, in clear air.
-
-    ``FDSVisMap.get_vismap`` decides
-
-        view_angle * visibility * non_concealed >= distance
-
-    where ``view_angle`` is
-    ``clip((sin(alpha)*dx + cos(alpha)*dy) / distance, 0, 1)`` for a signed
-    waypoint (1.0 when omni-directional), and ``visibility`` is the
-    smoke-limited sight distance capped at ``max_vis``.  With no smoke that cap
-    binds, so the rule reduces to ``view_angle * max_vis >= distance``.
-
-    Modelling the distance comparison matters, not just the half-plane: a sign
-    beyond ``max_vis`` is illegible at every bearing, which would quietly turn
-    the experiment into "neither exit is visible".
-    """
-
-    def __init__(self, signs: dict[str, dict], max_vis: float = MAX_VIS_M):
-        self._signs = signs
-        self._max_vis = max_vis
-
-    def view_angle(self, x: float, y: float, node_id: str) -> float:
-        sign = self._signs.get(node_id)
-        if sign is None or sign.get("alpha") is None:
-            return 1.0  # omni-directional or unsigned
-        dx, dy = x - float(sign["x"]), y - float(sign["y"])
-        distance = math.hypot(dx, dy)
-        if distance == 0.0:
-            return 1.0
-        alpha = math.radians(float(sign["alpha"]))
-        projection = math.sin(alpha) * dx + math.cos(alpha) * dy
-        return min(1.0, max(0.0, projection / distance))
-
-    def node_is_visible(self, time: float, x: float, y: float, node_id: str) -> bool:
-        del time
-        sign = self._signs.get(node_id)
-        if sign is None:
-            return True
-        distance = math.hypot(x - float(sign["x"]), y - float(sign["y"]))
-        return self.view_angle(x, y, node_id) * self._max_vis >= distance
+# Fine enough that this asset's walls still occlude; see
+# VisibilityModel.clear_air on why the rasterisation resolution matters.
+CELL_SIZE_M = 0.25
 
 
 def _load(config_name: str):
@@ -99,7 +61,9 @@ def _load(config_name: str):
     )
     signs = {eid: data["sign"] for eid, data in raw["exits"].items()}
     spawn = Polygon(next(iter(distributions.values()))["coordinates"]).centroid
-    return graph, (spawn.x, spawn.y), VisMapClearAir(signs)
+    walkable = shapely_wkt.loads((ASSET / "geometry.wkt").read_text().strip())
+    vis = VisibilityModel.clear_air(walkable, signs, cell_size_m=CELL_SIZE_M)
+    return graph, (spawn.x, spawn.y), vis
 
 
 def _known_exits(config_name: str) -> set[str]:
@@ -185,13 +149,16 @@ class TestAssetIsSingleVariable:
         reinstate the least-cost rejected route, and agents would take E_near
         regardless -- an experiment that proves nothing while appearing to pass.
         """
+        raw = json.loads((ASSET / "config_visible.json").read_text(encoding="utf-8"))
         _, position, vis_model = _load("config_visible")
         px, py = position
         for node_id in ("E_near", "E_far"):
-            sign = vis_model._signs[node_id]
+            sign = raw["exits"][node_id]["sign"]
             distance = math.hypot(px - sign["x"], py - sign["y"])
             assert distance < MAX_VIS_M, node_id
-            assert vis_model.view_angle(px, py, node_id) * MAX_VIS_M >= distance
+            # Legible in the reference config, so the hidden run's rejections
+            # can only come from the bearing it changes.
+            assert vis_model.node_is_visible(0.0, px, py, node_id), node_id
 
 
 class TestExitChoiceFollowsLegibility:

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 [[package]]
 name = "fdsvismap"
 version = "0.2.1"
-source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#c9b7c6d34d0aab688ea76dc8e212b56606472ca4" }
+source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#7076df45ceb6caa6d0729c236a81e39d65f15616" }
 dependencies = [
     { name = "fdsreader" },
     { name = "matplotlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 [[package]]
 name = "fdsvismap"
 version = "0.2.1"
-source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#7076df45ceb6caa6d0729c236a81e39d65f15616" }
+source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#64d9aa73144b3902bdc6d2cdd1a08e3494ec5690" }
 dependencies = [
     { name = "fdsreader" },
     { name = "matplotlib" },

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 [[package]]
 name = "fdsvismap"
 version = "0.2.1"
-source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#64d9aa73144b3902bdc6d2cdd1a08e3494ec5690" }
+source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=64d9aa73144b3902bdc6d2cdd1a08e3494ec5690#64d9aa73144b3902bdc6d2cdd1a08e3494ec5690" }
 dependencies = [
     { name = "fdsreader" },
     { name = "matplotlib" },
@@ -1078,7 +1078,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fdsreader" },
-    { name = "fdsvismap", git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid" },
+    { name = "fdsvismap", git = "https://github.com/FireDynamics/fdsvismap.git?rev=64d9aa73144b3902bdc6d2cdd1a08e3494ec5690" },
     { name = "jupedsim", specifier = ">=1.4.2" },
     { name = "matplotlib" },
     { name = "monsterui", marker = "extra == 'gui'" },

--- a/uv.lock
+++ b/uv.lock
@@ -293,7 +293,7 @@ wheels = [
 [[package]]
 name = "fdsvismap"
 version = "0.2.1"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid#c9b7c6d34d0aab688ea76dc8e212b56606472ca4" }
 dependencies = [
     { name = "fdsreader" },
     { name = "matplotlib" },
@@ -303,10 +303,6 @@ dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "sphinx-rtd-theme" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/a9/f19afbe4bcb783f5d5ca839cee7310527784a5655883fc0083d60f67f6cd/fdsvismap-0.2.1.tar.gz", hash = "sha256:97baaad98b56f795319e01aba1b66e13840bd44769c4fc16fa8ffbae2639f2c3", size = 19744, upload-time = "2026-04-08T19:38:32.737Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/a3/3834cfb993c34caa009782d90894257bbc125f2fe8e467dc698e99aa279a/fdsvismap-0.2.1-py3-none-any.whl", hash = "sha256:f3620538975e82c5d1b2c71081ebe77f13dc7d5fdccffb4cc8715720071d243d", size = 16053, upload-time = "2026-04-08T19:38:31.727Z" },
 ]
 
 [[package]]
@@ -1082,7 +1078,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fdsreader" },
-    { name = "fdsvismap", specifier = ">=0.1.3" },
+    { name = "fdsvismap", git = "https://github.com/FireDynamics/fdsvismap.git?rev=feat%2Fsynthetic-clear-air-grid" },
     { name = "jupedsim", specifier = ">=1.4.2" },
     { name = "matplotlib" },
     { name = "monsterui", marker = "extra == 'gui'" },


### PR DESCRIPTION
Two changes, found by trying to answer one question: does smoke change where a
discovery agent goes?

## Running without FDS data was not clear air

`run.py` offered two settings — no visibility model, or the FDS one — and the
first was being read as "the same scenario without a fire". It is not. With no
model, `expand_on_arrival` reveals **every** neighbour of a node the agent
reaches, so the agent learns the building by contact. Clear air still gates
sight on walls, sign facing and contrast; `VisibilityModel.clear_air` exists for
exactly this and takes `extinction_per_m=0.0`, running the same ray casting a
fire scene gets over an empty field.

On `assets/world_100`, one agent, `familiarity = 0`:

| run | evacuation | route switches |
|---|---|---|
| no visibility model | 58.5 s | 0 |
| clear-air visibility | 188.8 s | 31 (29 explore) |
| FDS smoke | 180.8 s | 30 |

Reading row 3 against row 1 — which is what the flags invited, and what I did
first — attributes a 3x gap to smoke when nearly all of it is the difference
between seeing and touching. Rows 2 and 3 are the honest comparison, and they
say the smoke did almost nothing.

So a deck with discovery agents now gets a model either way: FDS when
`--fds-dir` is given, clear air otherwise. Fully-familiar decks still get none —
such an agent holds the whole graph at t=0 and never consults it.

| invocation | model |
|---|---|
| *(nothing, discovery deck)* | clear air |
| *(nothing, all-familiar deck)* | none |
| `--vis-cache PATH` | clear air, cached |
| `--fds-dir D --vis-cache P` | smoke from FDS |
| `--clear-air-visibility` | clear air, forced onto a familiar deck |
| `--no-visibility` | none — learning by contact, explicit |

Details worth review: discovery detection reuses `familiarity_probability` so
`"full"`, `"discovery"` and numbers are read as the engine reads them;
`--vis-cache` no longer requires `--fds-dir`, and the clear-air grid is keyed on
a hash of the walkable WKT plus signs, cell size and extinction, so a geometry
edit invalidates it (a repeat `world_77` run drops to 1.4 s); and
`--clear-air-visibility` with `--fds-dir` is rejected, since claiming clear
sight in a fire is the one combination that silently produces a wrong answer.

563 tests pass. Suite time 68 s → 101 s, which is the grid builds.

## Fires you can place, and a world small enough to burn

`wkt_to_fds` always put its burner at the walkable representative point — a
placeholder, when where a fire starts decides which routes it cuts. `--fire-xy`
places it and refuses a footprint that does not fit inside the walkable area.
`--meshes NX NY` splits the domain, because FDS parallelises over meshes and
nothing else; `world_100` at dx=0.25 becomes 8 meshes of 151×51×12 and runs in
33 minutes rather than a day.

`world_77` is the same generator at `--room-scale 0.6`: 21.9 × 14.8 m against
`world_100`'s 74.8 × 50.4, so 0.31M cells and minutes rather than half an hour.
`--hide-exits` fails on most seeds at that scale — a small room holds too few
obstacles to block every sightline from the spawn.

Both decks carry the `.fds` they were burned with and are set to one agent at
familiarity 0. FDS output stays in sciebo under `fds-evac-data/`.

## What the fires did to the routing: nothing, for reasons the numbers give

`world_77`'s agent passes 1.6 m from its burner at t=12.3 s and is out at
14.8 s, before the plume spreads two metres — it samples 0.000 /m and the run is
identical to clear air. `world_100`'s fire sits away from the corridor its agent
explores: 0.122 /m peak on the path, 181 s against 189 s.

Both fires burn properly (1.1–1.9 /m directly above the burner), so this is
about timing and scale, not the coupling. Making smoke bite wants a premovement
delay so the walk happens after the layer forms, or a fire an order of magnitude
larger.
