### PR TITLE
docs: bring the documentation in line with the shipped model

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,9 +386,28 @@ sort (`current_exit_discount`, 0.9, FDS+Evac's `FAC_DOOR_OLD2`).
 no agent returning to an exit it abandoned -- the outcome the model exists to
 produce. On `l_corridor` it **regressed**: returns to abandoned exits went from
 0 to 51 and then to 34 across 14 agents, with switches 4 -> 74 -> 55 and the
-far-exit share unchanged at about 18. The cause is open -- the ordering is in
-`tau` and the exit-switch anchor compares travel time, so the two can disagree.
+far-exit share unchanged at about 18. The cause is **not** a currency mismatch
+between the `tau` ordering and the anchor's time fallthrough, which was the
+earlier reading: 29 of the 34 returns go to a route cleaner by more than the
+deadband, and 31 fall in `t = 40-60 s` where the two routes' `tau` genuinely
+cross over. The model is following a field that reverses, and no constant damps
+that -- what is missing is commitment
+([#124](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/124)).
 See [docs/route-cost-gate.md](docs/route-cost-gate.md#known-limitations).
+
+**This is a departure from FDS+Evac, not a reproduction of it.** The threshold
+`tau > 6` is borrowed with a citation; the *place* it is used is not. In the
+reference's first three tiers the rank is a time or distance norm and smoke is
+only a boolean admission test (`evac.f90:16265, :16354, :16401`), so smoke can
+move a door between tiers but cannot reorder candidates. It ranks on smoke only
+in the tier-4 last resort, over known-or-visible doors, on a bee line, with
+permanent strike-out. Here `tau` is the ordering everywhere, with no memory.
+On `l_corridor` that diverts 18 of 100 agents where the reference criterion
+would send essentially everyone to the near exit -- a prediction reasoned from
+`evac.f90`, not a measured run of it. A `L/d` geometric bias (1.41 near against
+1.27 far on that deck) tilts the criterion about 11 % further in the same
+direction. Both are written up in
+[docs/route-cost-gate.md](docs/route-cost-gate.md#the-diversion-is-a-departure-from-fdsevac-not-a-reproduction-of-it).
 
 An optional **clean-exit tier** (`clean_extinction_threshold`, **off by
 default**) prefers exits below an absolute smoke criterion outright, however
@@ -459,8 +478,10 @@ that consume the generated route-cost CSVs.
 ## Visibility-aware routing and cognitive maps
 
 Implements [Spec 008](specs/008-visibility-aware-routing/SPEC.md): sign
-visibility gates route rejection and per-agent cognitive maps control what
-knowledge each agent has about the building layout.
+visibility gates what each agent comes to *know*, and per-agent cognitive maps
+carry that knowledge into routing. (The spec's original design also had sign
+visibility reject routes directly; that second gate has since been removed --
+see below.)
 
 ### Sign visibility (Phase 1)
 
@@ -485,10 +506,20 @@ Every exit, checkpoint and waypoint gets a sign: nodes without an authored
 `alpha=None`, i.e. omni-directional). A node is never exempt from
 visibility gating for lack of an authored sign.
 
-At each reevaluation tick the `VisibilityModel` checks whether an agent
-can see the next node's sign using a cached [fdsvismap](https://github.com/FireDynamics/fdsvismap)
-pickle. If the sign is not visible, the route is rejected with
-`rejection_reason="next_node_not_visible"`.
+At each reevaluation tick the `VisibilityModel` checks whether an agent can see
+a node's sign, using a cached
+[fdsvismap](https://github.com/FireDynamics/fdsvismap) grid.
+
+**Sign legibility decides what an agent *knows*, not whether a route is
+allowed.** A sign it can see admits that node to the agent's cognitive map
+(`cognitive_map.expand_from_visibility`), and the map is what Dijkstra may route
+over -- so an unknown exit is *absent from the graph* rather than
+present-and-vetoed. Route choice does not consult the visibility model at all.
+An earlier version also re-checked sign visibility inside `rank_routes` and
+rejected the route with `rejection_reason="next_node_not_visible"`; that
+double-gated the same criterion, blocked agents who already knew the building,
+and forbade an agent from using an exit it had legitimately learned once the
+sign went out of view. That check and that reason string are gone.
 
 ```bash
 # Build or reuse the vismap cache and enable visibility-gated rejection
@@ -501,8 +532,9 @@ uv run run.py \
   --cleanup
 ```
 
-Rejected routes are recorded in the route-cost CSV with
-`rejected=True, rejection_reason=next_node_not_visible`.
+Under the gate the only rejection reasons a route-cost CSV carries are `tau ...`
+(optical depth over budget), `FED_max ...` (dose over threshold), and either of
+those under a `fallback:` prefix.
 
 #### Which visibility setting am I running?
 
@@ -561,6 +593,18 @@ know at the start of the simulation:
 | Trained staff | `"full"` | Complete stage graph | — |
 | Visitors | `"discovery"` | Spawn node + visible neighbors | On arrival + at reevaluation |
 
+**The tier limits topology, not perception of smoke.** A `discovery` agent does
+not know the building — it routes only over its cognitive subgraph and learns
+nodes through the perception-limited `VisibilityModel`. It *does* know the smoke
+field: to choose among the exits it knows, it integrates `tau = K_ave * L` over
+the whole remaining route, including legs it has never visited, and with
+`anticipate = True` and `foresight_horizon_s = inf` at times that have not
+happened. So route choice is an **optimality bound over the agent's known
+subgraph**, not a behavioural model — map growth, exploration order and wander
+behaviour are unaffected, but nothing here licenses the claim that a discovery
+agent's *route choice* is perception-limited. Open as
+[#125](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/125).
+
 Set per distribution group in the scenario config:
 
 ```json
@@ -575,8 +619,12 @@ Set per distribution group in the scenario config:
 }
 ```
 
-Without a visibility model — which requires `--vis-cache`, and therefore
-`--fds-dir` — the perception step adds nothing, so a `discovery` agent starts
+A deck with discovery agents gets a visibility model either way — from the FDS
+extinction field when `--fds-dir` is given, from clear air otherwise (see the
+table above) — because sight is gated by geometry, sign facing and contrast
+whether or not there is a fire. Running with no model at all is what
+`--no-visibility` asks for. Without a model the perception step adds nothing, so
+a `discovery` agent starts
 out knowing only its spawn node, its `entrance`, and whatever the familiarity
 draw gave it. Graph adjacency is not used as a stand-in for line of sight:
 with no `transitions` declared the graph is auto-wired from every spawn area to

--- a/docs/model-comparison.md
+++ b/docs/model-comparison.md
@@ -168,10 +168,46 @@ strikes the door out ("too much smoke"), and `L2_tmp < L2_min` picks
 the winner among those left.  The criterion vetoes *and* ranks, with
 `FAC_DOOR_OLD2 = 0.9` favouring the door already targeted.
 
-pyFDS-Evac splits those jobs.  Dose and sight both veto — dose when
-`fed_max_route` exceeds `fed_rejection_threshold`, sight on the rule
-above — and neither ranks; travel time ranks the survivors.  It also
-applies both criteria at once rather than choosing one by a sign.
+pyFDS-Evac splits those jobs differently.  Dose vetoes only: a route above
+`fed_rejection_threshold` is removed and dose never makes one exit outrank
+another.  Optical depth does both, as in tier 4 — it refuses a route above
+`tau_max` *and* orders the survivors, with travel time breaking ties.  It also
+applies dose and smoke at once rather than choosing one by a sign.
+
+#### Where the quantity is used: the decisive difference
+
+The threshold `tau > 6` is borrowed from tier 4 with a citation.  **The place
+the quantity is used is not**, and that is what changes the behaviour.
+
+In FDS+Evac's first three tiers the rank is `T_tmp` — a time in tier 1 when
+`FAC_DOOR_QUEUE` is active, a plain L2 or L1 distance norm otherwise — while
+`K_ave_Door` appears only as a boolean admission test:
+
+```fortran
+IF (T_tmp < L2_min .AND. L2_tmp < ABS(FED_DOOR_CRIT)) THEN   ! :16265, :16354, :16401
+```
+
+A change in the smoke field can move a door between tiers or out of the admitted
+set, but it cannot reorder the doors inside a tier — and geometry does not
+reorder itself.  Smoke enters the ordering only in the **tier-4 last resort**
+(`IF (L2_tmp < L2_min)`, `:16467`), reached once no smoke-free door is available,
+looping only over doors already known or visible, scoring a bee-line or L1
+distance, and striking a refused door out permanently (`:16463-16465`).
+
+pyFDS-Evac promotes that last-resort ranking criterion to its primary one, over
+all candidates, at every tick, on the walked polyline, and drops the permanent
+strike-out that makes it stable in the reference.  Measured consequence on
+`assets/l_corridor`: this model diverts **18 of 100** agents to the longer,
+cleaner route, where the reference criterion — distance ranking, both doors
+clearing the 0.03 /m admission test until the smoke is well developed — would
+send essentially everyone to the near exit, roughly 100/0.  **That 100/0 is a
+prediction reasoned from `evac.f90`, not a measured run of FDS+Evac**; the
+deck's own additive model is the nearest empirical proxy and does evacuate
+100/0.  The diversion is a deliberate departure, and stands or falls on its own
+merits.  See
+[route-cost-gate.md](route-cost-gate.md#the-diversion-is-a-departure-from-fdsevac-not-a-reproduction-of-it)
+for the accompanying `L/d` geometric bias (1.41 near against 1.27 far on that
+deck).
 
 ### pyFDS-Evac
 
@@ -240,9 +276,9 @@ group.
 | **Cost function** | `T_i = beta_k * lambda_i + tau_i` (queueing + walking time) [9] Eq. 6 | gate: route optical depth `K_ave * L`, with travel time (+ `w_queue` x queue time) as tie-break; additive: `length * (1 + w_smoke * K) + w_fed * FED` |
 | **Smoke test on a door** | Absolute `K_ave < 0.03 /m` (`FED_DOOR_CRIT`, evac.f90:1459, :5262, :16149); the `0.5 x d` visibility rule is the tier-4 last resort (:16463), where `L2_tmp = d * 0.5 / (3/K_ave) >= 1` is exactly `K_ave * d > 6` | Optical depth `K_ave * L <= 6`, the same threshold, but applied to the walked polyline rather than a straight sight line; x 0.8 budget for a rival exit; no absolute `K` door criterion. It vetoes *and* ranks |
 | **Congestion** | Modelled: queueing time depends on count of closer agents heading to same exit | Optional (`w_queue`), off by default; a global tally of agents targeting the exit |
-| **Familiarity** | Per-agent per-exit familiarity (user-configurable, constrains feasible exit set) | Per-agent cognitive map: an agent can only route over stages it knows or has discovered |
+| **Familiarity** | Per-agent per-exit familiarity (user-configurable, constrains feasible exit set) | Per-agent cognitive map: an agent can only route over stages it knows or has discovered. The restriction is on *topology* only — smoke is sampled globally, so a discovery agent's route choice is not perception-limited ([#125](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/125)) |
 | **Social behaviour** | Herding and follower agent types observe neighbours | Not modelled |
-| **Smoke in cost** | Binary: disturbing conditions at exit affect preference group, but extinction is not a continuous term in the cost function | gate: availability *and* ordering, both on route optical depth; additive: continuous weighted term |
+| **Smoke in cost** | Admission only in tiers 1–3 (`K_ave_Door < 0.03 /m`, the rank stays `T_tmp`); smoke ranks doors only in the tier-4 last resort (`:16467`), over known-or-visible doors, with permanent strike-out | gate: availability *and* ordering, both on route optical depth, for every candidate at every tick and with no memory; additive: continuous weighted term |
 | **FED in cost** | Not in cost function; only used for incapacitation at FED >= 1.0 | Veto threshold under both models (never a ranking term); additionally a `w_fed * FED_max` term under additive |
 | **Distance metric** | L2 for visible exits, L1 (Manhattan) for non-visible exits; direct agent-to-exit | Polyline arc length along corridor geometry (via JuPedSim RoutingEngine); routes through intermediate stages |
 | **Anticipation** | `FED_max_Door * dist / Speed`: extrapolation from presently observable conditions | `anticipate` prices each segment at the agent's arrival time from the FDS solution itself — an upper bound on foresight, not FDS+Evac's model |

--- a/docs/route-cost-gate.md
+++ b/docs/route-cost-gate.md
@@ -61,7 +61,7 @@ graph.
 
 ## How the gate decides
 
-> **This page describes `25a6f8f`.**
+> **This page describes `081380b`.**
 
 Per agent, per reevaluation tick:
 
@@ -191,6 +191,112 @@ among doors satisfying `K_ave_Door < ABS(FED_DOOR_CRIT)` = 0.03 /m
 `:5262`). pyFDS-Evac ships that absolute criterion as the opt-in clean-exit tier
 below. See [model-comparison.md](model-comparison.md#the-smoke-criteria-on-a-door).
 
+### The diversion is a departure from FDS+Evac, not a reproduction of it
+
+The threshold is borrowed; **the place the quantity is used is not**, and that
+difference is what produces the diversion the model exists for.
+
+In FDS+Evac's first three tiers the rank is `T_tmp` — a time in tier 1 when
+`FAC_DOOR_QUEUE` is active, a plain L2 or L1 distance norm otherwise — and
+`K_ave_Door` enters only as the boolean admission test
+`L2_tmp < ABS(FED_DOOR_CRIT)`:
+
+```fortran
+IF (T_tmp < L2_min .AND. L2_tmp < ABS(FED_DOOR_CRIT)) THEN   ! :16265, :16354, :16401
+   L2_min = MAX(0.0_EB, T_tmp)
+   i_tmp  = i
+END IF
+```
+
+Smoke can move a door between tiers, or out of the admitted set; it cannot
+reorder the doors inside a tier, and geometry does not reorder itself. Here
+`tau` **is** the ordering, at every tick and for every candidate.
+
+**One qualification, and it matters.** Smoke is not absent from FDS+Evac's
+ordering everywhere: the tier-4 last-resort branch minimises `L2_tmp` directly
+(`IF (L2_tmp < L2_min)`, `:16467`), and under the default `FED_DOOR_CRIT < 0`
+that `L2_tmp` is `tau/6`. So the reference does rank on smoke — but only after
+tiers 1-3 have all failed to find any admitted door, only over doors already
+known or visible, on a bee-line (or L1) distance to the door rather than a
+walked route, and with a door struck out there struck out *permanently*
+(`:16463-16465`). Stated exactly: **pyFDS-Evac promotes FDS+Evac's last-resort
+ranking criterion to its primary one, and drops the memory that makes it stable
+there.** "Smoke never enters FDS+Evac's ordering" is too strong and should not
+be written; "smoke never enters the ordering until every smoke-free tier is
+exhausted" is what the source supports.
+
+**The measured consequence, and what it is not.** On `l_corridor` the model
+diverts 18 of 100 agents to the longer, cleaner route. The reference criterion
+would not: tiers 1-3 rank on distance, both doors clear the `K_ave < 0.03 /m`
+admission test until the smoke is well developed, and the near exit is nearer
+throughout — so essentially every occupant goes near, roughly 100/0. **That
+100/0 is a reasoned prediction from the source, not a measured FDS+Evac run.**
+No run of the reference criterion on this deck exists here. The nearest
+empirical proxy is the deck's own additive model, which also ranks on a
+distance-like composite and does evacuate 100/0 (see [Evidence](#evidence)) —
+a proxy, not the same criterion. The diversion stands or falls on its own
+merits, not on fidelity to the reference.
+
+**A geometric bias rides along with the change of quantity.** FDS+Evac applies
+its threshold to a straight-line `d`; pyFDS-Evac applies it to the walked
+polyline `L`, and `L/d` is not the same on every route. On `l_corridor` from the
+spawn centroid (11.5, 15.0). Both legs are computed corner-to-corner along the
+corridor centreline, which is why they come out a metre under the 26 m / 46 m
+node-to-node figures the [Evidence](#evidence) section quotes — those run
+spawn-polygon to exit-polygon through the graph's own nodes:
+
+| route | walked `L` | bee-line `d` | `L/d` |
+|---|---|---|---|
+| near (exit A, (0, 1.5)) | 25.0 m | 17.7 m | **1.410** |
+| far (exit B, (45, 26.5)) | 45.0 m | 35.4 m | **1.271** |
+
+At equal `K_ave` the polyline form is therefore about 11 % (1.410 / 1.271)
+stricter on the near route than the far one, purely from geometry — a
+systematic tilt toward the diversion that no smoke measurement put there. The
+tilt is against the L2 bee line specifically; against the L1 norm FDS+Evac uses
+for non-visible doors (`:16460`) it vanishes on this deck, because both
+corridors are axis-aligned and the L1 distance equals the polyline exactly. The
+sign and size of the bias on other geometries have not been measured.
+
+### Route choice is an optimality bound, not a perception-limited model
+
+Issue [#125](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/125). Two assumptions
+apply to the same agent on the same tick and point in opposite directions:
+
+- **The cognitive map assumes the agent does not know the building.** A
+  `familiarity = 0` agent routes only over `cognitive_subgraph` and does not
+  know an exit exists until it reads a sign — through `VisibilityModel`, which
+  is genuinely perception-limited (obstruction-aware sight lines, sign facing,
+  extinction along the line).
+- **Route choice assumes the agent knows the smoke field.** To choose among the
+  exits it does know, it integrates `tau = K_ave * L_remaining` over the whole
+  remaining route, including legs it has never visited and corners it cannot see
+  past, and with `anticipate = True` and `foresight_horizon_s = inf` at times
+  that have not happened yet. The extinction sampler is global; the cognitive
+  map never touches it.
+
+These are different kinds of knowledge — topology versus state — so it is not a
+formal contradiction. It is still not a coherent position, and it is sharpest
+exactly where the discovery tier's modelling is most careful.
+
+**What this affects.** *Not* map growth: what an agent learns and when runs
+through `VisibilityModel` alone, so results about map expansion, exploration
+order, wander behaviour and the lost-exit failure mode stand. What it undercuts
+is any claim that a **discovery agent's route choice** is perception-limited. It
+is not.
+
+**So name what the model is.** Route choice here is an **optimality bound**:
+what an evacuee with perfect knowledge of the smoke field would choose *over the
+part of the building it happens to know*. Not "what a perfectly informed
+evacuee would choose" — the topology restriction is real and still binds. That
+bound is a legitimate and useful thing to publish, and the discovery tier
+remains a perception-limited model of *wayfinding*; but the two are different
+claims and only one of them is about smoke.
+
+Nothing is fixed here. `foresight_horizon_s` is the one lever already shipped
+that bounds half of it (the temporal half); it defaults to `inf`. #125 records
+the three options and evaluates none.
+
 ### Two asymmetries favour the exit the agent already walks to
 
 `tau_return_margin` (default 0.8) is a deadband on **feasibility**. The current
@@ -215,9 +321,12 @@ place unless a rival is clearly cleaner rather than momentarily cleaner.
 is applied as `L2_tmp = FAC_DOOR_OLD2 * L2_tmp` to the current door at `:16290`
 and `:16467` — and at `:16467` that `L2_tmp` is the `tau/6` of the tier-4 test,
 i.e. the same quantity, discounted in the same place, inside the loop that
-minimises it to pick a door. Note the shipped code comment in `route_graph.py`
-instead cites `FAC_DOOR_WAIT` at `evac.f90:1503`; `FAC_DOOR_WAIT` is at `:1505`,
-and it discounts the current door's *travel time* (`T_tmp`), not its smoke.
+minimises it to pick a door. The shipped comment on `tau_of` in `route_graph.py`
+cites that provenance correctly since `9508181`; an earlier version cited
+`FAC_DOOR_WAIT`, which is at `:1505` and discounts the current door's *travel
+time* (`T_tmp`), not its smoke. `FAC_DOOR_WAIT` is still the correct citation for
+`exit_switch_anchor` and `_PATH_IMPROVEMENT_THRESHOLD`, which are time
+comparisons, and the code cites it only there.
 
 **A reviewer will ask why both.** They act on different stages — one on the
 feasible set, one on the order within it — but they have not been measured
@@ -539,8 +648,39 @@ Setting them requires constructing `RouteCostConfig` in Python.
 ## Known limitations
 
 These are real and documented, not hypothetical. Details and measurements are
-in [gate-model-review-notes.md](gate-model-review-notes.md).
+in [gate-model-review-notes.md](gate-model-review-notes.md). This section is the
+single consolidated statement; anyone assessing the model should be able to read
+it alone.
 
+**Two open issues carry the unresolved ones.**
+
+- **[#124](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/124) — route
+  choice oscillates at a genuine optical-depth crossover.** `l_corridor`'s 34
+  returns, 31 of them in `t = 40-60 s`, the window in which the two routes' `tau`
+  cross over; at `t = 40 s` their distributions overlap by 61 %. The crossover
+  swings through 1.5-3x and sails past any
+  hysteresis constant that would not also blind the model to real change. What is
+  missing is *commitment* — hysteresis in time or in progress along a leg — not a
+  bigger threshold. Three attempts are already recorded as failures below.
+- **[#125](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/125) — route
+  choice is not perception-limited.** See
+  [Route choice is an optimality bound](#route-choice-is-an-optimality-bound-not-a-perception-limited-model).
+  It bounds what the discovery tier can be said to demonstrate about route
+  choice; it does not touch map growth.
+
+**And the model is a departure, not a reproduction.** `tau` is the ordering here;
+in FDS+Evac smoke ranks only inside the tier-4 last resort, over known-or-visible
+doors, on a bee line, with permanent strike-out. See
+[The diversion is a departure](#the-diversion-is-a-departure-from-fdsevac-not-a-reproduction-of-it).
+The 100/0 attributed to the reference criterion on `l_corridor` is a reasoned
+prediction from `evac.f90`, not a measured run of it.
+
+- **The `L/d` bias tilts the criterion by geometry alone.** `tau` is measured on
+  the walked polyline where the reference measures on a straight line, and
+  `L/d` is 1.41 on `l_corridor`'s near route against 1.27 on the far one — so at
+  equal `K_ave` the polyline form is about 11 % stricter on the near route, in
+  the same direction as the diversion the deck is used to demonstrate. Not
+  measured on any other geometry.
 - **The ordering is in optical depth and the anchor is partly in time.** The
   ordering is `tau`; `_anchor_allows` falls through to `rank_cost`, a travel
   time, whenever the two routes' `tau` are within the deadband. So the two

--- a/docs/routing-and-signs-notes.md
+++ b/docs/routing-and-signs-notes.md
@@ -97,7 +97,11 @@ Symbols used below:
    marked **rejected**. NOTE: FED currently appears twice — as the `w_fed` penalty
    *and* as this hard cut — which is conceptually muddled (see the toxicity notes).
 
-7. **Visibility is a hard reject too** (details in Part 2).
+7. **Visibility is not a reject at all under the gate.** Sign legibility decides
+   what enters the agent's cognitive map, and the map decides what Dijkstra can
+   see — an unknown exit is absent from the graph, not present-and-vetoed. The
+   per-segment `all segments non-visible` reject survives under `"additive"`
+   only. Details in Part 2, points 5 and 7.
 
 8. **Routes are sorted; the agent takes the best.**
    Sort key (`route_graph.py:1322`), additive:
@@ -241,10 +245,12 @@ Symbols used below:
    holds, provided the config contains sign descriptors:
    - the deck has agents below full familiarity (they need it to discover), or
    - `--vis-cache <path>` was passed, or
-   - rerouting is on and `cost_model` is `"gate"` — i.e. the default, which is
-     why familiarity-1.0 decks now pay for a vismap precompute they used to
-     skip (`_gate_needs_sight`). `--vis-cache` makes it a one-off.
    - `--clear-air-visibility` forces it on with no fire.
+
+   The gate no longer triggers it. `b16e900` moved the sight criterion onto the
+   route polyline and `89d13d4` removed the `_gate_needs_sight` precompute, so a
+   familiarity-1.0 gate deck builds no visibility model and runs without a
+   vismap.
 
    `--no-visibility` turns it off entirely; agents then learn every neighbour of
    each node they reach by contact. With `--fds-dir` the model reads the FDS

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -570,9 +570,11 @@ Full cost evaluation for one candidate route:
 | `rejected`         | `bool`              | Whether route was rejected        |
 | `rejection_reason` | `str \| None`       | Reason for rejection; `fallback: ` prefix when un-rejected |
 
-`rank_cost`, `k_max_route`, `tau_route` and `feasible` are all
-written to the route-cost CSV (`run.py --output-route-cost-history`), so the
-gate's decisions can be audited from its own output.
+`rank_cost`, `k_max_route`, `tau_route`, `k_leg_max`, `clean` and `feasible` are
+all written to the route-cost CSV (`run.py --output-route-cost-history`), so the
+gate's decisions can be audited from its own output. `composite_cost` is
+deliberately not enough on its own: it does not rank under the gate, and the
+quantity that does is `tau_route`.
 
 ## References
 

--- a/docs/testing-familiarity.md
+++ b/docs/testing-familiarity.md
@@ -198,6 +198,22 @@ passes with no regressions.
   and is geometrically paired with this maze for a follow-up smoke/toxicity-
   driven variant (discovery agents losing sight of exits through smoke via
   `--vis-cache`).
+- **The tiers limit topology, not perception of smoke.** A `discovery` agent is
+  ignorant of the *building* — it routes over `cognitive_subgraph` and learns
+  nodes through `VisibilityModel`, which is genuinely perception-limited. It is
+  not ignorant of the *smoke field*: to choose among the exits it does know it
+  integrates `tau = K_ave * L_remaining` over the whole remaining route,
+  including legs it has never visited, and (with `anticipate = True` and
+  `foresight_horizon_s = inf`) at times that have not happened. The extinction
+  sampler is global and the cognitive map never touches it. So the results on
+  this page — which are purely distance-based and run in clear air — are
+  unaffected, and so is every result about map growth, exploration order and
+  wander behaviour. What must **not** be claimed from this test, or from any
+  discovery run, is that a discovery agent's *route choice* is
+  perception-limited. It is an optimality bound over the agent's known
+  subgraph. See
+  [#125](https://github.com/PedestrianDynamics/pyFDS-Evac/issues/125) and
+  [route-cost-gate.md](route-cost-gate.md#route-choice-is-an-optimality-bound-not-a-perception-limited-model).
 - On a tie (two frontier candidates equidistant from a discovery agent), the
   choice is deterministic (lexicographically-first checkpoint ID), not
   randomized per agent — every discovery agent facing an identical tie makes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -58,13 +58,13 @@ silent unless you check the warning log.
 | `--no-visibility` | Turn sight gating off entirely; agents then learn each node's neighbours by contact. Not a fire scenario. |
 | `--vis-cell-size M` | Resolution of the clear-air visibility grid (default 0.25 m). Keep it below the thinnest wall that must block sight. |
 
-**The default route-choice model still triggers the visibility model.** With
-rerouting on and `routing.cost_model` left at its `"gate"` default, a vismap is
-built even for decks whose agents all start fully familiar. The gate itself no
-longer reads it — the sight criterion is computed from the route polyline
-(`b16e900`) — so what the precompute now buys is the line-of-sight diagnostic
-and sign legibility for the cognitive map. It is a precompute the deck used to
-skip; `--vis-cache` makes it a one-off. See
+**The default route-choice model does not trigger the visibility model.** The
+gate reads no vismap: `b16e900` moved the sight criterion onto the route
+polyline, and `89d13d4` removed the `_gate_needs_sight` precompute a gate deck
+used to trigger. A deck whose agents all start fully familiar therefore builds
+no visibility model at all unless you pass `--vis-cache` or
+`--clear-air-visibility`. A deck with discovery agents builds one either way,
+because they need it to learn the graph. See
 [route-cost-gate.md](route-cost-gate.md).
 
 ### Tenability (FIC slowdown + FED incapacitation)


### PR DESCRIPTION
Audited against `081380b` before review. The gate mechanics were already accurate; what had drifted was the framing, plus three mechanisms the docs described that no longer exist in the code — `next_node_not_visible`, the `--vis-cache`/`--fds-dir` precondition, and `_gate_needs_sight`.

Adds two findings that had reached the paper or the issues but not the markdown: the diversion departs from the reference rather than reproducing it, and route choice is an optimality bound over the agent's known subgraph (#125). Consolidates the limitations into one statement leading with #124 and #125.

Two things found and left for follow-up: `route_graph.py:1119` claims `k_max_route` orders the all-refused fallback, which `:1426` contradicts; and `assets/l_corridor/README.md` still documents the pre-`a98f8bb` spawn geometry.

Docs only.