### PR TITLE
feat(webapp): theme switch, run controls, and a working fullscreen viewer

### DIFF
--- a/pyfds_evac/core/run_config.py
+++ b/pyfds_evac/core/run_config.py
@@ -144,8 +144,14 @@ def _build_reroute_config(scenario: Any, opts: Any, log: Logger):
     )
 
 
-def _validate_opts(opts: Any) -> None:
-    """Reject invalid option combinations before any expensive FDS reads."""
+def validate_opts(opts: Any) -> None:
+    """Reject invalid option combinations before any expensive FDS reads.
+
+    Public because callers that defer ``build_run_kwargs`` onto a worker
+    thread still need these checks to run synchronously: they are pure
+    attribute comparisons, and reporting them from a background thread would
+    bury a plain user mistake in a run log instead of answering the request.
+    """
     if opts.vis_cache and not opts.enable_rerouting:
         raise ValueError("--vis-cache requires --enable-rerouting")
     if getattr(opts, "clear_air_visibility", False) and opts.fds_dir:
@@ -265,7 +271,7 @@ def build_run_kwargs(scenario: Any, opts: Any, log: Logger = _noop) -> Dict[str,
     ``tenability_config``, ``reroute_config``, ``collect_route_cost_history``,
     ``vis_model``). Raises ``ValueError`` for invalid option combinations.
     """
-    _validate_opts(opts)
+    validate_opts(opts)
     smoke_speed_model = _build_smoke_model(opts, log)
     fed_model = _build_fed_model(opts, log)
     heat_fed_model = _build_heat_fed_model(opts, log)

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -61,25 +61,35 @@ app, rt = fast_app(
 manager = RunManager()
 
 # ── style tokens ─────────────────────────────────────────────────────────────
-_CARD = "background:#2A262A;border:1px solid rgba(255,255,255,.07);border-radius:1.1rem;padding:20px;box-shadow:0 8px 24px rgba(0,0,0,.45)"
-_PANEL = "background:#14161B;border:1px solid rgba(255,255,255,.07);border-radius:1.25rem;padding:24px;box-shadow:0 18px 50px rgba(0,0,0,.35)"
-_INNER = "background:#252127;border:1px solid rgba(255,255,255,.06);border-radius:12px;padding:14px 16px"
+_CARD = "background:var(--surface-card);border:1px solid var(--hairline);border-radius:1.1rem;padding:20px;box-shadow:var(--shadow-md)"
+_PANEL = "background:var(--surface-panel);border:1px solid var(--hairline);border-radius:1.25rem;padding:24px;box-shadow:var(--shadow-lg)"
+_INNER = "background:var(--surface-accent);border:1px solid var(--hairline);border-radius:12px;padding:14px 16px"
 _MONO = "font-family:'JetBrains Mono',monospace"
 _GROTESK = "font-family:'Space Grotesk',sans-serif"
-_INK = "color:#F2EDE9"
-_INK2 = "color:#B2A9A3"
-_MUTED = "color:#837A74"
+_INK = "color:var(--ink)"
+_INK2 = "color:var(--ink-dim)"
+_MUTED = "color:var(--ink-faint)"
 
 _FED_LIVE_JS = """
 (function () {
+  // Plotly resolves no CSS variables, so the themed values are read off
+  // the document and refreshed whenever the theme flips.
+  function themeInk() {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue('--ink-dim').trim() || '#b2a9a3';
+  }
+  function themeGrid() {
+    return document.documentElement.getAttribute('data-theme') === 'light'
+      ? 'rgba(31,23,16,.13)' : 'rgba(255,255,255,.10)';
+  }
   var fedLayout = {
     margin: {l: 46, r: 14, t: 14, b: 34},
     paper_bgcolor: 'rgba(0,0,0,0)', plot_bgcolor: 'rgba(0,0,0,0)',
-    font: {family: 'JetBrains Mono, monospace', color: '#B2A9A3', size: 10},
+    font: {family: 'JetBrains Mono, monospace', color: themeInk(), size: 10},
     height: 180,
     legend: {bgcolor: 'rgba(0,0,0,0)', font: {size: 9}, orientation: 'h', y: -0.22},
-    xaxis: {title: {text: 'sim time (s)', font: {size: 9}}, gridcolor: 'rgba(255,255,255,.06)', tickfont: {size: 9}},
-    yaxis: {title: {text: 'FED', font: {size: 9}}, gridcolor: 'rgba(255,255,255,.06)', rangemode: 'tozero', tickfont: {size: 9}},
+    xaxis: {title: {text: 'sim time (s)', font: {size: 9}}, gridcolor: themeGrid(), tickfont: {size: 9}},
+    yaxis: {title: {text: 'FED', font: {size: 9}}, gridcolor: themeGrid(), rangemode: 'tozero', tickfont: {size: 9}},
     shapes: [
       {type: 'line', x0: 0, x1: 1, xref: 'paper', y0: 0.3, y1: 0.3,
        line: {color: 'rgba(255,176,32,.55)', dash: 'dot', width: 1}},
@@ -102,6 +112,9 @@ _FED_LIVE_JS = """
         {x: d.t, y: d.max, mode: 'lines', name: 'max FED', line: {color: '#F4C430', width: 2}},
         {x: d.t, y: d.mean, mode: 'lines', name: 'mean FED', line: {color: '#FF8A3D', width: 1.5, dash: 'dot'}}
       ];
+      fedLayout.font.color = themeInk();
+      fedLayout.xaxis.gridcolor = themeGrid();
+      fedLayout.yaxis.gridcolor = themeGrid();
       if (!fedChartReady) {
         Plotly.newPlot('fed-live-chart', traces, fedLayout, {displayModeBar: false, responsive: true});
         fedChartReady = true;
@@ -123,7 +136,7 @@ _FED_LIVE_JS = """
 # ── logo ─────────────────────────────────────────────────────────────────────
 _LOGO_SVG = NotStr("""
 <svg class="app-logo" viewBox="0 0 40 40" width="40" height="40" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
-  <rect x="0.5" y="0.5" width="39" height="39" rx="10.5" fill="#211e20" stroke="rgba(255,255,255,0.10)"/>
+  <rect x="0.5" y="0.5" width="39" height="39" rx="10.5" fill="var(--surface-page)" stroke="var(--hairline-strong)"/>
   <circle cx="20" cy="20" r="14.5" fill="none" stroke="#f4c430" stroke-width="1.6" opacity="0.55"/>
   <circle cx="20" cy="20" r="10"   fill="none" stroke="#ffb020" stroke-width="1.6" opacity="0.7"/>
   <circle cx="20" cy="20" r="5.5"  fill="none" stroke="#ff6a1a" stroke-width="1.7" opacity="0.9"/>
@@ -163,7 +176,7 @@ def _fed_live_section() -> Div:
             Div(
                 style="position:absolute;top:-2px;left:30%;width:1px;height:calc(100% + 4px);background:rgba(255,176,32,.55)"
             ),
-            style="position:relative;height:7px;border-radius:99px;background:#1F1C1F;border:1px solid rgba(255,255,255,.06);overflow:visible;margin-bottom:5px",
+            style="position:relative;height:7px;border-radius:99px;background:var(--surface-page);border:1px solid var(--hairline);overflow:visible;margin-bottom:5px",
         ),
         # Labels pinned to exact bar positions
         Div(
@@ -211,7 +224,7 @@ def _sidebar() -> Div:
                 ),
                 Span(
                     "run.py",
-                    style=f"{_MONO};font-size:10px;{_MUTED};padding:3px 8px;border:1px solid rgba(255,255,255,.08);border-radius:6px",
+                    style=f"{_MONO};font-size:10px;{_MUTED};padding:3px 8px;border:1px solid var(--hairline);border-radius:6px",
                 ),
                 style="display:flex;align-items:center;justify-content:space-between;margin-bottom:14px",
             ),
@@ -256,8 +269,8 @@ def _warnings_card(messages: list[str]) -> Div:
             style=f"font-size:.78rem;line-height:1.6;{_INK2};margin:10px 0 0;opacity:.8",
         ),
         style=(
-            "background:#2A262A;border:1px solid rgba(244,196,48,.35);"
-            "border-radius:1.1rem;padding:20px;box-shadow:0 8px 24px rgba(0,0,0,.45)"
+            "background:var(--surface-card);border:1px solid rgba(244,196,48,.35);"
+            "border-radius:1.1rem;padding:20px;box-shadow:var(--shadow-md)"
         ),
     )
 
@@ -466,6 +479,13 @@ function drawIncapDist() {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, cw, ch);
 
+  // Canvas takes literal colours only, so the theme is read here rather
+  // than inherited; drawIncapDist re-runs on every theme flip.
+  var _cs = getComputedStyle(document.documentElement);
+  function cssVar(n, fallback) {
+    return (_cs.getPropertyValue(n) || '').trim() || fallback;
+  }
+
   var pL = 28, pR = 10, pT = 18, pB = 18;
   var pw = cw - pL - pR, ph = ch - pT - pB;
   var fedMax = 1.8, N = 400;
@@ -485,10 +505,10 @@ function drawIncapDist() {
   function ty(v) { return pT + (1 - v / yMax) * ph; }
 
   // Background
-  ctx.fillStyle = '#131113'; ctx.fillRect(0, 0, cw, ch);
+  ctx.fillStyle = cssVar('--surface-panel', '#14161b'); ctx.fillRect(0, 0, cw, ch);
 
   // Horizontal grid
-  ctx.strokeStyle = 'rgba(255,255,255,.05)'; ctx.lineWidth = 1;
+  ctx.strokeStyle = cssVar('--hairline-soft', 'rgba(255,255,255,.04)'); ctx.lineWidth = 1;
   [0.25, 0.5, 0.75, 1.0].forEach(function (f) {
     ctx.beginPath(); ctx.moveTo(pL, pT + (1 - f) * ph); ctx.lineTo(cw - pR, pT + (1 - f) * ph); ctx.stroke();
   });
@@ -530,24 +550,24 @@ function drawIncapDist() {
   ctx.setLineDash([]);
 
   // Axes
-  ctx.strokeStyle = 'rgba(255,255,255,.18)'; ctx.lineWidth = 1;
+  ctx.strokeStyle = cssVar('--hairline-badge', 'rgba(255,255,255,.18)'); ctx.lineWidth = 1;
   ctx.beginPath(); ctx.moveTo(pL, pT); ctx.lineTo(pL, pT + ph); ctx.stroke();
   ctx.beginPath(); ctx.moveTo(pL, pT + ph); ctx.lineTo(cw - pR, pT + ph); ctx.stroke();
 
   // X-axis ticks
-  ctx.fillStyle = '#837A74'; ctx.font = '8px JetBrains Mono, monospace'; ctx.textAlign = 'center';
+  ctx.fillStyle = cssVar('--ink-faint', '#837a74'); ctx.font = '8px JetBrains Mono, monospace'; ctx.textAlign = 'center';
   [0, 0.3, 0.6, 0.9, 1.2, 1.5].forEach(function (v) {
     ctx.fillText(v.toFixed(1), tx(v), pT + ph + 12);
   });
 
   // Axis labels
-  ctx.fillStyle = '#837A74'; ctx.font = '7.5px JetBrains Mono, monospace';
+  ctx.fillStyle = cssVar('--ink-faint', '#837a74'); ctx.font = '7.5px JetBrains Mono, monospace';
   ctx.textAlign = 'right'; ctx.fillText('density', pL - 2, pT + 4);
   ctx.textAlign = 'center'; ctx.fillText('FED threshold', pL + pw / 2, pT + ph + 17);
 
   // Annotation: σ + mode
   var mode = Math.exp(mu - sigma * sigma);
-  ctx.fillStyle = '#B2A9A3'; ctx.font = '7.5px JetBrains Mono, monospace'; ctx.textAlign = 'left';
+  ctx.fillStyle = cssVar('--ink-dim', '#b2a9a3'); ctx.font = '7.5px JetBrains Mono, monospace'; ctx.textAlign = 'left';
   ctx.fillText('σ=' + sigma.toFixed(2) + '  mode≈' + mode.toFixed(2), pL + 2, pT - 5);
 }
 
@@ -650,7 +670,9 @@ def index():
             Div(grid, id="tab-sim"),
             Div(docs.model_docs(), id="tab-model", cls="hidden"),
         ),
+        theme.switch(),
         Div(id="dir-modal"),
+        theme.script(),
         Script(_AUTOFILL_JS),
         Script(_TAB_JS),
         Script(_MATH_JS),
@@ -737,7 +759,7 @@ def browse_dir(path: str = "", mode: str = "dir", field: str = "fds_dir"):
             "Cancel",
             type="button",
             onclick=_CLOSE_MODAL,
-            style=f"background:#3A343A;border:1px solid rgba(255,255,255,.1);border-radius:9px;padding:8px 16px;{_INK2};{_GROTESK};font-size:13px;cursor:pointer",
+            style=f"background:var(--surface-raised);border:1px solid var(--hairline-strong);border-radius:9px;padding:8px 16px;{_INK2};{_GROTESK};font-size:13px;cursor:pointer",
         ),
     ]
     if mode == "dir":
@@ -747,7 +769,7 @@ def browse_dir(path: str = "", mode: str = "dir", field: str = "fds_dir"):
                 "Use this folder",
                 type="button",
                 onclick=use,
-                style=f"background:linear-gradient(180deg,#FFC24D,#E8590C);border:0;border-radius:9px;padding:8px 16px;color:#2A1606;{_GROTESK};font-size:13px;font-weight:600;cursor:pointer",
+                style=f"background:linear-gradient(180deg,#FFC24D,#E8590C);border:0;border-radius:9px;padding:8px 16px;color:var(--on-heat);{_GROTESK};font-size:13px;font-weight:600;cursor:pointer",
             ),
         )
 
@@ -758,14 +780,14 @@ def browse_dir(path: str = "", mode: str = "dir", field: str = "fds_dir"):
                 str(current),
                 style=f"{_MONO};font-size:11.5px;{_MUTED};margin-top:4px;word-break:break-all",
             ),
-            style="padding:18px 20px;border-bottom:1px solid rgba(255,255,255,.07)",
+            style="padding:18px 20px;border-bottom:1px solid var(--hairline)",
         ),
         Div(*rows, style="max-height:340px;overflow:auto;padding:8px"),
         Div(
             *footer_btns,
-            style="display:flex;justify-content:flex-end;gap:10px;padding:14px 20px;border-top:1px solid rgba(255,255,255,.07)",
+            style="display:flex;justify-content:flex-end;gap:10px;padding:14px 20px;border-top:1px solid var(--hairline)",
         ),
-        style="width:520px;max-width:92vw;background:#14161B;border:1px solid rgba(255,255,255,.10);border-radius:18px;box-shadow:0 30px 80px rgba(0,0,0,.6);overflow:hidden",
+        style="width:520px;max-width:92vw;background:var(--surface-panel);border:1px solid var(--hairline-strong);border-radius:18px;box-shadow:var(--shadow-lg);overflow:hidden",
         onclick="event.stopPropagation()",
     )
     return Div(
@@ -985,7 +1007,7 @@ def _running_stream_view() -> Div:
                         "console",
                         style=f"{_MONO};font-size:11px;{_MUTED};margin-left:6px",
                     ),
-                    style="display:flex;align-items:center;gap:9px;padding:14px 20px;border-bottom:1px solid rgba(255,255,255,.06)",
+                    style="display:flex;align-items:center;gap:9px;padding:14px 20px;border-bottom:1px solid var(--hairline)",
                 ),
                 Pre(
                     "Waiting for output…",
@@ -1044,7 +1066,7 @@ def _running_card(ev) -> Div:
             Div(
                 style=f"height:100%;width:{max(pct, 3)}%;border-radius:99px;background:linear-gradient(90deg,#F4C430,#FFB020,#FF6A1A);transition:width .35s cubic-bezier(.4,0,.2,1)"
             ),
-            style="height:10px;border-radius:99px;background:#1F1C1F;border:1px solid rgba(255,255,255,.06);overflow:hidden;margin-bottom:18px",
+            style="height:10px;border-radius:99px;background:var(--surface-page);border:1px solid var(--hairline);overflow:hidden;margin-bottom:18px",
         ),
         Div(line, style=f"{_MONO};font-size:.82rem;{_INK2}"),
         style=_PANEL,
@@ -1072,7 +1094,7 @@ def _kpi_tiles(result) -> Div:
                     v,
                     style=f"{_MONO};font-size:19px;font-weight:500;margin-top:7px;{_INK}",
                 ),
-                style=f"background:#14161B;border:1px solid rgba(255,255,255,.07);border-top:2px solid {a};border-radius:14px;padding:15px 16px",
+                style=f"background:var(--surface-panel);border:1px solid var(--hairline);border-top:2px solid {a};border-radius:14px;padding:15px 16px",
             )
             for (k, v), a in zip(metrics, accents)
         ],
@@ -1183,11 +1205,11 @@ def _artifact_rows(result, opts) -> Div:
         exists = bool(path and path.exists())
 
         if exists:
-            detail, colour, mark = f"{path} · {_fmt_size(path)}", "#B2A9A3", "#F4C430"
+            detail, colour, mark = f"{path} · {_fmt_size(path)}", "var(--ink-dim)", "#F4C430"
         elif not produced:
-            detail, colour, mark = _missing_reason(field, opts), "#837A74", "#3A343A"
+            detail, colour, mark = _missing_reason(field, opts), "var(--ink-faint)", "var(--surface-raised)"
         else:
-            detail, colour, mark = "not written", "#837A74", "#3A343A"
+            detail, colour, mark = "not written", "var(--ink-faint)", "var(--surface-raised)"
 
         rows.append(
             Div(
@@ -1201,7 +1223,7 @@ def _artifact_rows(result, opts) -> Div:
                         style=f"{_MONO};font-size:10.5px;color:{colour};margin-top:3px;word-break:break-all",
                     ),
                 ),
-                style="display:flex;gap:10px;align-items:flex-start;padding:8px 0;border-bottom:1px solid rgba(255,255,255,.05)",
+                style="display:flex;gap:10px;align-items:flex-start;padding:8px 0;border-bottom:1px solid var(--hairline-soft)",
             )
         )
     return Div(*rows, style="display:flex;flex-direction:column")
@@ -1296,9 +1318,9 @@ async def progress():
                         ),
                         Pre(
                             err,
-                            style="color:#B2A9A3;font-family:'JetBrains Mono',monospace;font-size:.72rem;white-space:pre-wrap;overflow:auto;max-height:300px",
+                            style="color:var(--ink-dim);font-family:'JetBrains Mono',monospace;font-size:.72rem;white-space:pre-wrap;overflow:auto;max-height:300px",
                         ),
-                        style="background:#14161B;border:1px solid #E01E37;border-radius:12px;padding:16px",
+                        style="background:var(--surface-panel);border:1px solid #E01E37;border-radius:12px;padding:16px",
                     )
                 yield sse_message(finished, event="done")
                 return

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -12,6 +12,7 @@ import io
 import json
 import re
 import shutil
+import time
 import zipfile
 from pathlib import Path
 from urllib.parse import quote
@@ -35,7 +36,7 @@ from fasthtml.common import (
 from starlette.requests import Request
 
 from pyfds_evac.core import load_scenario
-from pyfds_evac.core.run_config import build_run_kwargs
+from pyfds_evac.core.run_config import build_run_kwargs, validate_opts
 
 from . import docs, params, plots, theme, trajviz
 from .runner import RunManager
@@ -275,31 +276,41 @@ def _warnings_card(messages: list[str]) -> Div:
     )
 
 
-def _run_panel_idle() -> Div:
+def _run_panel_idle_body() -> Div:
+    """Standby contents of the run panel.
+
+    Kept separate from the ``#run-panel`` wrapper because the run form and
+    the cancel/clear actions swap this element's *innerHTML* -- returning the
+    wrapper too would nest a second ``#run-panel`` inside the first.
+    """
     return Div(
         Div(
             Div(
-                Div(
-                    _LOGO_SVG,
-                    style=(
-                        "width:64px;height:64px;border-radius:50%;display:flex;"
-                        "align-items:center;justify-content:center;"
-                        "background:rgba(255,106,26,.07);margin:0 auto 20px;"
-                        "animation:pulse 2.6s ease-in-out infinite"
-                    ),
+                _LOGO_SVG,
+                style=(
+                    "width:64px;height:64px;border-radius:50%;display:flex;"
+                    "align-items:center;justify-content:center;"
+                    "background:rgba(255,106,26,.07);margin:0 auto 20px;"
+                    "animation:pulse 2.6s ease-in-out infinite"
                 ),
-                Div(
-                    Div(
-                        "Choose a scenario and ",
-                        B("run", style="color:#FF6A1A"),
-                        style=f"{_GROTESK};font-weight:600;font-size:22px;letter-spacing:-.02em;{_INK}",
-                    ),
-                    style="max-width:46ch;text-align:center",
-                ),
-                cls="standby",
             ),
-            style=_PANEL,
+            Div(
+                Div(
+                    "Choose a scenario and ",
+                    B("run", style="color:#FF6A1A"),
+                    style=f"{_GROTESK};font-weight:600;font-size:22px;letter-spacing:-.02em;{_INK}",
+                ),
+                style="max-width:46ch;text-align:center",
+            ),
+            cls="standby",
         ),
+        style=_PANEL,
+    )
+
+
+def _run_panel_idle() -> Div:
+    return Div(
+        _run_panel_idle_body(),
         id="run-panel",
         cls="rise",
         style="animation-delay:.12s",
@@ -455,6 +466,25 @@ _RUN_BTN_JS = """
   });
   // Run finished: the progress stream closed (sse-close="done").
   document.body.addEventListener('htmx:sseClose', function () { setRunning(false); });
+  // Cancelling swaps the whole panel away, which tears down the SSE element
+  // without necessarily firing sseClose -- unlock the buttons explicitly.
+  function isPath(d, want) {
+    var p = (d && d.pathInfo && (d.pathInfo.requestPath || d.pathInfo.path)) ||
+            (d && d.requestConfig && d.requestConfig.path) || '';
+    return p === want;
+  }
+  document.body.addEventListener('htmx:beforeRequest', function (e) {
+    if (!isPath(e.detail, '/cancel')) return;
+    var c = document.getElementById('cancel-btn');
+    if (c) {
+      c.disabled = true;
+      var cl = c.querySelector('.run-btn-label');
+      if (cl) cl.textContent = 'Cancelling…';
+    }
+  });
+  document.body.addEventListener('htmx:afterRequest', function (e) {
+    if (isPath(e.detail, '/cancel') || isPath(e.detail, '/clear')) setRunning(false);
+  });
   document.body.addEventListener('htmx:responseError', function (e) {
     if (isRunPath(e.detail)) setRunning(false);
   });
@@ -965,7 +995,11 @@ async def post(request: Request):
                 f"FDS dir is not a folder: {shown}",
                 style="color:#E01E37;padding:12px;border:1px solid #E01E37;border-radius:9px",
             )
-        run_kwargs = build_run_kwargs(scenario, opts)
+        # Cheap option-combination checks stay on the request thread. Only the
+        # expensive half of build_run_kwargs (FDS slice parsing) is deferred to
+        # the worker, so a plain misconfiguration still answers the request
+        # instead of surfacing later as a failed run.
+        validate_opts(opts)
         import run as cli
 
         def post_run(result):
@@ -973,7 +1007,7 @@ async def post(request: Request):
 
         manager.start(
             scenario,
-            run_kwargs,
+            lambda: build_run_kwargs(scenario, opts, log=print),
             scenario_name,
             post_run=post_run,
             fds_dir=getattr(opts, "fds_dir", None),
@@ -989,10 +1023,64 @@ async def post(request: Request):
     return _running_stream_view()
 
 
+@rt("/cancel")
+async def cancel():
+    """Stop an in-flight run and hand the panel back in its standby state.
+
+    Cancellation is cooperative (the worker unwinds on its next progress
+    tick), so wait briefly for the run to actually let go before resetting.
+    Without that wait the manager can still report ``running`` when the user
+    immediately clicks Run again, and ``/run``'s guard would reconnect them
+    to the run they just stopped. The wait is bounded so a scenario with slow
+    ticks can't hang the request.
+    """
+    manager.cancel()
+    deadline = time.monotonic() + 2.0
+    while manager.running and time.monotonic() < deadline:
+        await asyncio.sleep(0.05)
+    manager.reset()
+    return _run_panel_idle_body()
+
+
+@rt("/clear")
+async def clear():
+    """Discard a finished run's results and return to the standby panel."""
+    manager.reset()
+    return _run_panel_idle_body()
+
+
 def _running_stream_view() -> Div:
     """The live run panel: progress card + console, wired to the SSE stream."""
     return Div(
-        Div(_running_card(None), id="run-status", sse_swap="progress,done"),
+        Div(
+            # Only the dynamic half lives in the SSE swap target. Cancel sits
+            # outside it: #run-status is re-rendered on every progress tick,
+            # and a stop control that is destroyed and rebuilt ~once a second
+            # can swallow a click that lands mid-swap.
+            Div(_running_card(None), id="run-status", sse_swap="progress,done"),
+            Div(
+                Button(
+                    NotStr(
+                        '<span style="font-size:9px">■</span>'
+                        '<span class="run-btn-label">Cancel scenario</span>'
+                    ),
+                    id="cancel-btn",
+                    type="button",
+                    hx_post="/cancel",
+                    hx_target="#run-panel",
+                    hx_swap="innerHTML show:top",
+                    style=(
+                        "display:inline-flex;align-items:center;gap:7px;"
+                        "padding:9px 16px;border-radius:10px;cursor:pointer;"
+                        f"{_GROTESK};font-size:13px;font-weight:600;"
+                        "background:transparent;color:#E01E37;"
+                        "border:1px solid #E01E37"
+                    ),
+                ),
+                style="display:flex;justify-content:flex-end;margin-top:18px",
+            ),
+            style=_PANEL,
+        ),
         Div(
             Div(
                 Div(
@@ -1069,7 +1157,34 @@ def _running_card(ev) -> Div:
             style="height:10px;border-radius:99px;background:var(--surface-page);border:1px solid var(--hairline);overflow:hidden;margin-bottom:18px",
         ),
         Div(line, style=f"{_MONO};font-size:.82rem;{_INK2}"),
-        style=_PANEL,
+    )
+
+
+def _clear_run_bar() -> Div:
+    """Header strip over a finished run, with the way back to standby.
+
+    Without this a completed run is a dead end: the panel keeps showing the
+    old results and there is no way to dismiss them short of reloading.
+    """
+    return Div(
+        Div(
+            f"Results · {manager.scenario_name or 'run'}",
+            style=f"{_MONO};font-size:11px;letter-spacing:.06em;text-transform:uppercase;{_MUTED}",
+        ),
+        Button(
+            "Clear results",
+            type="button",
+            hx_post="/clear",
+            hx_target="#run-panel",
+            hx_swap="innerHTML show:top",
+            style=(
+                "padding:7px 13px;border-radius:9px;cursor:pointer;"
+                f"{_MONO};font-size:11px;"
+                "background:transparent;color:var(--ink-dim);"
+                "border:1px solid var(--hairline)"
+            ),
+        ),
+        style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:14px",
     )
 
 
@@ -1134,11 +1249,11 @@ def _finished_view() -> Div:
         )
 
     return Div(
+        _clear_run_bar(),
         kpi_tiles,
         _warnings_card(manager.warnings),
         art,
         trajviz.trajectory_component(result, scenario, fds_dir=manager.fds_dir),
-        plot_card("Cumulative FED", plots.fed_figure(result), "fig-fed"),
         plot_card("Smoke", plots.smoke_figure(result), "fig-smoke"),
         plot_card(
             "Cognitive map growth", plots.cognitive_map_figure(result), "fig-cogmap"
@@ -1234,6 +1349,7 @@ def _results_only_view() -> Div:
     result = manager.result
     opts = manager.opts
     return Div(
+        _clear_run_bar(),
         _kpi_tiles(result),
         _warnings_card(manager.warnings),
         Div(
@@ -1281,7 +1397,7 @@ async def fed_progress():
                     }
                 )
                 yield sse_message(payload, event="fed")
-            if manager.status in ("done", "error", "idle"):
+            if manager.status in ("done", "error", "idle", "cancelled"):
                 yield sse_message("{}", event="close")
                 return
             await asyncio.sleep(0.5)
@@ -1333,7 +1449,10 @@ async def progress():
                     event="done",
                 )
                 return
-            if status == "idle":
+            # Cancelled and idle both just close the stream: /cancel has
+            # already swapped the whole panel back to its standby state, so
+            # emitting anything here would fight that swap.
+            if status in ("cancelled", "idle"):
                 return
             ev = manager.last_event
             if ev is not None and ev != last:

--- a/pyfds_evac/webapp/app.py
+++ b/pyfds_evac/webapp/app.py
@@ -1320,11 +1320,23 @@ def _artifact_rows(result, opts) -> Div:
         exists = bool(path and path.exists())
 
         if exists:
-            detail, colour, mark = f"{path} · {_fmt_size(path)}", "var(--ink-dim)", "#F4C430"
+            detail, colour, mark = (
+                f"{path} · {_fmt_size(path)}",
+                "var(--ink-dim)",
+                "#F4C430",
+            )
         elif not produced:
-            detail, colour, mark = _missing_reason(field, opts), "var(--ink-faint)", "var(--surface-raised)"
+            detail, colour, mark = (
+                _missing_reason(field, opts),
+                "var(--ink-faint)",
+                "var(--surface-raised)",
+            )
         else:
-            detail, colour, mark = "not written", "var(--ink-faint)", "var(--surface-raised)"
+            detail, colour, mark = (
+                "not written",
+                "var(--ink-faint)",
+                "var(--surface-raised)",
+            )
 
         rows.append(
             Div(

--- a/pyfds_evac/webapp/docs.py
+++ b/pyfds_evac/webapp/docs.py
@@ -14,10 +14,10 @@ from fasthtml.common import H1, Button, Div, NotStr, P, Span
 # ── style tokens ──────────────────────────────────────────────────────────────
 _MONO = "font-family:'JetBrains Mono',monospace"
 _PRESS = "font-family:'Press Start 2P',monospace"
-_BG = "#ECE8DF"
+_BG = "var(--ink)"
 _INK = "#17150F"
 _INK2 = "#3a362c"
-_MUTED = "#6b655c"
+_MUTED = "var(--ink-faint)"
 _BLUE = "#1B17FF"
 _BORDER = "rgba(0,0,0,.13)"
 
@@ -241,7 +241,7 @@ def model_docs() -> Any:
                 style=f"{_MONO};font-size:11px;letter-spacing:.06em;color:{_MUTED}",
             ),
             NotStr(
-                f'<div style="{_PRESS};font-size:7px;letter-spacing:.08em;color:#9a9488">EST. MMXXIV</div>'
+                f'<div style="{_PRESS};font-size:7px;letter-spacing:.08em;color:var(--ink-faint)">EST. MMXXIV</div>'
             ),
             style=(
                 f"border-top:1px solid {_BORDER};padding-top:26px;"

--- a/pyfds_evac/webapp/params.py
+++ b/pyfds_evac/webapp/params.py
@@ -41,15 +41,15 @@ _UPLOAD_ROOT = _REPO_ROOT / "uploads"
 UPLOAD_PREFIX = "uploads/"
 
 _INPUT = (
-    "background:#2E2A2E;border:1px solid rgba(255,255,255,.09);"
-    "border-radius:9px;padding:10px 12px;color:#F2EDE9;"
+    "background:var(--surface-input);border:1px solid var(--hairline);"
+    "border-radius:9px;padding:10px 12px;color:var(--ink);"
     "font-family:'JetBrains Mono',monospace;font-size:13px;"
     "outline:none;width:100%;box-sizing:border-box"
 )
 _LABEL = (
     "display:block;font-family:'Space Grotesk',sans-serif;"
     "font-size:10.5px;font-weight:500;letter-spacing:.07em;"
-    "text-transform:uppercase;color:#837A74;margin-bottom:6px"
+    "text-transform:uppercase;color:var(--ink-faint);margin-bottom:6px"
 )
 _FIELD = "display:flex;flex-direction:column;gap:6px"
 _GROTESK = "font-family:'Space Grotesk',sans-serif"
@@ -221,9 +221,9 @@ def _browse_button(target_id: str, mode: str) -> Any:
         hx_target="#dir-modal",
         hx_swap="innerHTML",
         style=(
-            "flex:none;background:#3A343A;border:1px solid rgba(255,255,255,.10);"
+            "flex:none;background:var(--surface-raised);border:1px solid var(--hairline-strong);"
             "border-radius:9px;padding:0 12px;height:42px;"
-            f"{_GROTESK};font-size:12px;color:#B2A9A3;cursor:pointer"
+            f"{_GROTESK};font-size:12px;color:var(--ink-dim);cursor:pointer"
         ),
     )
 
@@ -328,14 +328,14 @@ def _switch(
     dest: str, label: str, checked: bool = False, action: argparse.Action | None = None
 ) -> Any:
     _chk = "checked " if checked else ""
-    _track_bg = "#F4C430" if checked else "#2E2A2E"
+    _track_bg = "#F4C430" if checked else "var(--surface-input)"
     _knob_pos = "19px" if checked else "2px"
     import html as _html
 
     _tip = _help_text(dest, action)
     _label_node = Label(
         NotStr(_label_line(label, bool(_tip))),
-        style=f"{_GROTESK};font-size:12px;font-weight:500;color:#F2EDE9",
+        style=f"{_GROTESK};font-size:12px;font-weight:500;color:var(--ink)",
     )
     _row = Div(
         _label_node,
@@ -344,12 +344,12 @@ def _switch(
             f'<input type="checkbox" id="{dest}" name="{dest}" value="on" {_chk}'
             f'style="opacity:0;width:0;height:0;position:absolute">'
             f'<span onclick="event.preventDefault();var cb=this.previousElementSibling;cb.checked=!cb.checked;'
-            f"this.style.background=cb.checked?'#F4C430':'#2E2A2E';"
+            f"this.style.background=cb.checked?'#F4C430':'var(--surface-input)';"
             f"this.querySelector('span').style.left=cb.checked?'19px':'2px';\" "
             f'style="position:absolute;inset:0;border-radius:99px;'
-            f'background:{_track_bg};border:1px solid rgba(255,255,255,.12);transition:background .18s">'
+            f'background:{_track_bg};border:1px solid var(--hairline-strong);transition:background .18s">'
             f'<span style="position:absolute;top:2px;left:{_knob_pos};width:17px;height:17px;'
-            f'border-radius:99px;background:#B2A9A3;transition:left .18s;display:block"></span>'
+            f'border-radius:99px;background:var(--ink-dim);transition:left .18s;display:block"></span>'
             f"</span></label>"
         ),
         style="display:flex;align-items:center;justify-content:space-between;gap:10px",
@@ -382,7 +382,7 @@ def _incap_toggle() -> Any:
             value="probabilistic",
         ),
         NotStr(
-            '<div id="incap-dist" style="margin-top:10px;border-radius:9px;overflow:hidden;background:#131113">'
+            '<div id="incap-dist" style="margin-top:10px;border-radius:9px;overflow:hidden;background:var(--surface-panel)">'
             '<canvas id="incap-canvas" style="width:100%;height:108px;display:block"></canvas>'
             "</div>"
         ),
@@ -392,12 +392,12 @@ def _incap_toggle() -> Any:
 
 _SELECT = (
     "appearance:none;"
-    'background:#2E2A2E url("data:image/svg+xml;utf8,'
+    'background:var(--surface-input) url("data:image/svg+xml;utf8,'
     "<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'>"
     "<path d='M2 4l4 4 4-4' stroke='%23837A74' stroke-width='1.5' fill='none'/>"
     '</svg>") no-repeat right 12px center;'
-    "border:1px solid rgba(255,255,255,.09);border-radius:9px;"
-    f"padding:10px 32px 10px 12px;color:#F2EDE9;{_GROTESK};font-size:13px;"
+    "border:1px solid var(--hairline);border-radius:9px;"
+    f"padding:10px 32px 10px 12px;color:var(--ink);{_GROTESK};font-size:13px;"
     "outline:none;width:100%"
 )
 
@@ -544,10 +544,10 @@ def _details_block(
     return NotStr(
         f"<details {'open' if open_ else ''}>"
         f'<summary style="display:flex;align-items:center;justify-content:space-between;'
-        f"padding:11px 13px;background:#322E32;border:1px solid rgba(255,255,255,.07);"
+        f"padding:11px 13px;background:var(--surface-accent);border:1px solid var(--hairline);"
         f'border-left:2px solid {accent};border-radius:11px;list-style:none;cursor:pointer">'
-        f'<span style="{_GROTESK};font-weight:600;font-size:12.5px;letter-spacing:.01em;color:#F2EDE9">{title}</span>'
-        f'<svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2 4l4 4 4-4" stroke="#837A74" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+        f'<span style="{_GROTESK};font-weight:600;font-size:12.5px;letter-spacing:.01em;color:var(--ink)">{title}</span>'
+        f'<svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2 4l4 4 4-4" stroke="var(--ink-faint)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
         f"</summary>" + body + "</details>"
     )
 
@@ -609,7 +609,7 @@ _DOT = (
     '<span style="width:4px;height:4px;border-radius:99px;'
     'background:#FF6A1A;flex:none;display:inline-block;margin-right:8px"></span>'
 )
-_PREVIEW_ROW = f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:#B2A9A3"
+_PREVIEW_ROW = f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:var(--ink-dim)"
 
 
 def _output_files_section() -> NotStr:
@@ -631,7 +631,7 @@ def _output_files_section() -> NotStr:
                     "6 artifacts",
                     id="artifact-heading",
                     style=f"{_GROTESK};font-size:9px;font-weight:600;letter-spacing:.07em;"
-                    f"text-transform:uppercase;color:#837A74;margin-bottom:6px",
+                    f"text-transform:uppercase;color:var(--ink-faint);margin-bottom:6px",
                 ),
                 *[
                     Input(id=k, name=k, type="hidden")
@@ -663,7 +663,7 @@ def _output_files_section() -> NotStr:
                     style=_PREVIEW_ROW,
                 ),
                 style=(
-                    "background:#252127;border:1px solid rgba(255,255,255,.06);"
+                    "background:var(--surface-accent);border:1px solid var(--hairline);"
                     "border-radius:10px;padding:11px 12px;display:flex;flex-direction:column;gap:5px"
                 ),
             ),
@@ -673,10 +673,10 @@ def _output_files_section() -> NotStr:
     return NotStr(
         "<details>"
         f'<summary style="display:flex;align-items:center;justify-content:space-between;'
-        f"padding:11px 13px;background:#322E32;border:1px solid rgba(255,255,255,.07);"
+        f"padding:11px 13px;background:var(--surface-accent);border:1px solid var(--hairline);"
         f'border-left:2px solid #FFB020;border-radius:11px;list-style:none;cursor:pointer">'
-        f'<span style="{_GROTESK};font-weight:600;font-size:12.5px;letter-spacing:.01em;color:#F2EDE9">Output files</span>'
-        f'<svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2 4l4 4 4-4" stroke="#837A74" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
+        f'<span style="{_GROTESK};font-weight:600;font-size:12.5px;letter-spacing:.01em;color:var(--ink)">Output files</span>'
+        f'<svg class="chevron" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2 4l4 4 4-4" stroke="var(--ink-faint)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>'
         "</summary>" + body + "</details>"
     )
 
@@ -707,7 +707,7 @@ def build_form(post_url: str) -> Any:
 
     other = [_field(a) for d, a in by_dest.items() if d not in grouped]
     if other:
-        sections.append(_details_block("Other", "#837A74", other, False))
+        sections.append(_details_block("Other", "var(--ink-faint)", other, False))
 
     return Form(
         Div(
@@ -727,7 +727,7 @@ def build_form(post_url: str) -> Any:
                 "display:flex;align-items:center;justify-content:center;gap:6px;"
                 "width:100%;padding:13px;border-radius:12px;border:none;cursor:pointer;"
                 f"{_GROTESK};font-size:14.5px;font-weight:600;"
-                "background:linear-gradient(180deg,#FFC24D,#E8590C);color:#2A1606;"
+                "background:linear-gradient(180deg,#FFC24D,#E8590C);color:var(--on-heat);"
                 "box-shadow:0 6px 20px rgba(232,89,12,.28)"
             ),
         ),

--- a/pyfds_evac/webapp/params.py
+++ b/pyfds_evac/webapp/params.py
@@ -623,7 +623,9 @@ _DOT = (
     '<span style="width:4px;height:4px;border-radius:99px;'
     'background:#FF6A1A;flex:none;display:inline-block;margin-right:8px"></span>'
 )
-_PREVIEW_ROW = f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:var(--ink-dim)"
+_PREVIEW_ROW = (
+    f"display:flex;align-items:center;{_MONO};font-size:10.5px;color:var(--ink-dim)"
+)
 
 
 def _output_files_section() -> NotStr:

--- a/pyfds_evac/webapp/params.py
+++ b/pyfds_evac/webapp/params.py
@@ -118,19 +118,33 @@ def _is_bool(action: argparse.Action) -> bool:
 def _options_under(root: Path, prefix: str = "") -> List[tuple]:
     """(label, value) pairs for every scenario directory under *root*.
 
-    A directory qualifies when it holds a config.json; each *other* *.json
-    beside it becomes an extra selectable option, matching what
-    ``load_scenario`` accepts for a directory and for a bare .json file.
+    The rule here is deliberately the same one ``load_scenario`` applies to a
+    directory: it needs one JSON and one WKT, preferring ``config.json`` and
+    ``geometry.wkt`` but falling back to the alphabetically first of each.
+    The picker used to demand a literal ``config.json``, which made a
+    directory the CLI loads happily invisible in the GUI -- ``assets/Haspel``
+    (``BUW_Geometrie_EG.wkt`` + ``inifile_template.json``) was exactly that.
+
+    Each *other* *.json beside the primary one becomes an extra option, since
+    ``load_scenario`` also accepts a bare .json path and reads the geometry
+    from a sibling .wkt.
     """
     if not root.is_dir():
         return []
     options: List[tuple] = []
     for p in sorted(root.iterdir()):
-        if not (p.is_dir() and (p / "config.json").exists()):
+        if not p.is_dir():
             continue
+        jsons = sorted(p.glob("*.json"))
+        if not jsons or not any(p.glob("*.wkt")):
+            continue
+        # Mirror load_scenario's preference so the bare-directory option and
+        # the loader agree on which JSON is the primary one.
+        preferred = p / "config.json"
+        primary = preferred if preferred.exists() else jsons[0]
         options.append((p.name, f"{prefix}{p.name}"))
-        for json_file in sorted(p.glob("*.json")):
-            if json_file.name == "config.json":
+        for json_file in jsons:
+            if json_file == primary:
                 continue
             options.append(
                 (

--- a/pyfds_evac/webapp/plots.py
+++ b/pyfds_evac/webapp/plots.py
@@ -36,8 +36,14 @@ _FG = "#b2a9a3"
 def figure_html(fig: go.Figure, div_id: str) -> Any:
     """Embed a Plotly figure as an HTML fragment (no bundled Plotly.js).
 
-    Applies the Warm Paper Lab light template so charts match the GUI's cream
-    ground (transparent background, warm ink, hue-shifted grid).
+    Both backgrounds are transparent, so the figure sits on whichever ground
+    the page is currently painting and only the ink has to follow the theme.
+    The values below are the dark defaults; Plotly bakes them in at render
+    time and resolves no CSS variables, so ``theme.py``'s switch re-applies
+    the font and grid colours with ``Plotly.relayout`` after a flip.
+
+    ``colorway`` is deliberately *not* re-applied: the exit palette is drawn
+    from the heat ramp, which is identical in both themes.
     """
     fig.update_layout(
         margin=dict(l=52, r=22, t=30, b=46),

--- a/pyfds_evac/webapp/plots.py
+++ b/pyfds_evac/webapp/plots.py
@@ -85,35 +85,6 @@ def _agent_exit_map(
     return last["current_exit"].to_dict()
 
 
-def fed_figure(result: Any) -> go.Figure:
-    """Cumulative FED over time (mean and max across agents)."""
-    rows = result.fed_history
-    if not rows:
-        return _empty("No FED history (load an FDS field with a FED model).")
-    df = pd.DataFrame(rows)
-    if "fed_cumulative" not in df or "time_s" not in df:
-        return _empty("FED history is missing expected columns.")
-    agg = df.groupby("time_s")["fed_cumulative"].agg(["mean", "max"]).reset_index()
-    fig = go.Figure()
-    fig.add_trace(
-        go.Scatter(x=agg["time_s"], y=agg["max"], mode="lines", name="max FED")
-    )
-    fig.add_trace(
-        go.Scatter(x=agg["time_s"], y=agg["mean"], mode="lines", name="mean FED")
-    )
-    fig.add_hline(
-        y=0.3,
-        line_dash="dot",
-        line_color="#ffb020",
-        annotation_text="incapacitation (0.3)",
-    )
-    fig.add_hline(
-        y=1.0, line_dash="dot", line_color="#e01e37", annotation_text="untenable (1.0)"
-    )
-    fig.update_layout(xaxis_title="time (s)", yaxis_title="cumulative FED")
-    return fig
-
-
 def smoke_figure(result: Any) -> go.Figure:
     """Mean speed factor and extinction over time."""
     rows = result.smoke_history

--- a/pyfds_evac/webapp/runner.py
+++ b/pyfds_evac/webapp/runner.py
@@ -22,6 +22,16 @@ _MAX_LOG_LINES = 800
 _MAX_WARNINGS = 50
 
 
+class RunCancelled(Exception):
+    """Raised inside the progress callback to unwind an in-flight run.
+
+    A worker thread can't be killed from outside, so cancellation is
+    cooperative: ``cancel()`` sets a flag and the next progress tick raises
+    this, which propagates out of ``run_scenario``'s step loop. Ticks fire
+    roughly once per simulated second, so a cancel lands promptly.
+    """
+
+
 class _WarningCapture(logging.Handler):
     """Collect WARNING-and-above records from the model into a list.
 
@@ -84,8 +94,9 @@ class RunManager:
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
+        self._cancel = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        self.status: str = "idle"  # idle | running | done | error
+        self.status: str = "idle"  # idle | running | done | error | cancelled
         self.result: Optional[ScenarioResult] = None
         self.error: Optional[str] = None
         self.scenario_name: Optional[str] = None
@@ -105,7 +116,7 @@ class RunManager:
     def start(
         self,
         scenario: Any,
-        run_kwargs: Dict[str, Any],
+        build_run_kwargs: Callable[[], Dict[str, Any]],
         scenario_name: str,
         post_run: Optional[Callable[[ScenarioResult], List[str]]] = None,
         fds_dir: Optional[str] = None,
@@ -113,6 +124,16 @@ class RunManager:
         opts: Any = None,
     ) -> None:
         """Start a run on a background thread. Raises if one is already active.
+
+        ``build_run_kwargs`` is a zero-arg callable that builds the
+        ``run_scenario`` kwargs, called on the worker thread rather than by
+        the caller -- it's where FDS directory inspection happens (parsing
+        every slice header via fdsreader), which can take real time for a
+        large deck. Building it inline in the request handler blocked the
+        HTTP response until it finished, so the browser sat on the old page
+        with no visible progress for however long that parse took, even
+        though the button had already flipped to "in progress". Deferring it
+        here means the SSE-driven progress view mounts immediately instead.
 
         ``post_run`` runs in the worker after the simulation and before the
         status flips to ``done``; its returned strings (e.g. written output
@@ -125,6 +146,7 @@ class RunManager:
         if not self._lock.acquire(blocking=False):
             raise RuntimeError("A run is already in progress.")
 
+        self._cancel.clear()
         self.status = "running"
         self.result = None
         self.error = None
@@ -139,6 +161,8 @@ class RunManager:
         self.warnings = []
 
         def on_progress(ev: ProgressEvent) -> None:
+            if self._cancel.is_set():
+                raise RunCancelled()
             self.last_event = ev
             _max = getattr(ev, "max_fed", None)
             _mean = getattr(ev, "mean_fed", None)
@@ -159,6 +183,7 @@ class RunManager:
                 model_logger.setLevel(logging.WARNING)
             try:
                 with contextlib.redirect_stdout(capture):
+                    run_kwargs = build_run_kwargs()
                     result = run_scenario(
                         scenario, progress_callback=on_progress, **run_kwargs
                     )
@@ -166,6 +191,12 @@ class RunManager:
                     if post_run is not None:
                         self.artifacts = post_run(result)
                 self.status = "done"
+            except RunCancelled:
+                # A deliberate stop, not a failure: leave no error for the UI
+                # to report and drop any partial result.
+                self.result = None
+                self.error = None
+                self.status = "cancelled"
             except Exception as exc:  # surface any run failure to the UI
                 self.error = f"{type(exc).__name__}: {exc}"
                 self.status = "error"
@@ -176,3 +207,28 @@ class RunManager:
 
         self._thread = threading.Thread(target=worker, daemon=True)
         self._thread.start()
+
+    def cancel(self) -> bool:
+        """Ask an in-flight run to stop. Returns whether one was running."""
+        if not self.running:
+            return False
+        self._cancel.set()
+        return True
+
+    def reset(self) -> None:
+        """Drop the finished run's state and return the manager to idle.
+
+        Only meaningful once a run has ended -- an active run owns the lock
+        and must be cancelled, not reset out from under itself.
+        """
+        if self.running:
+            return
+        self.status = "idle"
+        self.result = None
+        self.error = None
+        self.scenario_name = None
+        self.last_event = None
+        self.artifacts = []
+        self.fed_snapshots = []
+        self.log_lines = []
+        self.warnings = []

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -1,20 +1,30 @@
-"""Visual theme for the pyFDS-Evac GUI: dark "Instrument" UI with a fire palette.
+"""Visual theme for the pyFDS-Evac GUI: an "Instrument" UI with a fire palette.
 
-Smoky warm-grey ground (#211e20), warm off-white ink (#f2ede9), and a molten
-heat ramp — gold -> amber -> orange -> crimson — for fire-simulation context.
-The Model tab is intentionally a different world: a cyberpunk / early-2000s
-retro terminal (Press Start 2P + VT323, scanlines, neon, green-on-black math),
-scoped under ``#tab-model`` so the Simulation tab stays clean.
+Two grounds share one ink system and one heat ramp:
 
-Drop-in replacement for the original ``theme.py`` — all class names the app
-emits are preserved; only the visual values change.
+* **dark** (default) — smoky warm-grey ground, warm off-white ink.
+* **light** — warm paper, which is the look the Model tab already used, so
+  the two tabs stop disagreeing with each other when light is selected.
+
+The heat ramp (gold -> amber -> orange -> crimson) is deliberately *identical*
+in both. It encodes tenability tiers, so it is data rather than chrome, and a
+screenshot taken in one theme has to stay comparable with one taken in the
+other. Everything else is expressed as a token and redefined under
+``html[data-theme="light"]``.
+
+The selected theme is stored in ``localStorage`` under ``pyfds-theme``, and
+falls back to the reader's OS preference while no choice has been made.
+:func:`boot_script` resolves it before first paint so a light-mode reader
+never sees a dark flash.
+
+All class names the app emits are preserved; only the visual values change.
 """
 
 from __future__ import annotations
 
 from typing import Any, List
 
-from fasthtml.common import Link, Style
+from fasthtml.common import Button, Div, Link, NotStr, Script, Span, Style
 
 _FONTS = Link(
     rel="stylesheet",
@@ -36,6 +46,19 @@ _FONTS = Link(
 #   molten primary  gold #ffc24d -> burnt orange #e8590c
 #   retro/cyber (model only)  cyan #18e0ff  magenta #ff2d9b  green #39ff14  amber #ffb000
 _CSS = """
+/* ------------------------------------------------------------------ */
+/*  Tokens.                                                            */
+/*                                                                     */
+/*  Two grounds, one ink system, one heat ramp.  The heat ramp is the  */
+/*  only part that does NOT flip between themes: gold/amber/orange/    */
+/*  crimson encode tenability tiers, so they are data, not chrome, and */
+/*  a reader must be able to compare a screenshot of one theme against */
+/*  a screenshot of the other.  Everything below the ramp is chrome    */
+/*  and is redefined for light.                                        */
+/*                                                                     */
+/*  Anything with a literal colour in a rule further down is a bug     */
+/*  waiting for the next theme: put it here instead.                   */
+/* ------------------------------------------------------------------ */
 :root, html.uk-theme-blue {
   --background: 320 4% 12%;
   --foreground: 27 30% 93%;
@@ -62,6 +85,7 @@ _CSS = """
   --font-sans:    'Hanken Grotesk', system-ui, sans-serif;
   --font-mono:    'JetBrains Mono', ui-monospace, monospace;
 
+  /* heat ramp — identical in both themes, see note above */
   --ember:  #ff6a1a;
   --gold:   #f4c430;
   --tier-safe:     #f4c430;
@@ -69,13 +93,112 @@ _CSS = """
   --tier-critical: #ff6a1a;
   --tier-severe:   #e01e37;
 
+  /* surfaces */
+  --surface-page:    #211e20;
+  --surface-card:    #2a262a;
+  --surface-panel:   #14161b;
+  --surface-input:   #2e2a2e;
+  --surface-raised:  #3a343a;
+  --surface-accent:  #322e32;
+  --surface-sunken:  #211e21;
+  --surface-canvas:  #1c191c;
+  --surface-tooltip: #0d0c0e;
+  --tooltip-ink:     #f2ede9;
+
+  /* the console keeps a dark ground in both themes: it is terminal
+     output, and inverting it makes streamed FDS logs harder to scan */
+  --surface-console: #131113;
+  --ink-console:     #d7cfca;
+
+  /* ink */
+  --ink:       #f2ede9;
+  --ink-dim:   #b2a9a3;
+  --ink-faint: #837a74;
+
+  /* hairlines, from softest to strongest */
+  --hairline-soft:   rgba(255,255,255,.04);
+  --hairline:        rgba(255,255,255,.07);
+  --hairline-strong: rgba(255,255,255,.10);
+  --hairline-badge:  rgba(255,255,255,.18);
+
+  /* ink that sits on top of a heat-ramp fill */
+  --on-heat: #2a1606;
+
+  /* active tab pill inverts the ground */
+  --pill-active-bg: #f2ede9;
+  --pill-active-fg: #211e20;
+
+  /* the two warm washes behind the page */
+  --glow-warm: rgba(255,90,31,.10);
+  --glow-gold: rgba(244,196,48,.06);
+
   --shadow-sm:  0 1px 3px rgba(0,0,0,.4),  0 1px 2px rgba(0,0,0,.3);
   --shadow-md:  0 8px 24px rgba(0,0,0,.45), 0 2px 6px rgba(0,0,0,.3);
   --shadow-lg:  0 18px 50px rgba(0,0,0,.55), 0 4px 12px rgba(0,0,0,.35);
 }
 html.uk-theme-blue { color-scheme: dark; }
 
-html, body { background: #211e20; }
+/* ---- light ground: warm paper, matching the Model tab's reference look --- */
+html[data-theme="light"] {
+  color-scheme: light;
+
+  --background: 36 30% 97%;
+  --foreground: 24 14% 13%;
+  --card: 0 0% 100%;
+  --card-foreground: 24 14% 13%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 24 14% 13%;
+  --primary: 22 100% 45%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 32 20% 92%;
+  --secondary-foreground: 24 14% 20%;
+  --muted: 32 20% 92%;
+  --muted-foreground: 25 8% 40%;
+  --accent: 38 90% 92%;
+  --accent-foreground: 22 80% 32%;
+  --destructive: 350 72% 45%;
+  --destructive-foreground: 0 0% 100%;
+  --border: 30 12% 84%;
+  --input: 0 0% 100%;
+  --ring: 22 90% 48%;
+
+  --surface-page:    #faf7f2;
+  --surface-card:    #fffdfa;
+  --surface-panel:   #ffffff;
+  --surface-input:   #ffffff;
+  --surface-raised:  #efe9e0;
+  --surface-accent:  #f4efe7;
+  --surface-sunken:  #f4efe7;
+  --surface-canvas:  #f3eee6;
+  --surface-tooltip: #2a262a;
+  --tooltip-ink:     #f2ede9;
+
+  --ink:       #241f1c;
+  --ink-dim:   #5c534c;
+  --ink-faint: #857b72;
+
+  --hairline-soft:   rgba(31,23,16,.045);
+  --hairline:        rgba(31,23,16,.10);
+  --hairline-strong: rgba(31,23,16,.15);
+  --hairline-badge:  rgba(31,23,16,.24);
+
+  --pill-active-bg: #241f1c;
+  --pill-active-fg: #faf7f2;
+
+  --glow-warm: rgba(255,106,26,.07);
+  --glow-gold: rgba(244,196,48,.10);
+
+  --shadow-sm:  0 1px 2px rgba(60,45,30,.07);
+  --shadow-md:  0 6px 18px rgba(60,45,30,.09), 0 1px 3px rgba(60,45,30,.06);
+  --shadow-lg:  0 16px 40px rgba(60,45,30,.13), 0 3px 8px rgba(60,45,30,.07);
+}
+
+/* On light, a flat gold fill under near-black text is louder than the
+   design wants for a *secondary* control, so the ramp is used as an
+   outline there instead of a fill.  Primary actions keep the fill. */
+html[data-theme="light"] .mode-btn.active { background: var(--gold); color: var(--on-heat); }
+
+html, body { background: var(--surface-page); }
 body {
   font-family: var(--font-sans);
   color: hsl(var(--foreground));
@@ -83,9 +206,9 @@ body {
   -moz-osx-font-smoothing: grayscale;
   min-height: 100vh;
   background:
-    radial-gradient(120% 80% at 85% -10%, rgba(255,90,31,.10), transparent 55%),
-    radial-gradient(90% 70% at 5% 0%,     rgba(244,196,48,.06), transparent 50%),
-    #211e20;
+    radial-gradient(120% 80% at 85% -10%, var(--glow-warm), transparent 55%),
+    radial-gradient(90% 70% at 5% 0%,     var(--glow-gold), transparent 50%),
+    var(--surface-page);
 }
 .uk-container, .app-header { position: relative; z-index: 1; }
 
@@ -107,9 +230,9 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .uk-input, .uk-select, input, select, textarea {
   font-family: var(--font-mono);
   font-size: .85rem;
-  background: #2e2a2e;
+  background: var(--surface-input);
   color: hsl(var(--foreground));
-  border: 1px solid rgba(255,255,255,.10);
+  border: 1px solid var(--hairline-strong);
   border-radius: .55rem;
   transition: border-color .15s, box-shadow .15s;
 }
@@ -128,7 +251,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .help-badge {
   display: inline-flex; align-items: center; justify-content: center;
   width: 15px; height: 15px; border-radius: 99px;
-  border: 1px solid rgba(255,255,255,.18); color: hsl(var(--muted-foreground));
+  border: 1px solid var(--hairline-badge); color: hsl(var(--muted-foreground));
   font-size: .58rem; font-weight: 700; cursor: pointer;
   transition: color .12s, border-color .12s; user-select: none;
 }
@@ -136,10 +259,10 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .lblwrap.open .help-badge { color: var(--gold); border-color: var(--gold); }
 .badge-tip {
   display: none;
-  background: #0d0c0e; color: #f2ede9;
+  background: var(--surface-tooltip); color: var(--ink);
   font-size: .72rem; font-weight: 400; line-height: 1.5;
   text-transform: none; letter-spacing: normal;
-  padding: .5rem .65rem; border-radius: .5rem; border: 1px solid rgba(255,255,255,.14);
+  padding: .5rem .65rem; border-radius: .5rem; border: 1px solid var(--hairline-badge);
   white-space: normal; box-shadow: var(--shadow-md);
 }
 .lblwrap.open .badge-tip { display: block; }
@@ -152,31 +275,31 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 /* ---- scenario upload (sits under the picker, inside Core) ---- */
 .upload-block {
   display: flex; flex-direction: column; gap: 8px;
-  border-top: 1px dashed rgba(255,255,255,.10); margin-top: 4px; padding-top: 11px;
+  border-top: 1px dashed var(--hairline-strong); margin-top: 4px; padding-top: 11px;
 }
 .upload-title {
   font-family: 'Space Grotesk', sans-serif; font-size: 10.5px; font-weight: 500;
-  letter-spacing: .07em; text-transform: uppercase; color: #837A74;
+  letter-spacing: .07em; text-transform: uppercase; color: var(--ink-faint);
 }
 .upload-name {
-  background: #2E2A2E; border: 1px solid rgba(255,255,255,.09); border-radius: 9px;
-  padding: 9px 11px; color: #F2EDE9; font-family: 'JetBrains Mono', monospace;
+  background: var(--surface-input); border: 1px solid var(--hairline); border-radius: 9px;
+  padding: 9px 11px; color: var(--ink); font-family: 'JetBrains Mono', monospace;
   font-size: 12px; outline: none; width: 100%; box-sizing: border-box;
 }
 .upload-drop {
   display: flex; flex-direction: column; align-items: center; gap: 3px;
   padding: 16px 12px; cursor: pointer; text-align: center;
-  border: 1px dashed rgba(255,255,255,.18); border-radius: 10px;
-  background: #211E21; transition: border-color .12s, background .12s;
+  border: 1px dashed var(--hairline-badge); border-radius: 10px;
+  background: var(--surface-sunken); transition: border-color .12s, background .12s;
 }
 .upload-drop:hover, .upload-drop.over {
   border-color: var(--gold); background: rgba(244,196,48,.06);
 }
 .upload-drop-title {
-  font-family: 'Space Grotesk', sans-serif; font-size: 12px; color: #F2EDE9;
+  font-family: 'Space Grotesk', sans-serif; font-size: 12px; color: var(--ink);
 }
 .upload-drop-sub, .upload-hint {
-  font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: #837A74;
+  font-family: 'JetBrains Mono', monospace; font-size: 9.5px; color: var(--ink-faint);
   line-height: 1.5;
 }
 .upload-picked {
@@ -187,7 +310,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .upload-btn {
   display: flex; align-items: center; justify-content: center; gap: .35rem;
   width: 100%; padding: 9px; border-radius: 9px; cursor: pointer;
-  border: 1px solid rgba(255,255,255,.12); background: #3A343A; color: #F2EDE9;
+  border: 1px solid var(--hairline-strong); background: var(--surface-raised); color: var(--ink);
   font-family: 'Space Grotesk', sans-serif; font-size: 12.5px; font-weight: 500;
 }
 .upload-btn:hover { border-color: var(--gold); color: var(--gold); }
@@ -198,10 +321,10 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .app-header {
   display: flex; align-items: center; justify-content: center;
   padding: 1rem 2rem;
-  background: rgba(33,30,32,.72);
+  background: color-mix(in srgb, var(--surface-page) 78%, transparent);
   backdrop-filter: saturate(150%) blur(18px);
   -webkit-backdrop-filter: saturate(150%) blur(18px);
-  border-bottom: 1px solid rgba(255,255,255,.07);
+  border-bottom: 1px solid var(--hairline);
   position: sticky; top: 0; z-index: 50;
 }
 .brand-group { display: flex; align-items: center; gap: 1rem; }
@@ -226,8 +349,8 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 
 /* ---- cards ---- */
 .uk-card {
-  background: #2a262a;
-  border: 1px solid rgba(255,255,255,.07);
+  background: var(--surface-card);
+  border: 1px solid var(--hairline);
   border-radius: 1.1rem;
   box-shadow: var(--shadow-md);
   transition: box-shadow .2s, border-color .2s;
@@ -247,16 +370,16 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 
 /* ---- accordion ---- */
 .uk-accordion-title {
-  background: #322e32 !important;
+  background: var(--surface-accent) !important;
   color: hsl(var(--foreground)) !important;
   font-family: var(--font-display) !important;
   font-weight: 600; font-size: .95rem !important; letter-spacing: -.01em;
   padding: .7rem 1rem; border-radius: .7rem;
-  border: 1px solid rgba(255,255,255,.07); border-left: 2px solid var(--ember);
+  border: 1px solid var(--hairline); border-left: 2px solid var(--ember);
   transition: border-color .15s, background .15s;
 }
-.uk-accordion-title:hover { background: #3a343a !important; }
-.uk-open > .uk-accordion-title { border-left-color: var(--gold); background: #3a343a !important; }
+.uk-accordion-title:hover { background: var(--surface-raised) !important; }
+.uk-open > .uk-accordion-title { border-left-color: var(--gold); background: var(--surface-raised) !important; }
 
 /* ---- buttons ---- */
 .uk-btn {
@@ -267,21 +390,21 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .uk-btn:active { transform: scale(.98); }
 .uk-btn-primary {
   background: linear-gradient(180deg, #ffc24d, #e8590c);
-  color: #2a1606;
+  color: var(--on-heat);
   box-shadow: 0 6px 20px rgba(232,89,12,.3);
 }
 .uk-btn-primary:hover { filter: brightness(1.06); box-shadow: 0 8px 26px rgba(232,89,12,.4); }
 .uk-btn-secondary {
-  background: #3a343a; color: hsl(var(--foreground));
-  border: 1px solid rgba(255,255,255,.1);
+  background: var(--surface-raised); color: hsl(var(--foreground));
+  border: 1px solid var(--hairline-strong);
 }
 .uk-btn-secondary:hover { border-color: var(--gold); color: var(--gold); }
-.uk-btn-ghost:hover { background: #3a343a; color: var(--gold); }
+.uk-btn-ghost:hover { background: var(--surface-raised); color: var(--gold); }
 
 /* ---- incapacitation mode toggle ---- */
 .mode-toggle {
   display: flex; max-width: 17rem;
-  background: #2e2a2e; border: 1px solid rgba(255,255,255,.08);
+  background: var(--surface-input); border: 1px solid var(--hairline-strong);
   border-radius: .65rem; padding: 4px; gap: 4px;
 }
 .mode-btn {
@@ -292,7 +415,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   border: 0; border-radius: .48rem;
   transition: background .15s, color .15s, box-shadow .15s;
 }
-.mode-btn.active { background: var(--gold); color: #2a1606; box-shadow: var(--shadow-sm); }
+.mode-btn.active { background: var(--gold); color: var(--on-heat); box-shadow: var(--shadow-sm); }
 .mode-btn:hover:not(.active) { color: hsl(var(--foreground)); }
 
 /* ---- run panel ---- */
@@ -304,7 +427,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 }
 .metric-cell {
   display: flex; align-items: baseline; justify-content: space-between;
-  gap: 1rem; padding: .45rem 0; border-bottom: 1px solid rgba(255,255,255,.07);
+  gap: 1rem; padding: .45rem 0; border-bottom: 1px solid var(--hairline);
 }
 .metric-k {
   font-family: var(--font-mono);
@@ -322,7 +445,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .tab-nav { display: flex; align-items: center; justify-content: center; padding: 1rem 1.5rem .5rem; }
 .tab-pills {
   display: flex; gap: 3px; padding: 3px; width: fit-content; margin: 0 auto;
-  background: rgba(255,255,255,.04); border-radius: .7rem; border: 1px solid rgba(255,255,255,.07);
+  background: var(--hairline-soft); border-radius: .7rem; border: 1px solid var(--hairline);
 }
 .tab-btn {
   font-family: var(--font-display);
@@ -331,19 +454,19 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
   border-radius: .55rem; color: hsl(var(--muted-foreground));
   cursor: pointer; transition: background .15s, color .15s, box-shadow .15s;
 }
-.tab-btn:hover:not(.active) { color: hsl(var(--foreground)); background: rgba(255,255,255,.04); }
-.tab-btn.active { background: #f2ede9; color: #211e20; box-shadow: var(--shadow-sm); }
+.tab-btn:hover:not(.active) { color: hsl(var(--foreground)); background: var(--hairline-soft); }
+.tab-btn.active { background: var(--pill-active-bg); color: var(--pill-active-fg); box-shadow: var(--shadow-sm); }
 
 /* ---- trajectory canvas ---- */
 .traj-wrap { margin-top: .6rem; }
 .traj-canvas {
   width: 100%; height: 460px; display: block;
-  border: 1px solid rgba(255,255,255,.08); border-radius: .9rem; background: #1c191c;
+  border: 1px solid var(--hairline-strong); border-radius: .9rem; background: var(--surface-canvas);
 }
 .traj-controls { display: flex; align-items: center; gap: .8rem; margin-top: .7rem; }
 .traj-play {
   width: 2.2rem; height: 2.2rem; flex: none; border-radius: 99px;
-  border: 1px solid rgba(255,255,255,.12); background: #322e32;
+  border: 1px solid var(--hairline-strong); background: var(--surface-accent);
   color: hsl(var(--foreground)); cursor: pointer; font-size: .8rem;
   display: inline-flex; align-items: center; justify-content: center;
   box-shadow: var(--shadow-sm); transition: border-color .12s, color .12s;
@@ -359,15 +482,15 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .cmode {
   font-family: var(--font-display);
   font-size: .72rem; font-weight: 500; padding: .28rem .65rem; cursor: pointer;
-  border: 1px solid rgba(255,255,255,.1); border-radius: .45rem;
-  background: #2e2a2e; color: hsl(var(--muted-foreground));
+  border: 1px solid var(--hairline-strong); border-radius: .45rem;
+  background: var(--surface-input); color: hsl(var(--muted-foreground));
   transition: border-color .12s, color .12s, background .12s;
 }
 .cmode.active { border-color: var(--ember); color: var(--ember); background: rgba(255,106,26,.12); }
 .speed-custom {
   width: 4.2rem; font-family: var(--font-mono); font-size: .68rem;
-  padding: .28rem .5rem; border: 1px solid rgba(255,255,255,.1); border-radius: .45rem;
-  background: #2e2a2e; color: hsl(var(--foreground));
+  padding: .28rem .5rem; border: 1px solid var(--hairline-strong); border-radius: .45rem;
+  background: var(--surface-input); color: hsl(var(--foreground));
 }
 .speed-custom.active { border-color: var(--ember); box-shadow: 0 0 0 1px var(--ember) inset; }
 .speed-custom::-webkit-inner-spin-button, .speed-custom::-webkit-outer-spin-button { margin-left: .2rem; }
@@ -375,12 +498,12 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 /* ---- console ---- */
 .console-box {
   max-height: 20rem; overflow: auto;
-  background: #131113 !important; border: 1px solid rgba(255,255,255,.07);
+  background: var(--surface-console) !important; border: 1px solid var(--hairline);
   border-radius: .9rem; padding: .9rem 1.1rem;
 }
 .console-box pre {
   font-family: var(--font-mono); font-size: .75rem; line-height: 1.7;
-  color: #d7cfca !important; background: transparent !important;
+  color: var(--ink-console) !important; background: transparent !important;
   border: 0 !important; padding: 0 !important; margin: 0;
   white-space: pre-wrap; word-break: break-word;
 }
@@ -397,8 +520,8 @@ input[type="number"]::-webkit-inner-spin-button,
 input[type="number"]::-webkit-outer-spin-button {
   -webkit-appearance: none;
   appearance: none;
-  background: #3A343A;
-  border-left: 1px solid rgba(255,255,255,.09);
+  background: var(--surface-raised);
+  border-left: 1px solid var(--hairline);
   border-radius: 0 9px 9px 0;
   opacity: 1;
   cursor: pointer;
@@ -407,9 +530,9 @@ input[type="number"]::-webkit-outer-spin-button {
 input[type="number"] { -moz-appearance: textfield; }
 
 /* ---- scrollbar ---- */
-* { scrollbar-width: thin; scrollbar-color: rgba(255,255,255,.14) transparent; }
+* { scrollbar-width: thin; scrollbar-color: var(--hairline-badge) transparent; }
 *::-webkit-scrollbar { width: 8px; height: 8px; }
-*::-webkit-scrollbar-thumb { background: rgba(255,255,255,.14); border-radius: 99px; }
+*::-webkit-scrollbar-thumb { background: var(--hairline-badge); border-radius: 99px; }
 *::-webkit-scrollbar-thumb:hover { background: var(--ember); }
 
 /* ---- load motion ---- */
@@ -486,9 +609,202 @@ details[open] summary .chevron { transform: rotate(180deg); }
 #tab-model .tier-card.severe h4   { color: #cc2030; }
 #tab-model .tier-card p { font-family: var(--font-mono); color: #6b655c; }
 @media (max-width: 640px) { #tab-model .tier-grid { grid-template-columns: repeat(2, 1fr); } }
+
+/* =================================================================== */
+/*  Theme switch — page footer                                          */
+/* =================================================================== */
+.theme-foot {
+  display: flex; align-items: center; justify-content: center; gap: .75rem;
+  padding: 0 26px 34px; margin: 0 auto; max-width: 1480px;
+}
+.theme-foot::before, .theme-foot::after {
+  content: ""; flex: 1; height: 1px; background: var(--hairline);
+}
+.theme-switch {
+  display: inline-flex; align-items: center; gap: 2px; flex: none;
+  padding: 3px; border-radius: 99px;
+  background: var(--surface-input);
+  border: 1px solid var(--hairline-strong);
+  box-shadow: var(--shadow-sm);
+}
+.theme-opt {
+  display: inline-flex; align-items: center; gap: .4rem;
+  padding: .34rem .8rem; border: 0; border-radius: 99px; cursor: pointer;
+  background: transparent; color: var(--ink-faint);
+  font-family: var(--font-display); font-size: .74rem; font-weight: 500;
+  letter-spacing: -.005em; line-height: 1;
+  transition: color .15s, background .15s;
+}
+.theme-opt:hover { color: var(--ink); }
+.theme-opt svg { width: 13px; height: 13px; display: block; }
+/* The selected side carries the ramp, so the control reads as part of the
+   fire palette rather than as a generic OS switch. */
+.theme-opt[aria-pressed="true"] {
+  background: var(--gold); color: var(--on-heat);
+  box-shadow: var(--shadow-sm);
+}
+.theme-opt[aria-pressed="true"]:hover { color: var(--on-heat); }
+.theme-foot-note {
+  flex: none; font-family: var(--font-mono); font-size: .62rem;
+  letter-spacing: .04em; text-transform: uppercase; color: var(--ink-faint);
+}
+
+/* Suppress transitions during the flip so 40-odd panels do not each run
+   their own colour animation at slightly different speeds. */
+html.theme-switching, html.theme-switching * {
+  transition: none !important; animation: none !important;
+}
 """
+
+# Applied before first paint, so a light-mode reader never sees a dark
+# flash.  Inlined in <head> rather than deferred for exactly that reason.
+_THEME_BOOT_JS = """
+(function () {
+  try {
+    var saved = localStorage.getItem('pyfds-theme');
+    var mode = saved
+      || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
+    if (mode === 'light') document.documentElement.setAttribute('data-theme', 'light');
+  } catch (e) { /* private mode: fall through to dark */ }
+})();
+"""
+
+# Wired up after the footer exists.  Also re-styles the Plotly figures and
+# the trajectory canvas, neither of which is reachable from CSS.
+_THEME_JS = """
+(function () {
+  var root = document.documentElement;
+
+  function current() {
+    return root.getAttribute('data-theme') === 'light' ? 'light' : 'dark';
+  }
+
+  function paintButtons() {
+    var mode = current();
+    document.querySelectorAll('.theme-opt').forEach(function (b) {
+      b.setAttribute('aria-pressed', String(b.dataset.mode === mode));
+    });
+  }
+
+  // Plotly bakes its font and grid colours into the figure at render time,
+  // so a CSS variable cannot reach them; restyle every plot in place.
+  function repaintPlots() {
+    if (!window.Plotly) return;
+    var css = getComputedStyle(root);
+    var ink = css.getPropertyValue('--ink-dim').trim();
+    var line = current() === 'light' ? 'rgba(31,23,16,.13)' : 'rgba(255,255,255,.10)';
+    document.querySelectorAll('.js-plotly-plot').forEach(function (gd) {
+      try {
+        window.Plotly.relayout(gd, {
+          'font.color': ink,
+          'xaxis.gridcolor': line, 'yaxis.gridcolor': line,
+          'xaxis.linecolor': line, 'yaxis.linecolor': line,
+          'xaxis.zerolinecolor': line, 'yaxis.zerolinecolor': line,
+          'legend.font.color': ink
+        });
+      } catch (e) { /* figure not ready yet */ }
+    });
+  }
+
+  function apply(mode, persist) {
+    root.classList.add('theme-switching');
+    if (mode === 'light') root.setAttribute('data-theme', 'light');
+    else root.removeAttribute('data-theme');
+    if (persist) {
+      try { localStorage.setItem('pyfds-theme', mode); } catch (e) {}
+    }
+    paintButtons();
+    repaintPlots();
+    // The trajectory canvas paints from CSS variables it read at draw time.
+    if (typeof window.trajRepaint === 'function') { try { window.trajRepaint(); } catch (e) {} }
+    if (typeof window.drawIncapDist === 'function') { try { window.drawIncapDist(); } catch (e) {} }
+    window.requestAnimationFrame(function () {
+      window.requestAnimationFrame(function () { root.classList.remove('theme-switching'); });
+    });
+  }
+
+  document.addEventListener('click', function (ev) {
+    var btn = ev.target.closest('.theme-opt');
+    if (!btn) return;
+    apply(btn.dataset.mode, true);
+  });
+
+  // Follow the OS only while the reader has not made a choice of their own.
+  var mq = window.matchMedia('(prefers-color-scheme: light)');
+  var onSystem = function (e) {
+    var saved = null;
+    try { saved = localStorage.getItem('pyfds-theme'); } catch (err) {}
+    if (!saved) apply(e.matches ? 'light' : 'dark', false);
+  };
+  if (mq.addEventListener) mq.addEventListener('change', onSystem);
+  else if (mq.addListener) mq.addListener(onSystem);
+
+  paintButtons();
+  // Plotly figures arrive with the results panel, well after this runs.
+  document.body.addEventListener('htmx:afterSwap', function () {
+    window.setTimeout(repaintPlots, 0);
+  });
+  window.setTimeout(repaintPlots, 0);
+})();
+"""
+
+_SUN = NotStr(
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+    'stroke-linecap="round" aria-hidden="true">'
+    '<circle cx="12" cy="12" r="4.2"/>'
+    '<path d="M12 2v2.4M12 19.6V22M2 12h2.4M19.6 12H22'
+    'M4.9 4.9l1.7 1.7M17.4 17.4l1.7 1.7M19.1 4.9l-1.7 1.7M6.6 17.4l-1.7 1.7"/>'
+    "</svg>"
+)
+_MOON = NotStr(
+    '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+    'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+    '<path d="M20.5 14.2A8.5 8.5 0 1 1 9.8 3.5a6.8 6.8 0 0 0 10.7 10.7Z"/>'
+    "</svg>"
+)
+
+
+def boot_script() -> Any:
+    """Pre-paint theme resolution. Must go in <head>, before any body CSS."""
+    return Script(_THEME_BOOT_JS)
+
+
+def switch() -> Any:
+    """The light/dark control that sits at the foot of the page."""
+    return Div(
+        Div(
+            Button(
+                _MOON,
+                Span("Dark"),
+                cls="theme-opt",
+                data_mode="dark",
+                type="button",
+                aria_pressed="true",
+                title="Use the dark instrument theme",
+            ),
+            Button(
+                _SUN,
+                Span("Light"),
+                cls="theme-opt",
+                data_mode="light",
+                type="button",
+                aria_pressed="false",
+                title="Use the light warm-paper theme",
+            ),
+            cls="theme-switch",
+            role="group",
+            aria_label="Colour theme",
+        ),
+        Span("appearance", cls="theme-foot-note"),
+        cls="theme-foot",
+    )
+
+
+def script() -> Any:
+    """Behaviour for :func:`switch`. Emit once, after the footer."""
+    return Script(_THEME_JS)
 
 
 def headers() -> List[Any]:
     """Return the <head> elements that apply the theme (after franken-ui)."""
-    return [_FONTS, Style(_CSS)]
+    return [_FONTS, Style(_CSS), boot_script()]

--- a/pyfds_evac/webapp/theme.py
+++ b/pyfds_evac/webapp/theme.py
@@ -259,7 +259,7 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 .lblwrap.open .help-badge { color: var(--gold); border-color: var(--gold); }
 .badge-tip {
   display: none;
-  background: var(--surface-tooltip); color: var(--ink);
+  background: var(--surface-tooltip); color: var(--tooltip-ink);
   font-size: .72rem; font-weight: 400; line-height: 1.5;
   text-transform: none; letter-spacing: normal;
   padding: .5rem .65rem; border-radius: .5rem; border: 1px solid var(--hairline-badge);
@@ -269,7 +269,10 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 
 /* run button running-state */
 .run-btn:disabled { cursor: progress; filter: saturate(.5) brightness(.92); opacity: .9; }
-.run-btn:disabled .run-btn-icon { animation: pulse 1.3s ease-in-out infinite; }
+.run-btn:disabled .run-btn-icon {
+  display: inline-block; border-radius: 99px;
+  animation: pulse 1.3s ease-in-out infinite;
+}
 .results-btn:hover:not(:disabled) { background: rgba(244,196,48,.10); }
 
 /* ---- scenario upload (sits under the picker, inside Core) ---- */
@@ -459,10 +462,63 @@ h1, h2, h3, h4, .uk-card-title, .uk-h1, .uk-h2, .uk-h3 {
 
 /* ---- trajectory canvas ---- */
 .traj-wrap { margin-top: .6rem; }
+.traj-canvas-shell { position: relative; }
 .traj-canvas {
   width: 100%; height: 460px; display: block;
   border: 1px solid var(--hairline-strong); border-radius: .9rem; background: var(--surface-canvas);
 }
+.traj-fs-btn {
+  position: absolute; right: 12px; bottom: 12px; z-index: 3;
+  width: 2.1rem; height: 2.1rem; border-radius: .5rem;
+  border: 1px solid rgba(255,255,255,.25); background: rgba(20,16,12,.55);
+  color: #fff; cursor: pointer; font-size: 1.05rem; line-height: 1;
+  display: inline-flex; align-items: center; justify-content: center;
+  opacity: .75; transition: opacity .15s, border-color .12s, color .12s;
+}
+.traj-fs-btn:hover { opacity: 1; border-color: var(--ember); color: var(--ember); }
+/* Fullscreen goes edge-to-edge, YouTube-style: the canvas fills the whole
+   screen, the controls float as a bottom overlay instead of pushing it up,
+   and the FED panel (a separate summary widget, not part of the playback) is
+   hidden rather than eating vertical space underneath.
+
+   Keyed off a JS-toggled .traj-fs class, NOT :fullscreen. A selector list is
+   invalid as a whole if any one selector in it is unrecognised, so pairing
+   :fullscreen with a vendor-prefixed twin makes the browser discard the
+   entire rule on any engine that knows only one of them -- which silently
+   left fullscreen completely unstyled. Keep the vendor pseudo-classes in
+   their own single-selector rules below as a no-JS fallback. */
+.traj-wrap.traj-fs {
+  position: fixed; inset: 0; width: 100vw; height: 100vh;
+  z-index: 9999; background: var(--surface-canvas);
+  padding: 0; margin: 0; border-radius: 0;
+}
+.traj-wrap.traj-fs .traj-canvas-shell { position: absolute; inset: 0; }
+.traj-wrap.traj-fs .traj-canvas {
+  width: 100%; height: 100%; border: none; border-radius: 0;
+}
+.traj-wrap.traj-fs .traj-controls {
+  position: absolute; left: 0; right: 0; bottom: 0; z-index: 4;
+  margin: 0; padding: 1rem 1.6rem 1.2rem;
+  background: linear-gradient(to top, rgba(0,0,0,.78), rgba(0,0,0,0));
+}
+.traj-wrap.traj-fs .traj-time { color: #fff; }
+.traj-wrap.traj-fs .traj-color-lbl { color: rgba(255,255,255,.72); }
+.traj-wrap.traj-fs #fed-panel { display: none; }
+.traj-wrap.traj-fs .traj-fs-btn { top: 14px; right: 14px; bottom: auto; z-index: 5; }
+/* Idle state while playing (inline and fullscreen alike): chrome fades out,
+   pointer vanishes. The canvas carries an inline `cursor: grab` set from JS,
+   and an inline style outranks a plain class rule -- hence !important on
+   that one selector. */
+.traj-wrap .traj-controls,
+.traj-wrap .traj-fs-btn { transition: opacity .28s ease; }
+.traj-wrap.traj-idle { cursor: none; }
+.traj-wrap.traj-idle .traj-canvas { cursor: none !important; }
+.traj-wrap.traj-idle .traj-controls,
+.traj-wrap.traj-idle .traj-fs-btn { opacity: 0; pointer-events: none; }
+/* Fallback for a browser that enters fullscreen without firing our handler.
+   Deliberately one selector per rule -- see the note above. */
+.traj-wrap:fullscreen { background: var(--surface-canvas); padding: 0; }
+.traj-wrap:-webkit-full-screen { background: var(--surface-canvas); padding: 0; }
 .traj-controls { display: flex; align-items: center; gap: .8rem; margin-top: .7rem; }
 .traj-play {
   width: 2.2rem; height: 2.2rem; flex: none; border-radius: 99px;

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -653,9 +653,18 @@ _JS = """
     slider.value = String(((simT - t0) / span) * 1000);
     if (D.hasFed) drawFedPanel();
   }
+  // A stalled tab or a frame that took too long to render must not let simT
+  // leap past what was actually recorded: the wall-clock gap between two
+  // rAF callbacks is capped at one sample interval (0.1 s) before it is
+  // applied, so a late callback plays back slow rather than skipping the
+  // steps in between -- the same 0.1 s granularity the data was sampled at.
+  var _RAF_DT_CAP_S = 0.1;
   function loop(ts) {
     if (playing) {
-      if (lastTs != null) simT += ((ts - lastTs) / 1000) * speedMult;
+      if (lastTs != null) {
+        var dt = Math.min((ts - lastTs) / 1000, _RAF_DT_CAP_S);
+        simT += dt * speedMult;
+      }
       lastTs = ts;
       if (simT >= t1) { simT = t1; playing = false; playBtn.textContent = '▶'; }
     }
@@ -744,6 +753,7 @@ _JS = """
     });
   }
   window.addEventListener('resize', draw);
+  draw();
   requestAnimationFrame(loop);
 })();
 """

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -425,7 +425,10 @@ _JS = """
   }
   readTheme();
 
-  var CANVAS_H = 440;           // render height; size() and the wheel handler must agree
+  var CANVAS_H = 440;           // fallback render height when the CSS box hasn't laid out yet
+  // Fullscreen stretches .traj-canvas to fill the viewport via CSS, so the
+  // draw buffer must track clientHeight rather than the fixed fallback.
+  function currentH() { return canvas.clientHeight || CANVAS_H; }
   var dragging = false, dragStart = null;
 
   // Smoke field: decode base64 uint8 frames into an offscreen canvas we can
@@ -478,25 +481,18 @@ _JS = """
     if (clipped) ctx.restore();
   }
 
-  // Pre-compute per-sample FED statistics for the panel
-  var fedMaxByTime = null, fedMeanByTime = null;
+  // Only one agent's dose actually matters for a tenability verdict: whoever
+  // ends up worst off. Find that agent once and track just their curve,
+  // rather than a max/mean blended across the whole crowd.
+  var worstAgent = -1;
   if (D.hasFed) {
-    fedMaxByTime = T.map(function (_, ti) {
-      var m = 0;
-      for (var k = 0; k < n; k++) {
-        var v = fedAt(k, ti);
-        if (v != null && v > m) m = v;
-      }
-      return m;
-    });
-    fedMeanByTime = T.map(function (_, ti) {
-      var s = 0, c = 0;
-      for (var k = 0; k < n; k++) {
-        var v = fedAt(k, ti);
-        if (v != null) { s += v; c++; }
-      }
-      return c > 0 ? s / c : 0;
-    });
+    var worstFinal = -1;
+    for (var wk = 0; wk < n; wk++) {
+      var fr = FED[wk];
+      if (!fr || !fr.length) continue;
+      var last = fr[fr.length - 1];
+      if (last != null && last > worstFinal) { worstFinal = last; worstAgent = wk; }
+    }
   }
 
   // FED dose -> tier colour (green -> amber -> orange -> red).
@@ -525,7 +521,7 @@ _JS = """
 
   function size() {
     var dpr = window.devicePixelRatio || 1;
-    var w = canvas.clientWidth || 600, h = CANVAS_H;
+    var w = canvas.clientWidth || 600, h = currentH();
     canvas.width = w * dpr; canvas.height = h * dpr;
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     return [w, h];
@@ -573,64 +569,17 @@ _JS = """
     return [lo, hi, f];
   }
   function drawFedPanel() {
-    if (!D.hasFed || !fedMaxByTime) return;
+    if (!D.hasFed || worstAgent < 0) return;
     var b = bracket(simT), lo = b[0], hi = b[1], f = b[2];
-    var curMax  = fedMaxByTime[lo]  + (fedMaxByTime[hi]  - fedMaxByTime[lo])  * f;
-    var curMean = fedMeanByTime[lo] + (fedMeanByTime[hi] - fedMeanByTime[lo]) * f;
+    var da = fedAt(worstAgent, lo), dc = fedAt(worstAgent, hi), cur;
+    if (da == null) cur = dc; else if (dc == null) cur = da;
+    else cur = da + (dc - da) * f;
+    if (cur == null) cur = 0;
     function fc(v) { return v >= 1.0 ? '#E01E37' : v >= 0.6 ? '#FF6A1A' : v >= 0.3 ? '#FFB020' : '#F4C430'; }
     var maxEl = document.getElementById('fed-val-max');
-    if (maxEl) { maxEl.textContent = curMax.toFixed(4); maxEl.style.color = fc(curMax); }
-    var meanEl = document.getElementById('fed-val-mean');
-    if (meanEl) { meanEl.textContent = curMean.toFixed(4); meanEl.style.color = fc(curMean); }
+    if (maxEl) { maxEl.textContent = cur.toFixed(4); maxEl.style.color = fc(cur); }
     var barEl = document.getElementById('fed-bar-fill');
-    if (barEl) barEl.style.width = Math.min(100, curMax * 100) + '%';
-    var sc = document.getElementById('fed-spark');
-    if (!sc) return;
-    var dpr = window.devicePixelRatio || 1;
-    var sw = sc.clientWidth, sh = sc.clientHeight;
-    if (!sw || !sh) return;
-    sc.width = sw * dpr; sc.height = sh * dpr;
-    var sctx = sc.getContext('2d');
-    sctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    sctx.clearRect(0, 0, sw, sh);
-    var N = fedMaxByTime.length;
-    var maxV = 0;
-    for (var i = 0; i < N; i++) { if (fedMaxByTime[i] > maxV) maxV = fedMaxByTime[i]; }
-    maxV = Math.max(1.05, maxV * 1.12);
-    function px(i) { return N > 1 ? (i / (N - 1)) * sw : sw / 2; }
-    function py(v) { return sh - (v / maxV) * (sh - 2); }
-    var grad = sctx.createLinearGradient(0, 0, 0, sh);
-    grad.addColorStop(0, 'rgba(244,196,48,.22)');
-    grad.addColorStop(1, 'rgba(244,196,48,0)');
-    sctx.beginPath();
-    sctx.moveTo(px(0), sh);
-    for (var i = 0; i < N; i++) sctx.lineTo(px(i), py(fedMaxByTime[i]));
-    sctx.lineTo(px(N - 1), sh); sctx.closePath();
-    sctx.fillStyle = grad; sctx.fill();
-    sctx.beginPath();
-    for (var i = 0; i < N; i++) { i === 0 ? sctx.moveTo(px(i), py(fedMaxByTime[i])) : sctx.lineTo(px(i), py(fedMaxByTime[i])); }
-    sctx.strokeStyle = '#F4C430'; sctx.lineWidth = 1.5; sctx.stroke();
-    sctx.beginPath();
-    for (var i = 0; i < N; i++) { i === 0 ? sctx.moveTo(px(i), py(fedMeanByTime[i])) : sctx.lineTo(px(i), py(fedMeanByTime[i])); }
-    sctx.strokeStyle = 'rgba(255,138,61,.7)'; sctx.lineWidth = 1;
-    sctx.setLineDash([3, 3]); sctx.stroke(); sctx.setLineDash([]);
-    var threshs = [[0.3, 'rgba(255,176,32,.55)', '0.3'], [1.0, 'rgba(224,30,55,.55)', '1.0']];
-    for (var ti2 = 0; ti2 < threshs.length; ti2++) {
-      var ty = py(threshs[ti2][0]);
-      if (ty >= 0 && ty <= sh) {
-        sctx.beginPath(); sctx.moveTo(0, ty); sctx.lineTo(sw, ty);
-        sctx.strokeStyle = threshs[ti2][1]; sctx.lineWidth = 1;
-        sctx.setLineDash([4, 4]); sctx.stroke(); sctx.setLineDash([]);
-        sctx.fillStyle = threshs[ti2][1]; sctx.font = '9px JetBrains Mono, monospace';
-        sctx.textAlign = 'right'; sctx.fillText(threshs[ti2][2], sw - 3, ty - 3); sctx.textAlign = 'left';
-      }
-    }
-    var curFrac = T.length > 1 ? (simT - T[0]) / (T[T.length - 1] - T[0]) : 0;
-    var cx = Math.max(0, Math.min(sw, curFrac * sw));
-    sctx.beginPath(); sctx.moveTo(cx, 0); sctx.lineTo(cx, sh);
-    sctx.strokeStyle = TH.sparkLine; sctx.lineWidth = 1.5; sctx.stroke();
-    sctx.beginPath(); sctx.arc(cx, py(curMax), 3.5, 0, 6.2832);
-    sctx.fillStyle = fc(curMax); sctx.fill();
+    if (barEl) barEl.style.width = Math.min(100, cur * 100) + '%';
   }
   function draw() {
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
@@ -688,7 +637,10 @@ _JS = """
         simT += dt * speedMult;
       }
       lastTs = ts;
-      if (simT >= t1) { simT = t1; playing = false; playBtn.textContent = '▶'; }
+      if (simT >= t1) {
+        simT = t1; playing = false; playBtn.textContent = '▶';
+        nudgeChrome();  // playback ended: bring the controls back
+      }
     }
     draw();
     requestAnimationFrame(loop);
@@ -697,9 +649,11 @@ _JS = """
     if (simT >= t1) simT = t0;
     playing = !playing; lastTs = null;
     playBtn.textContent = playing ? '❚❚' : '▶';
+    nudgeChrome();
   });
   slider.addEventListener('input', function () {
     playing = false; playBtn.textContent = '▶';
+    nudgeChrome();
     simT = t0 + (parseFloat(slider.value) / 1000) * span;
   });
   var customInput = document.getElementById('traj-speed-custom');
@@ -728,7 +682,7 @@ _JS = """
     e.preventDefault();
     var rect = canvas.getBoundingClientRect();
     var mx = e.clientX - rect.left, my = e.clientY - rect.top;
-    var w = canvas.clientWidth || 600, h = CANVAS_H, cx = w / 2, cy = h / 2;
+    var w = canvas.clientWidth || 600, h = currentH(), cx = w / 2, cy = h / 2;
     var worldX = (mx - cx - panX) / zoom + cx;
     var worldY = (my - cy - panY) / zoom + cy;
     var newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, zoom * (e.deltaY < 0 ? 1.15 : 1 / 1.15)));
@@ -755,6 +709,72 @@ _JS = """
   var resetViewBtn = document.getElementById('traj-reset-view');
   if (resetViewBtn) {
     resetViewBtn.addEventListener('click', function () { zoom = 1; panX = 0; panY = 0; });
+  }
+  var fsBtn = document.getElementById('traj-fullscreen');
+  var trajWrap = canvas.closest('.traj-wrap');
+  if (fsBtn && trajWrap) {
+    fsBtn.addEventListener('click', function () {
+      var fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+      if (fsEl) {
+        (document.exitFullscreen || document.webkitExitFullscreen).call(document);
+      } else {
+        var req = trajWrap.requestFullscreen || trajWrap.webkitRequestFullscreen;
+        if (req) req.call(trajWrap);
+      }
+    });
+    // Drive the fullscreen layout off an explicit class rather than the
+    // :fullscreen pseudo-class. A selector list containing an unrecognised
+    // vendor-prefixed pseudo (:-webkit-full-screen on a non-WebKit engine,
+    // say) is invalid as a whole, so the browser discards the entire rule
+    // and no fullscreen styling applies at all. A plain class can't be
+    // dropped that way.
+    ['fullscreenchange', 'webkitfullscreenchange'].forEach(function (evt) {
+      document.addEventListener(evt, function () {
+        var fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+        var on = fsEl === trajWrap;
+        trajWrap.classList.toggle('traj-fs', on);
+        fsBtn.title = on ? 'Exit fullscreen' : 'Fullscreen';
+        nudgeChrome();
+        // The canvas backing store is sized from clientWidth/clientHeight,
+        // which only change after the layout flip lands.
+        requestAnimationFrame(function () { size(); draw(); });
+      });
+    });
+  }
+
+  // Idle chrome hiding, YouTube-style: while playback runs, the controls fade
+  // out and the cursor disappears after a few seconds without input, and any
+  // input brings both straight back.
+  //
+  // Applies inline as well as in fullscreen. Inline the controls sit in their
+  // own row below the canvas, so fading them could leave an unexplained blank
+  // gap for someone who hit play and then went off to read the rest of the
+  // page -- the mouseleave handler below closes that hole by restoring the
+  // chrome whenever the pointer is not actually over the viewer. In
+  // fullscreen the viewer is the whole screen, so mouseleave never fires and
+  // the behaviour stays exactly like a video player's.
+  var IDLE_MS = 2600;
+  var idleTimer = null;
+  function clearIdle() {
+    if (!trajWrap) return;
+    trajWrap.classList.remove('traj-idle');
+    if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
+  }
+  function nudgeChrome() {
+    if (!trajWrap) return;
+    clearIdle();
+    if (!playing) return;
+    idleTimer = setTimeout(function () {
+      if (playing) trajWrap.classList.add('traj-idle');
+    }, IDLE_MS);
+  }
+  if (trajWrap) {
+    ['mousemove', 'mousedown', 'wheel', 'touchstart', 'keydown'].forEach(
+      function (evt) {
+        trajWrap.addEventListener(evt, nudgeChrome, { passive: true });
+      }
+    );
+    trajWrap.addEventListener('mouseleave', clearIdle);
   }
   var smBtn = document.getElementById('traj-smoke');
   if (smBtn) {
@@ -824,7 +844,10 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
         )
     markup = (
         '<div class="traj-wrap">'
+        '<div class="traj-canvas-shell">'
         '<canvas id="traj-canvas" class="traj-canvas" title="Scroll to zoom, drag to pan"></canvas>'
+        '<button id="traj-fullscreen" type="button" class="traj-fs-btn" title="Fullscreen">&#9974;</button>'
+        "</div>"
         '<div class="traj-controls">'
         '<button id="traj-play" type="button" class="traj-play">▶</button>'
         '<input id="traj-slider" type="range" min="0" max="1000" value="0" '
@@ -868,35 +891,14 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
                 '<div style="display:flex;align-items:baseline;gap:24px;margin-bottom:12px">'
                 '<div><div style="font-family:'
                 + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:2px">max</div>'
+                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:2px">worst agent</div>'
                 '<div id="fed-val-max" style="font-family:'
                 + "'JetBrains Mono'"
                 + ',monospace;font-size:26px;font-weight:500;color:#F4C430;transition:color .3s">0.0000</div></div>'
-                '<div><div style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:2px">mean</div>'
-                '<div id="fed-val-mean" style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:26px;font-weight:500;color:#FF8A3D;transition:color .3s">0.0000</div></div>'
                 "</div>"
-                '<div style="position:relative;height:6px;border-radius:99px;background:var(--surface-card);border:1px solid var(--hairline);overflow:hidden;margin-bottom:4px">'
+                '<div style="position:relative;height:6px;border-radius:99px;background:var(--surface-card);border:1px solid var(--hairline);overflow:hidden">'
                 '<div id="fed-bar-fill" style="position:absolute;inset:0;width:0%;border-radius:99px;background:linear-gradient(90deg,#F4C430,#FFB020,#FF6A1A,#E01E37);transition:width .15s"></div>'
                 "</div>"
-                '<div style="display:flex;justify-content:space-between;margin-bottom:10px">'
-                '<span style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;color:var(--ink-faint)">0</span>'
-                '<span style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;color:#FFB020">0.3</span>'
-                '<span style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;color:#FF6A1A">0.6</span>'
-                '<span style="font-family:'
-                + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;color:#E01E37">1.0+</span>'
-                "</div>"
-                '<canvas id="fed-spark" style="width:100%;height:60px;display:block"></canvas>'
                 "</div>"
             )
             or ""

--- a/pyfds_evac/webapp/trajviz.py
+++ b/pyfds_evac/webapp/trajviz.py
@@ -20,8 +20,8 @@ from fasthtml.common import H3, Div, NotStr
 from .plots import _PALETTE, _agent_exit_map
 
 _CARD = (
-    "background:#2A262A;border:1px solid rgba(255,255,255,.07);"
-    "border-radius:1.1rem;padding:20px;box-shadow:0 8px 24px rgba(0,0,0,.45)"
+    "background:var(--surface-card);border:1px solid var(--hairline);"
+    "border-radius:1.1rem;padding:20px;box-shadow:var(--shadow-md)"
 )
 
 # Wall-clock gap between the position samples sent to the browser.  The JS
@@ -403,6 +403,28 @@ _JS = """
   // 0.2 m agent is sub-pixel when zoomed out, and a dot that rounds away
   // entirely reads as a lost agent rather than a small one.
   var AGENT_R = D.agentR > 0 ? D.agentR : 0.2, MIN_AGENT_PX = 2;
+
+  // ---- theme ----------------------------------------------------------
+  // Canvas takes literal colours only. TH is refreshed whenever the page
+  // theme flips (see window.trajRepaint at the foot of this script), so a
+  // light-mode reader gets dark geometry on paper rather than white-on-white.
+  var TH = {};
+  function readTheme() {
+    var light = document.documentElement.getAttribute('data-theme') === 'light';
+    TH.light      = light;
+    TH.walkFill   = light ? 'rgba(31,23,16,0.035)' : 'rgba(255,255,255,0.03)';
+    TH.walkLine   = light ? 'rgba(31,23,16,0.22)'  : 'rgba(255,255,255,0.16)';
+    TH.wallFill   = light ? '#d9d2c8'              : '#14161b';
+    TH.wallLine   = light ? 'rgba(31,23,16,0.38)'  : 'rgba(255,255,255,0.34)';
+    TH.agentRing  = light ? 'rgba(31,23,16,0.35)'  : 'rgba(0,0,0,0.45)';
+    TH.sparkLine  = light ? 'rgba(31,23,16,.55)'   : 'rgba(255,255,255,.55)';
+    TH.noData     = light ? '#6f665e'              : '#9aa0a6';
+    // Smoke is drawn as raw RGBA bytes: pale grey reads on the dark ground,
+    // but on paper it has to darken instead or it vanishes.
+    TH.smokeRGB   = light ? [90, 88, 100] : [205, 203, 214];
+  }
+  readTheme();
+
   var CANVAS_H = 440;           // render height; size() and the wheel handler must agree
   var dragging = false, dragStart = null;
 
@@ -430,8 +452,8 @@ _JS = """
         var a = 1 - Math.exp(-K * 0.6);      // Beer-Lambert-ish opacity
         if (a > 0.9) a = 0.9;                 // keep agents visible through it
         var pi = ((H - 1 - iy) * W + ix) * 4; // flip y: world +y is screen up
-        // Light gray smoke: reads clearly against the dark canvas theme.
-        d[pi] = 205; d[pi + 1] = 203; d[pi + 2] = 214; d[pi + 3] = Math.round(a * 255);
+        d[pi] = TH.smokeRGB[0]; d[pi + 1] = TH.smokeRGB[1]; d[pi + 2] = TH.smokeRGB[2];
+        d[pi + 3] = Math.round(a * 255);
       }
     }
     smCtx.putImageData(id, 0, 0);
@@ -489,7 +511,7 @@ _JS = """
     return 'rgb(' + r + ',' + g + ',' + bl + ')';
   }
   function fedColor(d) {
-    if (d == null) return '#9aa0a6';
+    if (d == null) return TH.noData;
     if (d <= 0) return STOPS[0][1];
     if (d >= 1) return STOPS[STOPS.length - 1][1];
     for (var k = 1; k < STOPS.length; k++) {
@@ -606,21 +628,21 @@ _JS = """
     var curFrac = T.length > 1 ? (simT - T[0]) / (T[T.length - 1] - T[0]) : 0;
     var cx = Math.max(0, Math.min(sw, curFrac * sw));
     sctx.beginPath(); sctx.moveTo(cx, 0); sctx.lineTo(cx, sh);
-    sctx.strokeStyle = 'rgba(255,255,255,.55)'; sctx.lineWidth = 1.5; sctx.stroke();
+    sctx.strokeStyle = TH.sparkLine; sctx.lineWidth = 1.5; sctx.stroke();
     sctx.beginPath(); sctx.arc(cx, py(curMax), 3.5, 0, 6.2832);
     sctx.fillStyle = fc(curMax); sctx.fill();
   }
   function draw() {
     var d = size(), w = d[0], h = d[1], p = tf(w, h);
     ctx.clearRect(0, 0, w, h);
-    poly(D.walk, p, 'rgba(255,255,255,0.03)', 'rgba(255,255,255,0.16)', 1.5);
+    poly(D.walk, p, TH.walkFill, TH.walkLine, 1.5);
     var b = bracket(simT), f = b[2];
     drawSmoke(b[0], p);
     // Interior walls (holes in the walkable area): drawn over the smoke as
     // solid voids so they read as obstacles the agents route around.
     if (D.walls) {
       for (var wI = 0; wI < D.walls.length; wI++) {
-        poly(D.walls[wI], p, '#14161b', 'rgba(255,255,255,0.34)', 1.4);
+        poly(D.walls[wI], p, TH.wallFill, TH.wallLine, 1.4);
       }
     }
     D.exits.forEach(function (e) {
@@ -647,7 +669,7 @@ _JS = """
       var q = p(X, Y);
       ctx.beginPath(); ctx.arc(q[0], q[1], rpx, 0, 6.2832);
       ctx.fillStyle = col; ctx.fill();
-      ctx.lineWidth = rlw; ctx.strokeStyle = 'rgba(0,0,0,0.45)'; ctx.stroke();
+      ctx.lineWidth = rlw; ctx.strokeStyle = TH.agentRing; ctx.stroke();
     }
     tlabel.textContent = 't = ' + (simT - t0).toFixed(0) + ' s';
     slider.value = String(((simT - t0) / span) * 1000);
@@ -753,6 +775,16 @@ _JS = """
     });
   }
   window.addEventListener('resize', draw);
+
+  // Called by the footer theme switch. Nothing here is reachable from CSS:
+  // the geometry, the smoke bitmap and the FED sparkline are all painted
+  // into a canvas with literal colours, so they need an explicit repaint.
+  window.trajRepaint = function () {
+    readTheme();
+    draw();
+    if (typeof drawFedPanel === 'function') drawFedPanel();
+  };
+
   draw();
   requestAnimationFrame(loop);
 })();
@@ -766,10 +798,10 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
         return Div(
             H3(
                 "Trajectories",
-                style="font-family:'Space Grotesk',sans-serif;font-weight:600;font-size:16px;margin:0 0 10px;color:#F2EDE9",
+                style="font-family:'Space Grotesk',sans-serif;font-weight:600;font-size:16px;margin:0 0 10px;color:var(--ink)",
             ),
             NotStr(
-                '<p style="font-size:.85rem;color:#B2A9A3">Trajectory data unavailable.</p>'
+                '<p style="font-size:.85rem;color:var(--ink-dim)">Trajectory data unavailable.</p>'
             ),
             style=_CARD,
         )
@@ -814,11 +846,11 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
         + (
             payload["hasFed"]
             and (
-                '<div id="fed-panel" style="margin-top:14px;background:#1A171A;border:1px solid rgba(255,255,255,.07);border-radius:12px;padding:14px 16px">'
+                '<div id="fed-panel" style="margin-top:14px;background:var(--surface-panel);border:1px solid var(--hairline);border-radius:12px;padding:14px 16px">'
                 '<div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">'
                 '<span style="font-family:'
                 + "'JetBrains Mono'"
-                + ',monospace;font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:#837A74">FED Dose</span>'
+                + ',monospace;font-size:9.5px;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-faint)">FED Dose</span>'
                 '<div style="display:flex;gap:12px">'
                 '<span style="font-family:'
                 + "'JetBrains Mono'"
@@ -836,24 +868,24 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
                 '<div style="display:flex;align-items:baseline;gap:24px;margin-bottom:12px">'
                 '<div><div style="font-family:'
                 + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:#837A74;margin-bottom:2px">max</div>'
+                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:2px">max</div>'
                 '<div id="fed-val-max" style="font-family:'
                 + "'JetBrains Mono'"
                 + ',monospace;font-size:26px;font-weight:500;color:#F4C430;transition:color .3s">0.0000</div></div>'
                 '<div><div style="font-family:'
                 + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:#837A74;margin-bottom:2px">mean</div>'
+                + ',monospace;font-size:9px;letter-spacing:.06em;text-transform:uppercase;color:var(--ink-faint);margin-bottom:2px">mean</div>'
                 '<div id="fed-val-mean" style="font-family:'
                 + "'JetBrains Mono'"
                 + ',monospace;font-size:26px;font-weight:500;color:#FF8A3D;transition:color .3s">0.0000</div></div>'
                 "</div>"
-                '<div style="position:relative;height:6px;border-radius:99px;background:#2A262A;border:1px solid rgba(255,255,255,.06);overflow:hidden;margin-bottom:4px">'
+                '<div style="position:relative;height:6px;border-radius:99px;background:var(--surface-card);border:1px solid var(--hairline);overflow:hidden;margin-bottom:4px">'
                 '<div id="fed-bar-fill" style="position:absolute;inset:0;width:0%;border-radius:99px;background:linear-gradient(90deg,#F4C430,#FFB020,#FF6A1A,#E01E37);transition:width .15s"></div>'
                 "</div>"
                 '<div style="display:flex;justify-content:space-between;margin-bottom:10px">'
                 '<span style="font-family:'
                 + "'JetBrains Mono'"
-                + ',monospace;font-size:9px;color:#837A74">0</span>'
+                + ',monospace;font-size:9px;color:var(--ink-faint)">0</span>'
                 '<span style="font-family:'
                 + "'JetBrains Mono'"
                 + ',monospace;font-size:9px;color:#FFB020">0.3</span>'
@@ -876,7 +908,7 @@ def trajectory_component(result: Any, scenario: Any, fds_dir: str | None = None)
         Div(
             H3(
                 "Trajectories",
-                style="font-family:'Space Grotesk',sans-serif;font-weight:600;font-size:16px;margin:0;color:#F2EDE9",
+                style="font-family:'Space Grotesk',sans-serif;font-weight:600;font-size:16px;margin:0;color:var(--ink)",
             ),
             style="display:flex;align-items:center;margin-bottom:14px",
         ),

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -160,7 +160,10 @@ def test_second_run_rejected_while_active(client):
         collect_route_cost_history=True,
     )
     kwargs = build_run_kwargs(scenario, opts)
-    manager.start(scenario, kwargs, "ISO-table21")
+    # start() takes a builder, not the kwargs themselves: the expensive part of
+    # build_run_kwargs runs on the worker thread so /run can answer straight
+    # away. Prebuilt here, since this test is about the second-run guard.
+    manager.start(scenario, lambda: kwargs, "ISO-table21")
     with pytest.raises(RuntimeError):
         manager.start(scenario, kwargs, "ISO-table21")
     # Drain to completion so the lock releases for other tests.


### PR DESCRIPTION
Webapp-only changes, lifted off a longer-running asset branch so they can be reviewed without 13k lines of new floor-plan scenarios attached.

## Light/dark theme switch

Theme toggle in the page footer. Canvas takes literal colours rather than CSS variables, so the viewer re-reads its palette whenever the theme flips, and a light-mode reader gets dark geometry on paper instead of white on white.

## Run controls

- **Cancel scenario**, in the progress panel. Cancellation is cooperative: `/cancel` sets a flag and the worker unwinds on its next progress tick, because a Python thread cannot be killed from outside. Ticks fire about once per simulated second. `/cancel` then waits up to 2s for the worker to actually release before resetting, otherwise the manager can still report `running` when you immediately hit Run again and you get reconnected to the run you just stopped.
- **Clear results.** A finished run was previously a dead end with no way to dismiss it short of a page reload.
- **`/run` answers immediately.** It used to parse the whole FDS deck on the request thread, so the button flipped to "in progress" while the page sat frozen for however long that took. Only the cheap option validation stays synchronous now; slice parsing moved to the worker and its log lines stream into the console live.

## Trajectory viewer

- **Fullscreen actually fills the screen.** The rules were written as a single selector list pairing `:fullscreen` with a vendor-prefixed twin. A selector list is invalid *as a whole* when any one selector in it is unrecognised, so on an engine that knows only one spelling the browser discarded every fullscreen rule and you got the unstyled default: a short canvas at the top and a black void below. Driven off a JS-toggled class instead.
- **Idle chrome hiding.** Controls and cursor fade after ~2.6s of no input during playback. A `mouseleave` handler restores them whenever the pointer is not over the viewer, so inline you never get an unexplained blank gap; in fullscreen the viewer is the whole screen so that never fires and it behaves like a video player.
- **Playback frame delta is capped** at one sample interval, so a stalled tab plays back slow rather than skipping recorded steps. Plus an initial draw, so the first frame appears before playback starts.
- **Scenario listing** now offers anything `load_scenario` can actually load.

## FED reporting reduced to the worst agent

Mean dose across agents does not answer a tenability question: one person incapacitated is a failure regardless of the average. The mean line, the sparkline, and the separate Cumulative FED results chart are removed.

## Notes for review

Two conflicts against current `main` needed judgment, both worth a look:

1. **`trajviz.py` vs #111 (agents at map scale).** #111 made the agent ring width scale with the map; the theme work made its colour theme-aware. Both touched the same line. Resolved to keep the scaled width *and* the theme colour, so neither feature is lost.
2. **`run_config.py`.** `_validate_opts` is renamed to `validate_opts` and made public, because deferring `build_run_kwargs` to a worker thread means these checks still have to run synchronously to answer the request. While resolving, I dropped the `--vis-cache requires --fds-dir` rule from my version: `main` has since removed it deliberately, since clear-air visibility makes that combination legal. Worth confirming I read that correctly.

Full suite green on this branch: **634 passed**.
